### PR TITLE
Fix: Do not load logger config automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/dgraph-io/badger/v2 v2.0.0
 	github.com/google/open-location-code/go v0.0.0-20190903173953-119bc96a3a51
 	github.com/iotaledger/iota.go v1.0.0-beta.9
-	github.com/magiconair/properties v1.8.1
 	github.com/panjf2000/ants/v2 v2.2.2
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.8.1

--- a/logger/config.go
+++ b/logger/config.go
@@ -2,6 +2,9 @@ package logger
 
 import "go.uber.org/zap/zapcore"
 
+// ViperKey defines the key name under which the logger config is stored.
+const ViperKey = "logger"
+
 // Config holds the settings to configure a root logger instance.
 type Config struct {
 	// Level is the minimum enabled logging level.

--- a/logger/events_test.go
+++ b/logger/events_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/iotaledger/hive.go/events"
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 )
@@ -50,7 +50,7 @@ func TestNewEventCore(t *testing.T) {
 
 		m.On("panic", LevelPanic, testName, testLoggedMsg).Once()
 		m.On("any", LevelPanic, testName, testLoggedMsg).Once()
-		assert.Panic(t, func() { logger.Panic(testMsg) }, testMsg)
+		assert.Panics(t, func() { logger.Panic(testMsg) }, testMsg)
 
 		m.AssertExpectations(t)
 	})


### PR DESCRIPTION
The caller should deal with loading/providing the config:

- Have `InitGlobalLogger` that takes viper and fails on re-inint.
- `Named` panics when called un-initialized.