### PR TITLE
Add stopped signal to the ordered daemon

### DIFF
--- a/daemon/ordered/daemon.go
+++ b/daemon/ordered/daemon.go
@@ -54,6 +54,11 @@ func IsRunning() bool {
 	return defaultDaemon.IsRunning()
 }
 
+// IsStopped checks whether the default daemon instance was stopped.
+func IsStopped() bool {
+	return defaultDaemon.IsStopped()
+}
+
 // New creates a new daemon instance.
 func New() *Daemon {
 	return &Daemon{
@@ -267,4 +272,9 @@ func (d *Daemon) ShutdownAndWait() {
 // IsRunning checks whether the daemon is running.
 func (d *Daemon) IsRunning() bool {
 	return d.running
+}
+
+// IsStopped checks whether the daemon was stopped.
+func (d *Daemon) IsStopped() bool {
+	return d.stopped
 }


### PR DESCRIPTION
This PR adds the possibility to mark the daemon as stopped, even before it was started.

If the daemon is already running, no new BackgroundWorkers can be started.
If the daemon was not running, it can't be started anymore.

This is necessary if the daemon received a shutdown() call during the startup process of HORNET.
Otherwise the BackgroundWorkers will never receive a shutdownSignal again.