### PR TITLE
Fixes daemon shutdown() closing already closed shutdown channels

### DIFF
--- a/daemon/ordered/daemon.go
+++ b/daemon/ordered/daemon.go
@@ -1,7 +1,6 @@
 package ordered
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 
@@ -163,8 +162,6 @@ func (d *Daemon) BackgroundWorker(name string, handler WorkerFunc, order ...int)
 	sort.Slice(d.shutdownOrderWorker, func(i, j int) bool {
 		return d.workers[d.shutdownOrderWorker[i]].shutdownOrder > d.workers[d.shutdownOrderWorker[j]].shutdownOrder
 	})
-
-	fmt.Println(d.shutdownOrderWorker)
 
 	if d.IsRunning() {
 		d.runBackgroundWorker(name, handler)

--- a/daemon/ordered/daemon_test.go
+++ b/daemon/ordered/daemon_test.go
@@ -1,10 +1,11 @@
 package ordered_test
 
 import (
-	ordered_daemon "github.com/iotaledger/hive.go/daemon/ordered"
 	"log"
 	"strconv"
 	"testing"
+
+	ordered_daemon "github.com/iotaledger/hive.go/daemon/ordered"
 )
 
 func TestStartShutdown(t *testing.T) {
@@ -65,8 +66,8 @@ func TestReRun(t *testing.T) {
 
 	daemonC := ordered_daemon.New()
 
-	terminate := make(chan struct{}, 2)
-	feedback := make(chan struct{}, 2)
+	terminate := make(chan struct{}, 1)
+	feedback := make(chan struct{}, 1)
 
 	if err := daemonC.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
 		<-terminate
@@ -77,17 +78,14 @@ func TestReRun(t *testing.T) {
 
 	daemonC.Start()
 
-	terminate<-struct{}{}
+	terminate <- struct{}{}
 	<-feedback
 
 	if err := daemonC.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
-		<-terminate
-		feedback <- struct{}{}
+		<-shutdownSignal
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	terminate<-struct{}{}
-	<-feedback
-
+	daemonC.ShutdownAndWait()
 }


### PR DESCRIPTION
The shutdown order slice was not cleaned when a new background worker was defined with the same name, leading to `shutdown()` closing the same shutdown channel of a given worker N times the redefinition of the background worker.