### PR TITLE
Feat: Create simple deterministic logger for tests

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -138,6 +138,14 @@ func NewLogger(name string) *Logger {
 	return logger.Named(name)
 }
 
+// NewExampleLogger builds a Logger that's designed to be only used in tests or examples.
+// It writes debug and above logs to standard out as JSON, but omits the timestamp and calling function to keep
+// example output short and deterministic.
+func NewExampleLogger(name string) *Logger {
+	root := zap.NewExample()
+	return root.Named(name).Sugar()
+}
+
 func newEncoder(name string, cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
 	switch strings.ToLower(name) {
 	case "console", "":


### PR DESCRIPTION
Add function to create a logger without any config.
This logger is supposed to be used in tests or examples to get deterministic results without any additional config.