### PR TITLE
Add "added" flag to workerpool Submit calls

### DIFF
--- a/batchhasher/batch_hasher.go
+++ b/batchhasher/batch_hasher.go
@@ -1,10 +1,11 @@
 package batchhasher
 
 import (
-	"github.com/iotaledger/hive.go/batchworkerpool"
-	"github.com/iotaledger/hive.go/ternary_mux"
 	"runtime"
 	"strconv"
+
+	"github.com/iotaledger/hive.go/batchworkerpool"
+	"github.com/iotaledger/hive.go/ternary_mux"
 
 	"github.com/iotaledger/iota.go/trinary"
 )
@@ -48,7 +49,8 @@ func (this *BatchHasher) GetPendingQueueSize() int {
 }
 
 func (this *BatchHasher) Hash(trits trinary.Trits) trinary.Trits {
-	return (<-this.workerPool.Submit(trits)).(trinary.Trits)
+	result, _ := this.workerPool.Submit(trits)
+	return (<-result).(trinary.Trits)
 }
 
 func (this *BatchHasher) processHashes(tasks []batchworkerpool.Task) {

--- a/batchworkerpool/batchworkerpool.go
+++ b/batchworkerpool/batchworkerpool.go
@@ -38,9 +38,10 @@ func New(workerFnc func([]Task), optionalOptions ...Option) (result *BatchWorker
 	return
 }
 
-func (wp *BatchWorkerPool) Submit(params ...interface{}) (result chan interface{}) {
+func (wp *BatchWorkerPool) Submit(params ...interface{}) (result chan interface{}, added bool) {
 
 	wp.mutex.RLock()
+	defer wp.mutex.RUnlock()
 
 	if !wp.shutdown {
 		result = make(chan interface{}, 1)
@@ -49,11 +50,10 @@ func (wp *BatchWorkerPool) Submit(params ...interface{}) (result chan interface{
 			params:     params,
 			resultChan: result,
 		}
+		return result, true
 	}
 
-	wp.mutex.RUnlock()
-
-	return
+	return nil, false
 }
 
 func (wp *BatchWorkerPool) Start() {

--- a/workerpool/workerpool_test.go
+++ b/workerpool/workerpool_test.go
@@ -16,7 +16,8 @@ func Benchmark(b *testing.B) {
 		wg.Add(1)
 
 		go func(i int) {
-			<-pool.Submit(i)
+			result, _ := pool.Submit(i)
+			<-result
 
 			wg.Done()
 		}(i)


### PR DESCRIPTION
This adds the "added" flag to the "Submit" function in the workerpool and batchedworkerpool.

This way we know if the workerpool was shut down in the meantime (needed for proper cachedObject management).