### PR TITLE
Fix: "invalid stored peer" warning

### DIFF
--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -170,7 +170,7 @@ func (p *Protocol) publicAddr() string {
 // Ping sends a Ping to the specified peer and blocks until a reply is received or timeout.
 func (p *Protocol) Ping(to *peer.Peer) error {
 	return backoff.Retry(retryPolicy, func() error {
-		err := <-p.sendPing(to.Address(), to.ID())
+		err := <-p.SendPing(to.Address(), to.ID())
 		if err != nil && !errors.Is(err, server.ErrTimeout) {
 			return backoff.Permanent(err)
 		}
@@ -178,9 +178,9 @@ func (p *Protocol) Ping(to *peer.Peer) error {
 	})
 }
 
-// sendPing sends a Ping to the specified address and expects a matching reply.
+// SendPing sends a Ping to the specified address and expects a matching reply.
 // This method is non-blocking, but it returns a channel that can be used to query potential errors.
-func (p *Protocol) sendPing(toAddr string, toID peer.ID) <-chan error {
+func (p *Protocol) SendPing(toAddr string, toID peer.ID) <-chan error {
 	ping := newPing(p.publicAddr(), toAddr)
 	data := marshal(ping)
 
@@ -360,7 +360,7 @@ func (p *Protocol) handlePing(s *server.Server, fromAddr string, fromID peer.ID,
 
 	// if the peer is new or expired, send a Ping to verify
 	if !p.IsVerified(fromID, fromAddr) {
-		p.sendPing(fromAddr, fromID)
+		p.SendPing(fromAddr, fromID)
 	} else if !p.mgr.isKnown(fromID) { // add a discovered peer to the manager if it is new
 		p.mgr.addDiscoveredPeer(newPeer(fromKey, s.LocalAddr().Network(), fromAddr))
 	}

--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -88,9 +88,9 @@ func (p *Protocol) EnsureVerified(peer *peer.Peer) error {
 }
 
 // GetVerifiedPeer returns the verified peer with the given ID, or nil if no such peer exists.
-func (p *Protocol) GetVerifiedPeer(id peer.ID, addr string) *peer.Peer {
+func (p *Protocol) GetVerifiedPeer(id peer.ID) *peer.Peer {
 	for _, verified := range p.mgr.getVerifiedPeers() {
-		if verified.ID() == id && verified.Address() == addr {
+		if verified.ID() == id {
 			return unwrapPeer(verified)
 		}
 	}

--- a/autopeering/discover/protocol_test.go
+++ b/autopeering/discover/protocol_test.go
@@ -108,7 +108,7 @@ func TestProtVerifiedPeers(t *testing.T) {
 	// protA should have peerB as the single verified peer
 	assert.ElementsMatch(t, []*peer.Peer{peerB}, protA.GetVerifiedPeers())
 	for _, p := range protA.GetVerifiedPeers() {
-		assert.Equal(t, p, protA.GetVerifiedPeer(p.ID(), p.Address()))
+		assert.Equal(t, p, protA.GetVerifiedPeer(p.ID()))
 	}
 }
 
@@ -129,11 +129,9 @@ func TestProtVerifiedPeer(t *testing.T) {
 	time.Sleep(graceTime)
 
 	// we should have peerB as a verified peer
-	assert.Equal(t, peerB, protA.GetVerifiedPeer(peerB.ID(), peerB.Address()))
+	assert.Equal(t, peerB, protA.GetVerifiedPeer(peerB.ID()))
 	// we should not have ourselves as a verified peer
-	assert.Nil(t, protA.GetVerifiedPeer(peerA.ID(), peerA.Address()))
-	// the address of peerB should match
-	assert.Nil(t, protA.GetVerifiedPeer(peerB.ID(), ""))
+	assert.Nil(t, protA.GetVerifiedPeer(peerA.ID()))
 }
 
 func TestProtDiscoveryRequest(t *testing.T) {

--- a/autopeering/peer/peerdb_test.go
+++ b/autopeering/peer/peerdb_test.go
@@ -36,7 +36,9 @@ func TestPeerDB(t *testing.T) {
 		err := db.UpdatePeer(p)
 		require.NoError(t, err)
 
-		assert.Equal(t, p, db.Peer(p.ID()))
+		dbPeer, err := db.Peer(p.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, p, dbPeer)
 	})
 
 	t.Run("LastPing", func(t *testing.T) {

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -29,10 +29,12 @@ var retryPolicy = backoff.ExponentialBackOff(500*time.Millisecond, 1.5).With(
 
 // DiscoverProtocol specifies the methods from the peer discovery that are required.
 type DiscoverProtocol interface {
-	IsVerified(id peer.ID, addr string) bool
+	IsVerified(peer.ID, string) bool
 	EnsureVerified(*peer.Peer) error
 
-	GetVerifiedPeer(id peer.ID) *peer.Peer
+	SendPing(string, peer.ID) <-chan error
+
+	GetVerifiedPeer(peer.ID) *peer.Peer
 	GetVerifiedPeers() []*peer.Peer
 }
 
@@ -319,7 +321,8 @@ func (p *Protocol) handlePeeringRequest(s *server.Server, fromAddr string, fromI
 			)
 			return
 		}
-		// TODO: ping the peer from DB
+		// send ping to restored peer to ensure that it will be verified
+		p.disc.SendPing(from.Address(), from.ID())
 	}
 
 	var status bool

--- a/autopeering/selection/protocol_test.go
+++ b/autopeering/selection/protocol_test.go
@@ -127,10 +127,11 @@ func TestProtocol(t *testing.T) {
 // dummyDiscovery is a dummy implementation of DiscoveryProtocol never returning any verified peers.
 type dummyDiscovery struct{}
 
-func (d dummyDiscovery) IsVerified(peer.ID, string) bool       { return true }
-func (d dummyDiscovery) EnsureVerified(*peer.Peer) error       { return nil }
-func (d dummyDiscovery) GetVerifiedPeer(id peer.ID) *peer.Peer { return peerMap[id] }
-func (d dummyDiscovery) GetVerifiedPeers() []*peer.Peer        { return []*peer.Peer{} }
+func (d dummyDiscovery) IsVerified(_ peer.ID, _ string) bool       { return true }
+func (d dummyDiscovery) EnsureVerified(_ *peer.Peer) error         { return nil }
+func (d dummyDiscovery) SendPing(_ string, _ peer.ID) <-chan error { return nil }
+func (d dummyDiscovery) GetVerifiedPeer(id peer.ID) *peer.Peer     { return peerMap[id] }
+func (d dummyDiscovery) GetVerifiedPeers() []*peer.Peer            { return []*peer.Peer{} }
 
 // newTestProtocol creates a new neighborhood server and also returns the teardown.
 func newTestProtocol(trans transport.Transport) (*Protocol, func()) {

--- a/autopeering/selection/protocol_test.go
+++ b/autopeering/selection/protocol_test.go
@@ -127,10 +127,10 @@ func TestProtocol(t *testing.T) {
 // dummyDiscovery is a dummy implementation of DiscoveryProtocol never returning any verified peers.
 type dummyDiscovery struct{}
 
-func (d dummyDiscovery) IsVerified(peer.ID, string) bool                 { return true }
-func (d dummyDiscovery) EnsureVerified(*peer.Peer) error                 { return nil }
-func (d dummyDiscovery) GetVerifiedPeer(id peer.ID, _ string) *peer.Peer { return peerMap[id] }
-func (d dummyDiscovery) GetVerifiedPeers() []*peer.Peer                  { return []*peer.Peer{} }
+func (d dummyDiscovery) IsVerified(peer.ID, string) bool       { return true }
+func (d dummyDiscovery) EnsureVerified(*peer.Peer) error       { return nil }
+func (d dummyDiscovery) GetVerifiedPeer(id peer.ID) *peer.Peer { return peerMap[id] }
+func (d dummyDiscovery) GetVerifiedPeers() []*peer.Peer        { return []*peer.Peer{} }
 
 // newTestProtocol creates a new neighborhood server and also returns the teardown.
 func newTestProtocol(trans transport.Transport) (*Protocol, func()) {


### PR DESCRIPTION
Warning is issued when a peering request comes from a peer that is verified in the DB but not contained in the current list of verified peers.
- In this case, load the peer from the DB and consider peering. 
- If the peer is not verified, send a ping to assure that it will be verified soon.
- Handle the case where the address of the stored peer does not match the current address.