### PR TITLE
Feat: Add simple and configurable backoff retry package

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,3 +1,9 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Use Retry function for retrying operations that may fail.
+// If Retry does not meet your needs, you can create an own backoff Policy.
+//
+// See Examples section below for usage examples.
 package backoff
 
 import (

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,150 @@
+package backoff
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Stop indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// Permanent wraps the given err in a permanent error signaling that the operation should not be retried.
+func Permanent(err error) error {
+	return &permanentError{
+		err: err,
+	}
+}
+
+// Policy is a backoff policy for retrying an operation.
+type Policy interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff.Stop to indicate that no more retries should be made.
+	NextBackOff() time.Duration
+
+	// New creates a new instance of the policy in its initial state.
+	New() Policy
+}
+
+// NewBackOff wraps a backoff policy into a modifiable BackOff.
+func NewBackOff(policy Policy) *BackOff {
+	if b, ok := policy.(*BackOff); ok {
+		return b
+	}
+	return &BackOff{Policy: policy}
+}
+
+// BackOff is a backoff policy that can be modified with options.
+type BackOff struct {
+	Policy
+}
+
+// With modifies the backoff policy by applying additional options.
+func (b *BackOff) With(opts ...Option) *BackOff {
+	p := b.Policy
+	for _, opt := range opts {
+		p = opt.apply(p)
+	}
+	return NewBackOff(p)
+}
+
+// Retry calls the function f until it does not return error or the backoff policy stops.
+// The function is guaranteed to be run at least once.
+// If the functions returns a permanent error, the operation is not retried, and the wrapped error is returned.
+// Retry sleeps the goroutine for the duration returned by BackOff after a failed operation returns.
+func Retry(p Policy, f func() error) (err error) {
+	p = p.New()
+	for {
+		if err = f(); err == nil {
+			return
+		}
+
+		var permanent *permanentError
+		if errors.As(err, &permanent) {
+			return permanent.Unwrap()
+		}
+
+		duration := p.NextBackOff()
+		if duration == Stop {
+			break
+		}
+
+		time.Sleep(duration)
+	}
+	return fmt.Errorf("retry failed: %w", err)
+}
+
+// permanentError signals that the operation should not be retried.
+type permanentError struct {
+	err error
+}
+
+func (e *permanentError) Error() string {
+	return e.err.Error()
+}
+
+func (e *permanentError) Unwrap() error {
+	return e.err
+}
+
+type zeroPolicy struct{}
+
+func (zeroPolicy) NextBackOff() time.Duration { return 0 }
+func (zeroPolicy) New() Policy                { return zeroPolicy{} }
+
+var zeroBackOffInstance = NewBackOff(zeroPolicy{})
+
+// ZeroBackOff returns a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+func ZeroBackOff() *BackOff {
+	return zeroBackOffInstance
+}
+
+type constantPolicy struct {
+	Interval time.Duration
+}
+
+// ConstantBackOff returns a backoff policy that always returns the same backoff delay. This is in contrast to an
+// exponential backoff policy, which returns a delay that grows longer as you call NextBackOff() over and over again.
+func ConstantBackOff(d time.Duration) *BackOff {
+	return NewBackOff(&constantPolicy{Interval: d})
+}
+
+func (b *constantPolicy) NextBackOff() time.Duration { return b.Interval }
+func (b *constantPolicy) New() Policy                { return b }
+
+// ExponentialBackOff returns a backoff policy that increases the backoff period for each retry attempt using a
+// function that grows exponentially.
+// After each call of NextBackOff() the interval is multiplied by the provided factor starting with initialInterval.
+func ExponentialBackOff(initialInterval time.Duration, factor float64) *BackOff {
+	p := &exponentialPolicy{
+		initialInterval: initialInterval,
+		factor:          factor,
+		currentInterval: initialInterval,
+	}
+	return NewBackOff(p)
+}
+
+type exponentialPolicy struct {
+	initialInterval time.Duration
+	factor          float64
+	currentInterval time.Duration
+}
+
+func (b *exponentialPolicy) NextBackOff() time.Duration {
+	defer b.incrementCurrentInterval()
+	return b.currentInterval
+}
+
+func (b *exponentialPolicy) New() Policy {
+	return &exponentialPolicy{
+		initialInterval: b.initialInterval,
+		factor:          b.factor,
+		currentInterval: b.currentInterval,
+	}
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *exponentialPolicy) incrementCurrentInterval() {
+	b.currentInterval = time.Duration(float64(b.currentInterval) * b.factor)
+}

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -1,0 +1,162 @@
+package backoff
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errTest = errors.New("test")
+
+const (
+	intervalDelta = 10 * time.Millisecond // allow 10ms deviation to pass the test
+)
+
+func assertInterval(t assert.TestingT, expected time.Duration, actual time.Duration) bool {
+	return assert.Greater(t, actual.Microseconds(), expected.Microseconds()) &&
+		assert.LessOrEqual(t, actual.Microseconds(), (expected+intervalDelta).Microseconds())
+}
+
+func TestNoError(t *testing.T) {
+	err := Retry(ZeroBackOff(), func() error {
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+func TestPermanentError(t *testing.T) {
+	err := Retry(ZeroBackOff(), func() error {
+		return Permanent(errTest)
+	})
+	assert.EqualError(t, err, errTest.Error())
+}
+
+func TestZeroBackOff(t *testing.T) {
+	var count uint
+	last := time.Now()
+	err := Retry(ZeroBackOff(), func() error {
+		now := time.Now()
+		assert.LessOrEqual(t, now.Sub(last).Microseconds(), intervalDelta.Microseconds())
+		last = now
+		if count >= 10 {
+			return nil
+		}
+		count++
+		return errTest
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, count)
+}
+
+func TestConstantBackOff(t *testing.T) {
+	const interval = 20 * time.Millisecond
+
+	p := ConstantBackOff(interval)
+
+	var (
+		count uint
+		last  time.Time
+	)
+	err := Retry(p, func() error {
+		now := time.Now()
+		if count > 0 {
+			assertInterval(t, interval, now.Sub(last))
+		}
+		last = now
+		if count >= 10 {
+			return nil
+		}
+		count++
+		return errTest
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, count)
+}
+
+func TestExponentialBackOff(t *testing.T) {
+	const (
+		interval = 20 * time.Millisecond
+		factor   = 1.5
+	)
+
+	p := ExponentialBackOff(interval, factor)
+
+	var (
+		count uint
+		last  time.Time
+	)
+	err := Retry(p, func() error {
+		now := time.Now()
+		if count > 0 {
+			expected := time.Duration(float64(interval) * math.Pow(factor, float64(count-1)))
+			assertInterval(t, expected, now.Sub(last))
+		}
+		last = now
+		if count >= 10 {
+			return nil
+		}
+		count++
+		return errTest
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, count)
+}
+
+func TestExponentialBackOffParallel(t *testing.T) {
+	const (
+		interval    = 20 * time.Millisecond
+		factor      = 1.5
+		parallelism = 3
+	)
+
+	var wg sync.WaitGroup
+	p := ExponentialBackOff(interval, factor)
+
+	test := func() {
+		defer wg.Done()
+		var (
+			count uint
+			last  time.Time
+		)
+		err := Retry(p, func() error {
+			now := time.Now()
+			if count > 0 {
+				expected := time.Duration(float64(interval) * math.Pow(factor, float64(count-1)))
+				assertInterval(t, expected, now.Sub(last))
+			}
+			last = now
+			if count >= 10 {
+				return nil
+			}
+			count++
+			return errTest
+		})
+		assert.NoError(t, err)
+		assert.EqualValues(t, 10, count)
+	}
+
+	wg.Add(parallelism)
+	for i := 0; i < parallelism; i++ {
+		go test()
+	}
+	wg.Wait()
+}
+
+func BenchmarkBackOff(b *testing.B) {
+	p := ZeroBackOff().With(
+		MaxRetries(b.N),
+		MaxInterval(time.Microsecond),
+		Timeout(time.Now().Add(time.Minute)),
+		Cancel(nil),
+		Jitter(0.5),
+	)
+
+	b.ResetTimer()
+	_ = Retry(p, func() error {
+		return errTest
+	})
+}

--- a/backoff/example_test.go
+++ b/backoff/example_test.go
@@ -1,0 +1,42 @@
+package backoff
+
+import (
+	"fmt"
+	"time"
+)
+
+func ExampleRetry() {
+	// An operation that may fail.
+	operation := func() error {
+		fmt.Println("do something")
+		return nil // or an error
+	}
+
+	err := Retry(ExponentialBackOff(100*time.Millisecond, 1.5), operation)
+	if err != nil {
+		// Handle error.
+		return
+	}
+
+	// Output: do something
+}
+
+func ExampleMaxRetries() {
+	// An operation that may fail.
+	operation := func() error {
+		fmt.Println("do something")
+		return errTest
+	}
+
+	p := ConstantBackOff(100 * time.Millisecond).With(MaxRetries(2))
+	err := Retry(p, operation)
+	if err != nil {
+		// Handle error.
+		return
+	}
+
+	// Output:
+	// do something
+	// do something
+	// do something
+}

--- a/backoff/options.go
+++ b/backoff/options.go
@@ -1,0 +1,143 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+// An Option configures a BackOff.
+type Option interface {
+	apply(b Policy) Policy
+}
+
+// optionFunc wraps a func so it satisfies the Option interface.
+type optionFunc func(Policy) Policy
+
+func (f optionFunc) apply(p Policy) Policy {
+	return f(p)
+}
+
+// statelessOptionFunc wraps a function modifying the duration so it satisfies the Option interface.
+type statelessOptionFunc func(time.Duration) time.Duration
+
+func (f statelessOptionFunc) apply(p Policy) Policy {
+	return &statelessOption{
+		delegate: p,
+		f:        f,
+	}
+}
+
+// MaxRetries configures a backoff policy to return Stop if NextBackOff() has been called too many times.
+func MaxRetries(max int) Option {
+	return optionFunc(func(p Policy) Policy {
+		return &maxRetriesOption{
+			delegate: p,
+			maxTries: max,
+			numTries: 0,
+		}
+	})
+}
+
+// MaxInterval configures a backoff policy to not return longer intervals when NextBackOff() is called.
+func MaxInterval(maxInterval time.Duration) Option {
+	return statelessOptionFunc(func(duration time.Duration) time.Duration {
+		if duration > maxInterval {
+			return maxInterval
+		}
+		return duration
+	})
+}
+
+// Timeout configures a backoff policy to stop when the current time passes the time given with timeout.
+func Timeout(timeout time.Time) Option {
+	return statelessOptionFunc(func(duration time.Duration) time.Duration {
+		if duration == Stop {
+			return Stop
+		}
+		now := time.Now()
+		if now.After(timeout) {
+			return Stop
+		}
+		if now.Add(duration).After(timeout) {
+			return timeout.Sub(now)
+		}
+		return duration
+	})
+}
+
+// Cancel configures a backoff policy to stop the given channel is closed.
+func Cancel(done <-chan struct{}) Option {
+	return statelessOptionFunc(func(duration time.Duration) time.Duration {
+		select {
+		case <-done:
+			return Stop
+		default:
+		}
+		return duration
+	})
+}
+
+// Jitter configures a backoff policy to randomly modify the duration by the given factor.
+// The modified duration is a random value in the interval [randomFactor * duration, duration).
+func Jitter(randomFactor float64) Option {
+	return statelessOptionFunc(func(duration time.Duration) time.Duration {
+		if duration == Stop {
+			return Stop
+		}
+		if randomFactor <= 0 {
+			return duration
+		}
+		delta := randomFactor * float64(duration)
+		return time.Duration(float64(duration) - rand.Float64()*delta)
+	})
+}
+
+type statelessOption struct {
+	delegate Policy
+	f        func(time.Duration) time.Duration
+}
+
+func (o *statelessOption) apply(p Policy) Policy {
+	return &statelessOption{
+		delegate: p,
+		f:        o.f,
+	}
+}
+
+func (o *statelessOption) NextBackOff() time.Duration {
+	return o.f(o.delegate.NextBackOff())
+}
+
+func (o *statelessOption) New() Policy {
+	return &statelessOption{
+		delegate: o.delegate.New(),
+		f:        o.f,
+	}
+}
+
+type maxRetriesOption struct {
+	delegate Policy
+	maxTries int
+	numTries int
+}
+
+func (b *maxRetriesOption) NextBackOff() time.Duration {
+	if b.maxTries == 0 {
+		return Stop
+	}
+	if b.maxTries > 0 {
+		if b.maxTries <= b.numTries {
+			return Stop
+		}
+		b.numTries++
+	}
+	return b.delegate.NextBackOff()
+}
+
+func (b *maxRetriesOption) New() Policy {
+	return &maxRetriesOption{
+		delegate: b.delegate.New(),
+		maxTries: b.maxTries,
+		numTries: 0,
+	}
+}

--- a/backoff/options_test.go
+++ b/backoff/options_test.go
@@ -1,0 +1,160 @@
+package backoff
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaxRetries(t *testing.T) {
+	const retries = 10
+
+	p := ZeroBackOff().With(MaxRetries(retries))
+
+	var count uint
+	err := Retry(p, func() error {
+		count++
+		return errTest
+	})
+	assert.True(t, errors.Is(err, errTest))
+	assert.EqualValues(t, retries+1, count)
+}
+
+func TestMaxRetriesNew(t *testing.T) {
+	const retries = 10
+
+	p := ZeroBackOff().With(MaxRetries(retries))
+
+	for i := 0; i < 3; i++ {
+		var count uint
+		err := Retry(p, func() error {
+			count++
+			return errTest
+		})
+		assert.True(t, errors.Is(err, errTest))
+		assert.EqualValues(t, retries+1, count)
+	}
+}
+
+func TestMaxRetriesParallel(t *testing.T) {
+	const (
+		retries     = 10
+		parallelism = 3
+	)
+
+	var wg sync.WaitGroup
+	p := ZeroBackOff().With(MaxRetries(retries))
+
+	test := func() {
+		defer wg.Done()
+		var count uint
+		err := Retry(p, func() error {
+			count++
+			return errTest
+		})
+		assert.True(t, errors.Is(err, errTest))
+		assert.EqualValues(t, retries+1, count)
+	}
+
+	wg.Add(parallelism)
+	for i := 0; i < parallelism; i++ {
+		go test()
+	}
+	wg.Wait()
+}
+
+func TestMaxInterval(t *testing.T) {
+	const interval = 20 * time.Millisecond
+
+	p := ConstantBackOff(10 * interval).With(MaxInterval(interval))
+
+	var (
+		count uint
+		last  time.Time
+	)
+	err := Retry(p, func() error {
+		now := time.Now()
+		if count > 0 {
+			assertInterval(t, interval, now.Sub(last))
+		}
+		last = now
+		if count >= 10 {
+			return nil
+		}
+		count++
+		return errTest
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, count)
+}
+
+func TestTimeout(t *testing.T) {
+	timeout := time.Now().Add(20 * time.Millisecond)
+	max := timeout.Add(intervalDelta)
+
+	p := ZeroBackOff().With(Timeout(timeout))
+
+	err := Retry(p, func() error {
+		assert.LessOrEqual(t, time.Now().UnixNano(), max.UnixNano())
+		return errTest
+	})
+	assert.True(t, errors.Is(err, errTest))
+	assert.GreaterOrEqual(t, time.Now().UnixNano(), timeout.UnixNano())
+}
+
+func TestCancel(t *testing.T) {
+	cancel := make(chan struct{})
+
+	p := ZeroBackOff().With(Cancel(cancel))
+
+	stopped := make(chan struct{}, 1)
+	go func() {
+		err := Retry(p, func() error {
+			return errTest
+		})
+		assert.True(t, errors.Is(err, errTest))
+		stopped <- struct{}{}
+	}()
+	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-stopped:
+		assert.FailNow(t, "retry stopped prematurely")
+	default:
+	}
+	close(cancel)
+	<-stopped
+}
+
+func TestJitter(t *testing.T) {
+	const (
+		interval    = 20 * time.Millisecond
+		factor      = 0.5
+		minInterval = time.Duration(float64(interval)*factor) - intervalDelta
+		maxInterval = interval + intervalDelta
+	)
+
+	p := ConstantBackOff(interval).With(Jitter(factor))
+
+	var (
+		count uint
+		last  time.Time
+	)
+	err := Retry(p, func() error {
+		now := time.Now()
+		if count > 0 {
+			assert.GreaterOrEqual(t, now.Sub(last).Microseconds(), minInterval.Microseconds())
+			assert.Less(t, now.Sub(last).Microseconds(), maxInterval.Microseconds())
+		}
+		last = now
+		if count >= 10 {
+			return nil
+		}
+		count++
+		return errTest
+	})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, count)
+}


### PR DESCRIPTION
Implements different  backoff policies for retrying operations that may fail:
- Zero backoff
- Constant backoff
- [Exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff)

All backoff policies can be further configured to
- limit retries
- jitter backoff
- cancel retires
- timeout retries