### PR TITLE
Feat: Added a Shutdown() method to the ObjectStorage

### DIFF
--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -56,7 +56,7 @@ func BenchmarkStore(b *testing.B) {
 		objects.Store(NewTestObject("Hans"+strconv.Itoa(i), uint32(i))).Release()
 	}
 
-	objects.Flush()
+	objects.Shutdown()
 }
 
 func BenchmarkLoad(b *testing.B) {
@@ -115,7 +115,7 @@ func TestStoreIfAbsent(t *testing.T) {
 		t.Error("the object should be nil if it wasn't stored")
 	}
 
-	objects.Flush()
+	objects.Shutdown()
 }
 
 func TestDelete(t *testing.T) {
@@ -137,7 +137,7 @@ func TestDelete(t *testing.T) {
 	}
 	cachedObject.Release()
 
-	objects.Flush()
+	objects.Shutdown()
 }
 
 func TestConcurrency(t *testing.T) {


### PR DESCRIPTION
The ObjectStorage now has a "Shutdown()" method.

The Shutdown() method sets a flag to mark the storage as shutdown and then flushes and waits for all the elements to be persisted. Any additional calls to any of the public API methods will panic.

This allows us to test if an ObjectStorage is not being used anymore after the final shutdown (during debugging / development).