### PR TITLE
Feat: Persistence in the ObjectStorage can be disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iotaledger/hive.go
 go 1.13
 
 require (
+	github.com/dgraph-io/badger v1.5.4
 	github.com/dgraph-io/badger/v2 v2.0.1
 	github.com/google/open-location-code/go v0.0.0-20190903173953-119bc96a3a51
 	github.com/iotaledger/iota.go v1.0.0-beta.9

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/iotaledger/hive.go
 go 1.13
 
 require (
-	github.com/dgraph-io/badger v1.5.4
 	github.com/dgraph-io/badger/v2 v2.0.1
 	github.com/google/open-location-code/go v0.0.0-20190903173953-119bc96a3a51
 	github.com/iotaledger/iota.go v1.0.0-beta.9

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -73,6 +73,13 @@ func (bw *BatchedWriter) batchWrite(object *CachedObject) {
 
 func (bw *BatchedWriter) writeObject(writeBatch *badger.WriteBatch, cachedObject *CachedObject) {
 	objectStorage := cachedObject.objectStorage
+	if !objectStorage.options.persistenceEnabled {
+		if storableObject := cachedObject.Get(); storableObject != nil {
+			storableObject.SetModified(false)
+		}
+
+		return
+	}
 
 	if consumers := atomic.LoadInt32(&(cachedObject.consumers)); consumers == 0 {
 		if storableObject := cachedObject.Get(); storableObject != nil {

--- a/objectstorage/object_storage_options.go
+++ b/objectstorage/object_storage_options.go
@@ -15,6 +15,7 @@ type ObjectStorageOptions struct {
 func newObjectStorageOptions(optionalOptions []ObjectStorageOption) *ObjectStorageOptions {
 	result := &ObjectStorageOptions{
 		cacheTime: 0,
+		persistenceEnabled: true,
 	}
 
 	for _, optionalOption := range optionalOptions {


### PR DESCRIPTION
- The `PersistenceEnabled` option does work now and skips the writes and loads from and to badger.