### PR TITLE
Add KeysOnly to object storage

### DIFF
--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -82,7 +82,11 @@ func (bw *BatchedWriter) writeObject(writeBatch *badger.WriteBatch, cachedObject
 			} else if storableObject.PersistenceEnabled() && storableObject.IsModified() {
 				storableObject.SetModified(false)
 
-				marshaledObject, _ := storableObject.MarshalBinary()
+				var marshaledObject []byte
+				if !objectStorage.options.keysOnly {
+					marshaledObject, _ = storableObject.MarshalBinary()
+				}
+
 				if err := writeBatch.Set(objectStorage.generatePrefix([][]byte{cachedObject.key}), marshaledObject); err != nil {
 					panic(err)
 				}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -693,15 +693,15 @@ func (objectStorage *ObjectStorage) loadObjectFromBadger(key []byte) StorableObj
 		return nil
 	}
 
-	if objectStorage.options.keysOnly {
-		return objectStorage.objectFactory(key)
-	}
-
 	var marshaledData []byte
 	if err := objectStorage.badgerInstance.View(func(txn *badger.Txn) error {
 		if item, err := txn.Get(objectStorage.generatePrefix([][]byte{key})); err != nil {
 			return err
 		} else {
+			if objectStorage.options.keysOnly {
+				return nil
+			}
+
 			return item.Value(func(val []byte) error {
 				marshaledData = make([]byte, len(val))
 				copy(marshaledData, val)
@@ -716,6 +716,10 @@ func (objectStorage *ObjectStorage) loadObjectFromBadger(key []byte) StorableObj
 			panic(err)
 		}
 	} else {
+		if objectStorage.options.keysOnly {
+			return objectStorage.objectFactory(key)
+		}
+
 		return objectStorage.unmarshalObject(key, marshaledData)
 	}
 }

--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	cacheTime             time.Duration
 	keyPartitions         []int
 	persistenceEnabled    bool
+	keysOnly              bool
 	leakDetectionOptions  *LeakDetectionOptions
 	leakDetectionWrapper  func(cachedObject *CachedObjectImpl) LeakDetectionWrapper
 }
@@ -51,6 +52,12 @@ func BatchedWriterInstance(batchedWriterInstance *BatchedWriter) Option {
 func PersistenceEnabled(persistenceEnabled bool) Option {
 	return func(args *Options) {
 		args.persistenceEnabled = persistenceEnabled
+	}
+}
+
+func KeysOnly(keysOnly bool) Option {
+	return func(args *Options) {
+		args.keysOnly = keysOnly
 	}
 }
 


### PR DESCRIPTION
This PR adds an option `KeysOnly` to object storage to skip marshaling/unmarshaling and loading values from badger if the object has no data.
This should be much faster for objects that only consist of data of their keys.