### PR TITLE
Fix: Append plugins instead of assigning them in NodeOption

### DIFF
--- a/node/node_options.go
+++ b/node/node_options.go
@@ -27,7 +27,7 @@ type NodeOption func(*NodeOptions)
 
 func Plugins(plugins ...*Plugin) NodeOption {
 	return func(args *NodeOptions) {
-		args.plugins = plugins
+		args.plugins = append(args.plugins, plugins...)
 	}
 }
 


### PR DESCRIPTION
Using assignment will only keep the plugins of the last NodeOption
in the list in newNodeOptions().