### PR TITLE
Makes autopeering VersionNum configurable

### DIFF
--- a/autopeering/discover/common.go
+++ b/autopeering/discover/common.go
@@ -31,21 +31,24 @@ type Options struct {
 
 type option func(*Options)
 
+// Logger sets the logger
 func Logger(log *logger.Logger) option {
-	return func(c *Options) {
-		c.Log = log
+	return func(args *Options) {
+		args.Log = log
 	}
 }
 
+// Version sets the VersionNumber of the protocol
 func Version(version uint32) option {
-	return func(c *Options) {
-		c.Version = version
+	return func(args *Options) {
+		args.Version = version
 	}
 }
 
+// MasterPeers sets the masterPeers to use
 func MasterPeers(masterPeers []*peer.Peer) option {
-	return func(c *Options) {
-		c.MasterPeers = masterPeers
+	return func(args *Options) {
+		args.MasterPeers = masterPeers
 	}
 }
 

--- a/autopeering/discover/common.go
+++ b/autopeering/discover/common.go
@@ -27,6 +27,8 @@ type Config struct {
 	// These settings are required and configure the listener:
 	Log *logger.Logger
 
+	Version uint32 // Protocol version
+
 	// These settings are optional:
 	MasterPeers []*peer.Peer // list of master peers used for bootstrapping
 }

--- a/autopeering/discover/common.go
+++ b/autopeering/discover/common.go
@@ -22,33 +22,29 @@ var (
 	maxReplacements  = DefaultMaxReplacements  // maximum number of peers kept in the replacement list
 )
 
-// Config holds discovery related settings.
-type Config struct {
-	// These settings are required and configure the listener:
-	Log *logger.Logger
-
-	Version uint32 // Protocol version
-
-	// These settings are optional:
-	MasterPeers []*peer.Peer // list of master peers used for bootstrapping
+// Options holds discovery related settings.
+type Options struct {
+	Log         *logger.Logger // Logger
+	Version     uint32         // Protocol version
+	MasterPeers []*peer.Peer   // list of master peers used for bootstrapping
 }
 
-type option func(*Config)
+type option func(*Options)
 
-func SetLogger(log *logger.Logger) option {
-	return func(c *Config) {
+func Logger(log *logger.Logger) option {
+	return func(c *Options) {
 		c.Log = log
 	}
 }
 
-func SetVersion(version uint32) option {
-	return func(c *Config) {
+func Version(version uint32) option {
+	return func(c *Options) {
 		c.Version = version
 	}
 }
 
-func SetMasterPeers(masterPeers []*peer.Peer) option {
-	return func(c *Config) {
+func MasterPeers(masterPeers []*peer.Peer) option {
+	return func(c *Options) {
 		c.MasterPeers = masterPeers
 	}
 }

--- a/autopeering/discover/common.go
+++ b/autopeering/discover/common.go
@@ -33,6 +33,26 @@ type Config struct {
 	MasterPeers []*peer.Peer // list of master peers used for bootstrapping
 }
 
+type option func(*Config)
+
+func SetLogger(log *logger.Logger) option {
+	return func(c *Config) {
+		c.Log = log
+	}
+}
+
+func SetVersion(version uint32) option {
+	return func(c *Config) {
+		c.Version = version
+	}
+}
+
+func SetMasterPeers(masterPeers []*peer.Peer) option {
+	return func(c *Config) {
+		c.MasterPeers = masterPeers
+	}
+}
+
 // Parameters holds the parameters that can be configured.
 type Parameters struct {
 	ReverifyInterval time.Duration // time interval after which the next peer is reverified

--- a/autopeering/discover/manager.go
+++ b/autopeering/discover/manager.go
@@ -17,9 +17,11 @@ const (
 	MaxPeersInResponse = 6
 	// MaxServices is the maximum number of services a peer can support.
 	MaxServices = 5
+)
 
+var (
 	// VersionNum specifies the expected version number for this Protocol.
-	VersionNum = 0
+	VersionNum = uint32(0)
 )
 
 type network interface {

--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -41,27 +41,27 @@ type Protocol struct {
 }
 
 // New creates a new discovery protocol.
-func New(local *peer.Local, opts ...option) *Protocol {
+func New(local *peer.Local, setters ...option) *Protocol {
 	log := logger.NewExampleLogger("discover")
-	cfg := &Config{
+	args := &Options{
 		Log:     log.Named("disc"),
 		Version: 0,
 	}
 
-	for _, opt := range opts {
-		opt(cfg)
+	for _, setter := range setters {
+		setter(args)
 	}
 
 	p := &Protocol{
 		Protocol: server.Protocol{},
 		loc:      local,
-		log:      cfg.Log,
+		log:      args.Log,
 		running:  typeutils.NewAtomicBool(),
 	}
 
-	VersionNum = cfg.Version
+	VersionNum = args.Version
 
-	p.mgr = newManager(p, cfg.MasterPeers, cfg.Log.Named("mgr"))
+	p.mgr = newManager(p, args.MasterPeers, args.Log.Named("mgr"))
 
 	return p
 }

--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -41,7 +41,17 @@ type Protocol struct {
 }
 
 // New creates a new discovery protocol.
-func New(local *peer.Local, cfg Config) *Protocol {
+func New(local *peer.Local, opts ...option) *Protocol {
+	log := logger.NewExampleLogger("discover")
+	cfg := &Config{
+		Log:     log.Named("disc"),
+		Version: 0,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	p := &Protocol{
 		Protocol: server.Protocol{},
 		loc:      local,

--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -48,6 +48,9 @@ func New(local *peer.Local, cfg Config) *Protocol {
 		log:      cfg.Log,
 		running:  typeutils.NewAtomicBool(),
 	}
+
+	VersionNum = cfg.Version
+
 	p.mgr = newManager(p, cfg.MasterPeers, cfg.Log.Named("mgr"))
 
 	return p

--- a/autopeering/discover/protocol_test.go
+++ b/autopeering/discover/protocol_test.go
@@ -274,7 +274,7 @@ func newTestProtocol(trans transport.Transport, logger *logger.Logger, masters .
 	local := peertest.NewLocal(trans.LocalAddr().Network(), trans.LocalAddr().String(), db)
 	log := logger.Named(trans.LocalAddr().String())
 
-	prot := New(local, SetLogger(log), SetMasterPeers(masters))
+	prot := New(local, Logger(log), MasterPeers(masters))
 
 	srv := server.Serve(local, trans, log, prot)
 	prot.Start(srv)

--- a/autopeering/discover/protocol_test.go
+++ b/autopeering/discover/protocol_test.go
@@ -274,7 +274,7 @@ func newTestProtocol(trans transport.Transport, logger *logger.Logger, masters .
 	local := peertest.NewLocal(trans.LocalAddr().Network(), trans.LocalAddr().String(), db)
 	log := logger.Named(trans.LocalAddr().String())
 
-	prot := New(local, Config{Log: log, MasterPeers: masters})
+	prot := New(local, SetLogger(log), SetMasterPeers(masters))
 
 	srv := server.Serve(local, trans, log, prot)
 	prot.Start(srv)

--- a/autopeering/selection/common.go
+++ b/autopeering/selection/common.go
@@ -24,33 +24,30 @@ var (
 	fullOutboundUpdateInterval = DefaultFullOutboundUpdateInterval // time after which full out neighbors are updated
 )
 
-// Config holds settings for the peer selection.
-type Config struct {
-	// Logger
-	Log *logger.Logger
-
-	// These settings are optional:
-	DropOnUpdate      bool      // set true to drop all neighbors when the salt is updated
-	NeighborValidator Validator // potential neighbor validator
+// Options holds settings for the peer selection.
+type Options struct {
+	Log               *logger.Logger // Logger
+	DropOnUpdate      bool           // set true to drop all neighbors when the salt is updated
+	NeighborValidator Validator      // potential neighbor validator
 }
 
-type option func(*Config)
+type option func(*Options)
 
-func SetLogger(log *logger.Logger) option {
-	return func(c *Config) {
-		c.Log = log
+func Logger(log *logger.Logger) option {
+	return func(args *Options) {
+		args.Log = log
 	}
 }
 
-func SetDropOnUpdate(dropOnUpdate bool) option {
-	return func(c *Config) {
-		c.DropOnUpdate = dropOnUpdate
+func DropOnUpdate(dropOnUpdate bool) option {
+	return func(args *Options) {
+		args.DropOnUpdate = dropOnUpdate
 	}
 }
 
-func SetNeighborValidator(neighborValidator Validator) option {
-	return func(c *Config) {
-		c.NeighborValidator = neighborValidator
+func NeighborValidator(neighborValidator Validator) option {
+	return func(args *Options) {
+		args.NeighborValidator = neighborValidator
 	}
 }
 

--- a/autopeering/selection/common.go
+++ b/autopeering/selection/common.go
@@ -33,18 +33,21 @@ type Options struct {
 
 type option func(*Options)
 
+// Logger sets the logger
 func Logger(log *logger.Logger) option {
 	return func(args *Options) {
 		args.Log = log
 	}
 }
 
+// DropOnUpdate sets the option to drop all neighbors when the salt is updated
 func DropOnUpdate(dropOnUpdate bool) option {
 	return func(args *Options) {
 		args.DropOnUpdate = dropOnUpdate
 	}
 }
 
+// NeighborValidator sets the potential neighbor validator
 func NeighborValidator(neighborValidator Validator) option {
 	return func(args *Options) {
 		args.NeighborValidator = neighborValidator

--- a/autopeering/selection/common.go
+++ b/autopeering/selection/common.go
@@ -34,6 +34,26 @@ type Config struct {
 	NeighborValidator Validator // potential neighbor validator
 }
 
+type option func(*Config)
+
+func SetLogger(log *logger.Logger) option {
+	return func(c *Config) {
+		c.Log = log
+	}
+}
+
+func SetDropOnUpdate(dropOnUpdate bool) option {
+	return func(c *Config) {
+		c.DropOnUpdate = dropOnUpdate
+	}
+}
+
+func SetNeighborValidator(neighborValidator Validator) option {
+	return func(c *Config) {
+		c.NeighborValidator = neighborValidator
+	}
+}
+
 // A Validator checks whether a peer is a valid neighbor
 type Validator interface {
 	IsValid(*peer.Peer) bool

--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -50,13 +50,13 @@ type manager struct {
 	closing chan struct{}
 }
 
-func newManager(net network, peersFunc func() []*peer.Peer, log *logger.Logger, config Config) *manager {
+func newManager(net network, peersFunc func() []*peer.Peer, log *logger.Logger, opts Options) *manager {
 	return &manager{
 		net:               net,
 		getPeersToConnect: peersFunc,
 		log:               log,
-		dropOnUpdate:      config.DropOnUpdate,
-		neighborValidator: config.NeighborValidator,
+		dropOnUpdate:      opts.DropOnUpdate,
+		neighborValidator: opts.NeighborValidator,
 		inbound:           NewNeighborhood(inboundNeighborSize),
 		outbound:          NewNeighborhood(outboundNeighborSize),
 		rejectionFilter:   NewFilter(),

--- a/autopeering/selection/manager_test.go
+++ b/autopeering/selection/manager_test.go
@@ -210,7 +210,7 @@ func newTestManager(name string, mgrMap map[peer.ID]*manager) *manager {
 	db, _ := peer.NewDB(mapdb.NewMapDB())
 	local := peertest.NewLocal("mock", name, db)
 	networkMock := &networkMock{loc: local, mgr: mgrMap}
-	m := newManager(networkMock, networkMock.GetKnownPeers, log.Named(name), Config{})
+	m := newManager(networkMock, networkMock.GetKnownPeers, log.Named(name), Options{})
 	mgrMap[m.getID()] = m
 	return m
 }

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -53,24 +53,24 @@ type Protocol struct {
 }
 
 // New creates a new neighbor selection protocol.
-func New(local *peer.Local, disc DiscoverProtocol, opts ...option) *Protocol {
+func New(local *peer.Local, disc DiscoverProtocol, setters ...option) *Protocol {
 	log := logger.NewExampleLogger("selection")
-	cfg := &Config{
+	args := &Options{
 		Log: log.Named("sel"),
 	}
 
-	for _, opt := range opts {
-		opt(cfg)
+	for _, setter := range setters {
+		setter(args)
 	}
 
 	p := &Protocol{
 		Protocol: server.Protocol{},
 		loc:      local,
 		disc:     disc,
-		log:      cfg.Log,
+		log:      args.Log,
 		running:  typeutils.NewAtomicBool(),
 	}
-	p.mgr = newManager(p, disc.GetVerifiedPeers, cfg.Log.Named("mgr"), *cfg)
+	p.mgr = newManager(p, disc.GetVerifiedPeers, args.Log.Named("mgr"), *args)
 
 	return p
 }

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -53,7 +53,16 @@ type Protocol struct {
 }
 
 // New creates a new neighbor selection protocol.
-func New(local *peer.Local, disc DiscoverProtocol, cfg Config) *Protocol {
+func New(local *peer.Local, disc DiscoverProtocol, opts ...option) *Protocol {
+	log := logger.NewExampleLogger("selection")
+	cfg := &Config{
+		Log: log.Named("sel"),
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	p := &Protocol{
 		Protocol: server.Protocol{},
 		loc:      local,
@@ -61,7 +70,7 @@ func New(local *peer.Local, disc DiscoverProtocol, cfg Config) *Protocol {
 		log:      cfg.Log,
 		running:  typeutils.NewAtomicBool(),
 	}
-	p.mgr = newManager(p, disc.GetVerifiedPeers, cfg.Log.Named("mgr"), cfg)
+	p.mgr = newManager(p, disc.GetVerifiedPeers, cfg.Log.Named("mgr"), *cfg)
 
 	return p
 }

--- a/autopeering/selection/protocol_test.go
+++ b/autopeering/selection/protocol_test.go
@@ -141,7 +141,7 @@ func newTestProtocol(trans transport.Transport) (*Protocol, func()) {
 	peerMap[local.ID()] = &local.Peer
 	l := log.Named(trans.LocalAddr().String())
 
-	prot := New(local, dummyDiscovery{}, Config{Log: l.Named("disc")})
+	prot := New(local, dummyDiscovery{}, SetLogger(l.Named("sel")))
 	srv := server.Serve(local, trans, l.Named("srv"), prot)
 	prot.Start(srv)
 
@@ -160,13 +160,8 @@ func newFullTestProtocol(trans transport.Transport, masterPeers ...*peer.Peer) (
 	peerMap[local.ID()] = &local.Peer
 	l := log.Named(trans.LocalAddr().String())
 
-	discovery := discover.New(local, discover.Config{
-		Log:         l.Named("disc"),
-		MasterPeers: masterPeers,
-	})
-	selection := New(local, discovery, Config{
-		Log: l.Named("sel"),
-	})
+	discovery := discover.New(local, discover.SetLogger(l.Named("disc")), discover.SetMasterPeers(masterPeers))
+	selection := New(local, discovery, SetLogger(l.Named("sel")))
 
 	srv := server.Serve(local, trans, l.Named("srv"), discovery, selection)
 

--- a/autopeering/selection/protocol_test.go
+++ b/autopeering/selection/protocol_test.go
@@ -141,7 +141,7 @@ func newTestProtocol(trans transport.Transport) (*Protocol, func()) {
 	peerMap[local.ID()] = &local.Peer
 	l := log.Named(trans.LocalAddr().String())
 
-	prot := New(local, dummyDiscovery{}, SetLogger(l.Named("sel")))
+	prot := New(local, dummyDiscovery{}, Logger(l.Named("sel")))
 	srv := server.Serve(local, trans, l.Named("srv"), prot)
 	prot.Start(srv)
 
@@ -160,8 +160,11 @@ func newFullTestProtocol(trans transport.Transport, masterPeers ...*peer.Peer) (
 	peerMap[local.ID()] = &local.Peer
 	l := log.Named(trans.LocalAddr().String())
 
-	discovery := discover.New(local, discover.SetLogger(l.Named("disc")), discover.SetMasterPeers(masterPeers))
-	selection := New(local, discovery, SetLogger(l.Named("sel")))
+	discovery := discover.New(local,
+		discover.Logger(l.Named("disc")),
+		discover.MasterPeers(masterPeers),
+	)
+	selection := New(local, discovery, Logger(l.Named("sel")))
 
 	srv := server.Serve(local, trans, l.Named("srv"), discovery, selection)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/google/open-location-code/go v0.0.0-20190903173953-119bc96a3a51
 	github.com/iotaledger/iota.go v1.0.0-beta.9
+	github.com/kr/text v0.1.0
 	github.com/panjf2000/ants/v2 v2.2.2
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
This PR changes the autopeering VersionNum from `const` to `var` and allows to configure it via functional options. However, since the VersionNum is a global variable of the package, multiple autopeering instances will share the same version.
It also changes both discover and selection packages to accept functional options instead of a config struct