### PR TITLE
Refactor: Renamed interface methods and signatures

### DIFF
--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -86,12 +86,12 @@ func (bw *BatchedWriter) writeObject(writeBatch *badger.WriteBatch, cachedObject
 			} else if storableObject.PersistenceEnabled() && storableObject.IsModified() {
 				storableObject.SetModified(false)
 
-				var marshaledObject []byte
+				var marshaledValue []byte
 				if !objectStorage.options.keysOnly {
-					marshaledObject = storableObject.ObjectStorageValue()
+					marshaledValue = storableObject.ObjectStorageValue()
 				}
 
-				if err := writeBatch.Set(objectStorage.generatePrefix([][]byte{cachedObject.key}), marshaledObject); err != nil {
+				if err := writeBatch.Set(objectStorage.generatePrefix([][]byte{cachedObject.key}), marshaledValue); err != nil {
 					panic(err)
 				}
 			}

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -88,7 +88,7 @@ func (bw *BatchedWriter) writeObject(writeBatch *badger.WriteBatch, cachedObject
 
 				var marshaledObject []byte
 				if !objectStorage.options.keysOnly {
-					marshaledObject, _ = storableObject.MarshalBinary()
+					marshaledObject = storableObject.ObjectStorageValue()
 				}
 
 				if err := writeBatch.Set(objectStorage.generatePrefix([][]byte{cachedObject.key}), marshaledObject); err != nil {

--- a/objectstorage/storable_object.go
+++ b/objectstorage/storable_object.go
@@ -1,14 +1,6 @@
 package objectstorage
 
-import (
-	"encoding"
-)
-
 type StorableObject interface {
-	// import the default Marshaler interfaces
-	encoding.BinaryMarshaler
-	encoding.BinaryUnmarshaler
-
 	// Marks the object as modified, which causes it to be written to the disk (if persistence is enabled).
 	// Default value when omitting the parameter: true
 	SetModified(modified ...bool)
@@ -34,6 +26,12 @@ type StorableObject interface {
 	// Updates the object with the values of another object "in place" (so it should use a pointer receiver)
 	Update(other StorableObject)
 
-	// Returns the key that identifies the object in the object storage.
-	GetStorageKey() []byte
+	// ObjectStorageKey returns the bytes, that are used as a key to store the object in the k/v store.
+	ObjectStorageKey() []byte
+
+	// ObjectStorageValue returns the bytes, that are stored in the value part of the k/v store.
+	ObjectStorageValue() []byte
+
+	// UnmarshalStorageValue parses the value part of the k/v store.
+	UnmarshalObjectStorageValue(valueBytes []byte) error
 }

--- a/objectstorage/storable_object_factory.go
+++ b/objectstorage/storable_object_factory.go
@@ -1,3 +1,0 @@
-package objectstorage
-
-type StorableObjectFactory func(key []byte) StorableObject

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -25,7 +25,9 @@ func init() {
 	testDatabase = database.GetBadgerInstance("objectsdb")
 }
 
-func testObjectFactory(key []byte) objectstorage.StorableObject { return &TestObject{id: key} }
+func testObjectFactory(key []byte) (objectstorage.StorableObject, error) {
+	return &TestObject{id: key}, nil
+}
 
 func TestPrefixIteration(t *testing.T) {
 	objects := objectstorage.New(testDatabase, []byte("TestStoreIfAbsentStorage"), testObjectFactory, objectstorage.PartitionKey(1, 1), objectstorage.LeakDetectionEnabled(true))

--- a/objectstorage/test/test_object.go
+++ b/objectstorage/test/test_object.go
@@ -23,16 +23,16 @@ func NewTestObject(id string, value uint32) *TestObject {
 	}
 }
 
-func (testObject *TestObject) GetStorageKey() []byte {
+func (testObject *TestObject) ObjectStorageKey() []byte {
 	return testObject.id
 }
 
-func (testObject *TestObject) MarshalBinary() ([]byte, error) {
+func (testObject *TestObject) ObjectStorageValue() []byte {
 	result := make([]byte, 4)
 
 	binary.LittleEndian.PutUint32(result, testObject.value)
 
-	return result, nil
+	return result
 }
 
 func (testObject *TestObject) Update(object objectstorage.StorableObject) {
@@ -43,7 +43,7 @@ func (testObject *TestObject) Update(object objectstorage.StorableObject) {
 	}
 }
 
-func (testObject *TestObject) UnmarshalBinary(data []byte) error {
+func (testObject *TestObject) UnmarshalObjectStorageValue(data []byte) error {
 	testObject.value = binary.LittleEndian.Uint32(data)
 
 	return nil
@@ -74,7 +74,7 @@ func (t ThreeLevelObj) Update(object objectstorage.StorableObject) {
 	}
 }
 
-func (t ThreeLevelObj) GetStorageKey() []byte {
+func (t ThreeLevelObj) ObjectStorageKey() []byte {
 	var b bytes.Buffer
 	b.WriteByte(t.id)
 	b.WriteByte(t.id2)
@@ -82,11 +82,11 @@ func (t ThreeLevelObj) GetStorageKey() []byte {
 	return b.Bytes()
 }
 
-func (t ThreeLevelObj) MarshalBinary() (data []byte, err error) {
-	return []byte{t.id3}, nil
+func (t ThreeLevelObj) ObjectStorageValue() []byte {
+	return []byte{t.id3}
 }
 
-func (t ThreeLevelObj) UnmarshalBinary(data []byte) error {
+func (t ThreeLevelObj) UnmarshalObjectStorageValue(data []byte) error {
 	t.id3 = data[0]
 	return nil
 }


### PR DESCRIPTION
Initially, we tried to conform to the builtin MarshalBinary and UnmarshalBinary methods, but it does not make much sense, since SotrableObjects frequently store information in their keys. It therefore makes more sense to introduce custom methods that make it more clear that the unmarshaling happens in a 2 step process.