### PR TITLE
Enable LeakDetection with bool parameter

### DIFF
--- a/objectstorage/object_storage_options.go
+++ b/objectstorage/object_storage_options.go
@@ -67,18 +67,20 @@ func PersistenceEnabled(persistenceEnabled bool) ObjectStorageOption {
 	}
 }
 
-func EnableLeakDetection(options ...LeakDetectionOptions) ObjectStorageOption {
+func LeakDetectionEnabled(leakDetectionEnabled bool, options ...LeakDetectionOptions) ObjectStorageOption {
 	return func(args *ObjectStorageOptions) {
-		switch len(options) {
-		case 0:
-			args.leakDetectionOptions = &LeakDetectionOptions{
-				MaxConsumersPerObject: 20,
-				MaxConsumerHoldTime:   240 * time.Second,
+		if leakDetectionEnabled {
+			switch len(options) {
+			case 0:
+				args.leakDetectionOptions = &LeakDetectionOptions{
+					MaxConsumersPerObject: 20,
+					MaxConsumerHoldTime:   240 * time.Second,
+				}
+			case 1:
+				args.leakDetectionOptions = &options[0]
+			default:
+				panic("too many arguments in call to EnableLeakDetection (only 0 or 1 allowed")
 			}
-		case 1:
-			args.leakDetectionOptions = &options[0]
-		default:
-			panic("too many arguments in call to EnableLeakDetection (only 0 or 1 allowed")
 		}
 	}
 }

--- a/objectstorage/object_storage_options.go
+++ b/objectstorage/object_storage_options.go
@@ -79,7 +79,7 @@ func LeakDetectionEnabled(leakDetectionEnabled bool, options ...LeakDetectionOpt
 			case 1:
 				args.leakDetectionOptions = &options[0]
 			default:
-				panic("too many arguments in call to EnableLeakDetection (only 0 or 1 allowed")
+				panic("too many additional arguments in call to LeakDetectionEnabled (only 0 or 1 allowed")
 			}
 		}
 	}

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -17,7 +17,7 @@ import (
 func testObjectFactory(key []byte) objectstorage.StorableObject { return &TestObject{id: key} }
 
 func TestPrefixIteration(t *testing.T) {
-	objects := objectstorage.New([]byte("TestStoreIfAbsentStorage"), testObjectFactory, objectstorage.PartitionKey(1, 1), objectstorage.CacheTime(10*time.Second), objectstorage.EnableLeakDetection())
+	objects := objectstorage.New([]byte("TestStoreIfAbsentStorage"), testObjectFactory, objectstorage.PartitionKey(1, 1), objectstorage.CacheTime(10*time.Second), objectstorage.LeakDetectionEnabled(true))
 	if err := objects.Prune(); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR renames `EnableLeakDetection` to `LeakDetectionEnabled` and adds a bool flag to enable it.

This way, we can define a setting in the config file and just pass the value of the config to this call, to enable the LeakDetection or not. 