### PR TITLE
Fix: Flags in node parameters

### DIFF
--- a/node/parameters.go
+++ b/node/parameters.go
@@ -1,18 +1,15 @@
 package node
 
 import (
-	"github.com/iotaledger/hive.go/logger"
 	flag "github.com/spf13/pflag"
 )
 
 const (
-	CFG_LOG_LEVEL       = "node.LogLevel"
 	CFG_DISABLE_PLUGINS = "node.disablePlugins"
 	CFG_ENABLE_PLUGINS  = "node.enablePlugins"
 )
 
 func init() {
-	flag.Int(CFG_LOG_LEVEL, int(logger.LevelInfo), "controls the log types that are shown")
-	flag.String(CFG_DISABLE_PLUGINS, "", "a list of plugins that shall be disabled")
-	flag.String(CFG_ENABLE_PLUGINS, "", "a list of plugins that shall be enabled")
+	flag.StringSlice(CFG_DISABLE_PLUGINS, nil, "a list of plugins that shall be disabled")
+	flag.StringSlice(CFG_ENABLE_PLUGINS, nil, "a list of plugins that shall be enabled")
 }


### PR DESCRIPTION
- `node.logLevel` no longer needed with new logger
- `node.disablePlugins` and `node.enablePlugins` should be string slices, as they can contain multiple values.