### PR TITLE
Add websockethub package

### DIFF
--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -1,0 +1,115 @@
+package websockethub
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 125 // 125 is the maximum payload size for ping pongs
+
+	// Maximum size of queued messages that should be sent to the peer.
+	sendChannelSize = 100
+)
+
+// Client is a middleman between the node and the websocket connection.
+type Client struct {
+	hub *Hub
+
+	// The websocket connection.
+	conn *websocket.Conn
+
+	// Buffered channel of outbound messages.
+	sendChan chan interface{}
+}
+
+// checkPong checks if the client is still available and answers to the ping messages
+// that are sent periodically in the writePump function.
+//
+// At most one reader per websocket connection is allowed
+func (c *Client) checkPong() {
+
+	defer func() {
+		// Send a unregister message to the hub
+		c.hub.unregister <- c
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error { c.conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+
+	for {
+		_, _, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				c.hub.logger.Warnf("Websocket error: %v", err)
+			}
+			return
+		}
+	}
+}
+
+// writePump pumps messages from the node to the websocket connection.
+//
+// At most one writer per websocket connection is allowed
+func (c *Client) writePump() {
+
+	pingTicker := time.NewTicker(pingPeriod)
+
+	defer func() {
+		// stop the ping ticker
+		pingTicker.Stop()
+
+		// Send a unregister message to the hub
+		c.hub.unregister <- c
+
+		// close the websocket connection
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+
+		case <-c.hub.shutdownSignal:
+			return
+
+		case msg, ok := <-c.sendChan:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// The Hub closed the channel.
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			if err := c.conn.WriteJSON(msg); err != nil {
+				c.hub.logger.Warnf("Websocket error: %v", err)
+				return
+			}
+
+		case <-pingTicker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// Send sends a message to the client
+func (c *Client) Send(msg interface{}) {
+	select {
+	case c.sendChan <- msg:
+	default:
+	}
+}

--- a/websockethub/hub.go
+++ b/websockethub/hub.go
@@ -1,0 +1,106 @@
+package websockethub
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/iotaledger/hive.go/logger"
+)
+
+// Hub maintains the set of active clients and broadcasts messages to the clients.
+type Hub struct {
+
+	// Websocket Upgrader.
+	upgrader *websocket.Upgrader
+
+	// Used Logger instance.
+	logger *logger.Logger
+
+	// Registered clients.
+	clients map[*Client]struct{}
+
+	// Inbound messages from the clients.
+	broadcast chan interface{}
+
+	// Register requests from the clients.
+	register chan *Client
+
+	// Unregister requests from clients.
+	unregister chan *Client
+
+	shutdownSignal <-chan struct{}
+}
+
+func NewHub(logger *logger.Logger, upgrader *websocket.Upgrader, broadcastQueueSize int) *Hub {
+	return &Hub{
+		logger:     logger,
+		upgrader:   upgrader,
+		clients:    make(map[*Client]struct{}),
+		broadcast:  make(chan interface{}, broadcastQueueSize),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+	}
+}
+
+// BroadcastMsg sends a message to all clients
+func (h *Hub) BroadcastMsg(msg interface{}) {
+	select {
+	case h.broadcast <- msg:
+	default:
+	}
+}
+
+// Start the hub
+func (h *Hub) Run(shutdownSignal <-chan struct{}) {
+
+	for {
+		select {
+		case <-shutdownSignal:
+			for client := range h.clients {
+				delete(h.clients, client)
+				close(client.sendChan)
+			}
+			return
+
+		case client := <-h.register:
+			// register client
+			h.clients[client] = struct{}{}
+
+		case client := <-h.unregister:
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.sendChan)
+				h.logger.Infof("Removed websocket client")
+			}
+
+		case message := <-h.broadcast:
+			for client := range h.clients {
+				select {
+				case client.sendChan <- message:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// ServeWebsocket handles websocket requests from the peer.
+func (h *Hub) ServeWebsocket(w http.ResponseWriter, r *http.Request, onConnect ...func(client *Client)) {
+
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		h.logger.Warnf("Upgrade websocket: %v", err)
+		return
+	}
+
+	client := &Client{hub: h, conn: conn, sendChan: make(chan interface{}, sendChannelSize)}
+	h.register <- client
+
+	go client.checkPong()
+	go client.writePump()
+
+	if len(onConnect) > 0 {
+		onConnect[0](client)
+	}
+}


### PR DESCRIPTION
This PR adds a websocket manager called hub.

The hub has several advantages:
- maintains a list of active clients
- sends ping messages to all clients
- enables broadcast messages to all clients
- handles the concurrency of the websocket connections