### PR TITLE
Adds shutdown priority to daemon package

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStartShutdown(t *testing.T) {
 
-	daemonA := daemon.NewDaemon()
+	daemonA := daemon.New()
 
 	var isShutdown, wasStarted bool
 	if err := daemonA.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
@@ -34,7 +34,7 @@ func TestStartShutdown(t *testing.T) {
 
 func TestShutdownPriority(t *testing.T) {
 
-	daemonB := daemon.NewDaemon()
+	daemonB := daemon.New()
 
 	const highShutdownPriorityWorker = "highShutdownPriorityWorker"
 	const lowShutdownPriorityWorker = "lowShutdownPriorityWorker"
@@ -58,7 +58,7 @@ func TestShutdownPriority(t *testing.T) {
 	}
 
 	daemonB.Start()
-	daemonB.ShutdownAndWait(time.Second)
+	daemonB.ShutdownAndWait()
 
 	if <-feedback != highShutdownPriorityWorker {
 		t.Fatalf("expected worker %s to be shutdown before worker %s", highShutdownPriorityWorker, lowShutdownPriorityWorker)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,0 +1,67 @@
+package daemon_test
+
+import (
+	"github.com/iotaledger/hive.go/daemon"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestStartShutdown(t *testing.T) {
+
+	daemonA := daemon.NewDaemon()
+
+	var isShutdown, wasStarted bool
+	if err := daemonA.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
+		wasStarted = true
+		<-shutdownSignal
+		isShutdown = true
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonA.Start()
+	daemonA.ShutdownAndWait()
+
+	if !wasStarted {
+		log.Fatalf("expected worker A to be started")
+	}
+
+	if !isShutdown {
+		log.Fatalf("expected worker A to be shutdown")
+	}
+}
+
+func TestShutdownPriority(t *testing.T) {
+
+	daemonB := daemon.NewDaemon()
+
+	const highShutdownPriorityWorker = "highShutdownPriorityWorker"
+	const lowShutdownPriorityWorker = "lowShutdownPriorityWorker"
+
+	feedback := make(chan string, 2)
+	if err := daemonB.BackgroundWorker(highShutdownPriorityWorker, func(shutdownSignal <-chan struct{}) {
+		<-shutdownSignal
+		feedback <- highShutdownPriorityWorker
+	}, daemon.ShutdownPriorityHigh); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := daemonB.BackgroundWorker(lowShutdownPriorityWorker, func(shutdownSignal <-chan struct{}) {
+		<-shutdownSignal
+		// fake slowness of shutdown so we get meaningful results
+		// as otherwise both workers are ended roughly at the same time
+		<-time.After(time.Duration(100) * time.Millisecond)
+		feedback <- lowShutdownPriorityWorker
+	}, daemon.ShutdownPriorityLow); err != nil {
+		t.Fatal(err)
+	}
+
+	daemonB.Start()
+	daemonB.ShutdownAndWait(time.Second)
+
+	if <-feedback != highShutdownPriorityWorker {
+		t.Fatalf("expected worker %s to be shutdown before worker %s", highShutdownPriorityWorker, lowShutdownPriorityWorker)
+	}
+
+}


### PR DESCRIPTION
* Adds the ability to define a shutdown priority when creating a new background worker
* One can create now separate instances of daemons for different purposes
* Adds a duration in `Shutdown()`/`ShutdownAndWait()` which is used to sleep between shutdowns of different priority background workers.