### PR TITLE
Feat: Made run optional when creating a Plugin

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -5,15 +5,9 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
-)
-
-var (
-	defaultConfig     *viper.Viper
-	defaultConfigInit sync.Once
 )
 
 // PrintConfig prints the actual configuration, ignoreSettingsAtPrint are not shown
@@ -36,21 +30,6 @@ func PrintConfig(config *viper.Viper, ignoreSettingsAtPrint ...[]string) {
 	if cfg, err := json.MarshalIndent(settings, "", "  "); err == nil {
 		fmt.Printf("Parameters loaded: \n %+v\n", string(cfg))
 	}
-}
-
-func DefaultConfig() *viper.Viper {
-	defaultConfigInit.Do(func() {
-		configName := *flag.StringP("config", "c", "config", "Filename of the config file without the file extension")
-		configDirPath := *flag.StringP("config-dir", "d", ".", "Path to the directory containing the config file")
-
-		defaultConfig = viper.New()
-		err := LoadConfigFile(defaultConfig, configDirPath, configName, true, true)
-		if err != nil {
-			log.Panicf("Error loading config: %s", err)
-		}
-	})
-
-	return defaultConfig
 }
 
 // LoadConfigFile fetches config values from a dir defined in "configDir" (or the current working dir if not set)


### PR DESCRIPTION
This PR allows to create Plugins without a callback. This makes sense, if the plugin does not execute anything in the configure step, but instead uses `init()` to execute its logic.