### PR TITLE
Feat: Added optional `Init` phase to plugin lifecycle

### DIFF
--- a/node/events.go
+++ b/node/events.go
@@ -5,6 +5,7 @@ import (
 )
 
 type pluginEvents struct {
+	Init      *events.Event
 	Configure *events.Event
 	Run       *events.Event
 }

--- a/node/node.go
+++ b/node/node.go
@@ -71,6 +71,10 @@ func isEnabled(plugin *Plugin) bool {
 
 func (node *Node) configure(plugins ...*Plugin) {
 	for _, plugin := range plugins {
+		plugin.Events.Init.Trigger(plugin)
+	}
+
+	for _, plugin := range plugins {
 		if IsSkipped(plugin) {
 			node.Logger.Infof("Skipping Plugin: %s", plugin.Name)
 			continue

--- a/node/plugin.go
+++ b/node/plugin.go
@@ -29,6 +29,7 @@ func NewPlugin(name string, status int, callbacks ...Callback) *Plugin {
 		Name:   name,
 		Status: status,
 		Events: pluginEvents{
+			Init:      events.NewEvent(pluginCaller),
 			Configure: events.NewEvent(pluginCaller),
 			Run:       events.NewEvent(pluginCaller),
 		},


### PR DESCRIPTION
This phase can for example be used to trigger the parsing of the config file before the node runs checks on skipped Plugins.

It happens after ìnit()` and before `configure()`