### PR TITLE
Added option to flush tasks at shutdown

### DIFF
--- a/batchworkerpool/options.go
+++ b/batchworkerpool/options.go
@@ -10,6 +10,7 @@ var DEFAULT_OPTIONS = &Options{
 	QueueSize:              2 * runtime.NumCPU() * 64,
 	BatchSize:              64,
 	BatchCollectionTimeout: 15 * time.Millisecond,
+	FlushTasksAtShutdown:   false,
 }
 
 func WorkerCount(workerCount int) Option {
@@ -36,11 +37,18 @@ func QueueSize(queueSize int) Option {
 	}
 }
 
+func FlushTasksAtShutdown(flush bool) Option {
+	return func(args *Options) {
+		args.FlushTasksAtShutdown = flush
+	}
+}
+
 type Options struct {
 	WorkerCount            int
 	QueueSize              int
 	BatchSize              int
 	BatchCollectionTimeout time.Duration
+	FlushTasksAtShutdown   bool
 }
 
 func (options Options) Override(optionalOptions ...Option) *Options {

--- a/workerpool/options.go
+++ b/workerpool/options.go
@@ -5,8 +5,9 @@ import (
 )
 
 var DEFAULT_OPTIONS = &Options{
-	WorkerCount: 2 * runtime.NumCPU(),
-	QueueSize:   4 * runtime.NumCPU(),
+	WorkerCount:          2 * runtime.NumCPU(),
+	QueueSize:            4 * runtime.NumCPU(),
+	FlushTasksAtShutdown: false,
 }
 
 func WorkerCount(workerCount int) Option {
@@ -21,9 +22,16 @@ func QueueSize(queueSize int) Option {
 	}
 }
 
+func FlushTasksAtShutdown(flush bool) Option {
+	return func(args *Options) {
+		args.FlushTasksAtShutdown = flush
+	}
+}
+
 type Options struct {
-	WorkerCount int
-	QueueSize   int
+	WorkerCount          int
+	QueueSize            int
+	FlushTasksAtShutdown bool
 }
 
 func (options Options) Override(optionalOptions ...Option) *Options {

--- a/workerpool/task.go
+++ b/workerpool/task.go
@@ -3,7 +3,6 @@ package workerpool
 type Task struct {
 	params     []interface{}
 	resultChan chan interface{}
-	barrier    bool
 }
 
 func (task *Task) Return(result interface{}) {

--- a/workerpool/workerpool.go
+++ b/workerpool/workerpool.go
@@ -1,27 +1,27 @@
 package workerpool
 
 import (
-	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/syncutils"
 	"sync"
+
+	"github.com/iotaledger/hive.go/syncutils"
 )
 
 type WorkerPool struct {
 	workerFnc func(Task)
 	options   *Options
 
-	calls       chan Task
-	terminate   chan int
-	barrierIn   chan struct{}
-	barrierOut  chan struct{}
-	barrierWait sync.WaitGroup
-	barrierLock syncutils.Mutex
+	calls     chan Task
+	terminate chan struct{}
 
-	BarrierEvent *events.Event
+	running  bool
+	shutdown bool
 
-	running bool
-	mutex   syncutils.RWMutex
-	wait    sync.WaitGroup
+	mutex syncutils.RWMutex
+	wait  sync.WaitGroup
+}
+
+func voidCaller(handler interface{}, params ...interface{}) {
+	handler.(func())()
 }
 
 func New(workerFnc func(Task), optionalOptions ...Option) (result *WorkerPool) {
@@ -30,81 +30,63 @@ func New(workerFnc func(Task), optionalOptions ...Option) (result *WorkerPool) {
 	result = &WorkerPool{
 		workerFnc: workerFnc,
 		options:   options,
+		calls:     make(chan Task, options.QueueSize),
+		terminate: make(chan struct{}),
 	}
-
-	result.resetChannels()
-
-	return
-}
-
-func NewWithBarrier(workerFnc func(Task), barrierEvent *events.Event, optionalOptions ...Option) (result *WorkerPool) {
-	options := DEFAULT_OPTIONS.Override(optionalOptions...)
-
-	result = &WorkerPool{
-		workerFnc:    workerFnc,
-		options:      options,
-		BarrierEvent: barrierEvent,
-	}
-
-	result.resetChannels()
-
-	return
-}
-
-func (wp *WorkerPool) submit(barrier bool, params ...interface{}) (result chan interface{}) {
-	result = make(chan interface{}, 1)
-
-	wp.mutex.RLock()
-
-	wp.calls <- Task{
-		params:     params,
-		resultChan: result,
-		barrier:    barrier,
-	}
-
-	wp.mutex.RUnlock()
-
-	return
-}
-
-func (wp *WorkerPool) trySubmit(params ...interface{}) (result chan interface{}, added bool) {
-	result = make(chan interface{}, 1)
-
-	wp.mutex.RLock()
-
-	select {
-	case wp.calls <- Task{
-		params:     params,
-		resultChan: result,
-		barrier:    false,
-	}:
-		added = true
-	default:
-		// Queue full => drop the task
-		added = false
-	}
-
-	wp.mutex.RUnlock()
 
 	return
 }
 
 func (wp *WorkerPool) Submit(params ...interface{}) (result chan interface{}) {
-	return wp.submit(false, params...)
+
+	wp.mutex.RLock()
+
+	if !wp.shutdown {
+		result = make(chan interface{}, 1)
+
+		wp.calls <- Task{
+			params:     params,
+			resultChan: result,
+		}
+	}
+
+	wp.mutex.RUnlock()
+
+	return
 }
 
 func (wp *WorkerPool) TrySubmit(params ...interface{}) (result chan interface{}, added bool) {
-	return wp.trySubmit(params...)
-}
 
-func (wp *WorkerPool) SubmitBarrier(params ...interface{}) (result chan interface{}) {
-	return wp.submit(true, params...)
+	wp.mutex.RLock()
+
+	if !wp.shutdown {
+		result = make(chan interface{}, 1)
+
+		select {
+		case wp.calls <- Task{
+			params:     params,
+			resultChan: result,
+		}:
+			added = true
+		default:
+			// Queue full => drop the task
+			added = false
+			close(result)
+		}
+	}
+
+	wp.mutex.RUnlock()
+
+	return
 }
 
 func (wp *WorkerPool) Start() {
 	wp.mutex.Lock()
 
 	if !wp.running {
+		if wp.shutdown {
+			panic("Worker was already used before")
+		}
 		wp.running = true
 
 		wp.startWorkers()
@@ -120,22 +102,21 @@ func (wp *WorkerPool) Run() {
 }
 
 func (wp *WorkerPool) Stop() {
-	go wp.StopAndWait()
-}
-
-func (wp *WorkerPool) StopAndWait() {
 	wp.mutex.Lock()
 
 	if wp.running {
+		wp.shutdown = true
 		wp.running = false
 
 		close(wp.terminate)
 	}
 
-	wp.wait.Wait()
-	wp.resetChannels()
-
 	wp.mutex.Unlock()
+}
+
+func (wp *WorkerPool) StopAndWait() {
+	wp.Stop()
+	wp.wait.Wait()
 }
 
 func (wp *WorkerPool) GetWorkerCount() int {
@@ -146,39 +127,7 @@ func (wp *WorkerPool) GetPendingQueueSize() int {
 	return len(wp.calls)
 }
 
-func (wp *WorkerPool) signalBarrier(params ...interface{}) {
-	if !wp.running {
-		return
-	}
-
-	wp.barrierLock.Lock()
-	wp.barrierWait.Add(1)
-
-	// signal all threads to enter the barrier after processing their last task or being idle
-	for i := 0; i < wp.options.WorkerCount; i++ {
-		wp.barrierIn <- struct{}{}
-	}
-
-	// wait for all threads to enter the barrier
-	for i := 0; i < wp.options.WorkerCount; i++ {
-		<-wp.barrierOut
-	}
-
-	wp.barrierWait.Done()
-	wp.BarrierEvent.Trigger(params...)
-	wp.barrierLock.Unlock()
-}
-
-func (wp *WorkerPool) resetChannels() {
-	wp.calls = make(chan Task, wp.options.QueueSize)
-	wp.terminate = make(chan int, 1)
-	wp.barrierIn = make(chan struct{}, wp.options.WorkerCount)
-	wp.barrierOut = make(chan struct{}, wp.options.WorkerCount)
-}
-
 func (wp *WorkerPool) startWorkers() {
-	calls := wp.calls
-	terminate := wp.terminate
 
 	for i := 0; i < wp.options.WorkerCount; i++ {
 		wp.wait.Add(1)
@@ -189,20 +138,25 @@ func (wp *WorkerPool) startWorkers() {
 			for !aborted {
 				select {
 
-				case <-terminate:
+				case <-wp.terminate:
 					aborted = true
 
-				case <-wp.barrierIn:
-					wp.barrierOut <- struct{}{}
-					wp.barrierWait.Wait()
+					if wp.options.FlushTasksAtShutdown {
+					terminateLoop:
+						// process all waiting tasks after shutdown signal
+						for {
+							select {
+							case batchTask := <-wp.calls:
+								wp.workerFnc(batchTask)
 
-				case batchTask := <-calls:
-					if !batchTask.barrier {
-						wp.workerFnc(batchTask)
-					} else {
-						// barrier detected, signal all workers
-						go wp.signalBarrier(batchTask.params...)
+							default:
+								break terminateLoop
+							}
+						}
 					}
+
+				case batchTask := <-wp.calls:
+					wp.workerFnc(batchTask)
 				}
 			}
 

--- a/workerpool/workerpool_test.go
+++ b/workerpool/workerpool_test.go
@@ -1,54 +1,14 @@
-package workerpool_test
+package workerpool
 
 import (
-	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/workerpool"
 	"sync"
 	"testing"
 )
 
-func TestSignalBarrier(t *testing.T) {
-	pool := workerpool.NewWithBarrier(func(task workerpool.Task) {
-		println(task.Param(0).(int))
-		task.Return(nil)
-	},
-		events.NewEvent(events.CallbackCaller),
-		workerpool.WorkerCount(10),
-		workerpool.QueueSize(2000),
-	)
-	pool.Start()
-
-	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
-		wg.Add(1)
-
-		go func(i int) {
-			<-pool.Submit(i)
-
-			wg.Done()
-		}(i)
-	}
-
-	pool.SubmitBarrier()
-
-	for i := 0; i < 200; i++ {
-		wg.Add(1)
-
-		go func(i int) {
-			<-pool.Submit(i)
-
-			wg.Done()
-		}(i)
-	}
-
-	wg.Wait()
-
-}
-
 func Benchmark(b *testing.B) {
-	pool := workerpool.New(func(task workerpool.Task) {
+	pool := New(func(task Task) {
 		task.Return(task.Param(0))
-	}, workerpool.WorkerCount(10), workerpool.QueueSize(2000))
+	}, WorkerCount(10), QueueSize(2000))
 	pool.Start()
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
This PR adds a config option to the batched-/ workerpool to flush all tasks at shutdown signal.

It also removes the "sync barrier" from the workerpool since it is not used and broken.