### PR TITLE
Refactor: Refactor the ObjectStorage parsing methods to return the consumed bytes

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -348,7 +348,7 @@ func (objectStorage *ObjectStorage) ForEach(consumer func(key []byte, cachedObje
 				var storableObject StorableObject
 
 				if objectStorage.options.keysOnly {
-					if storableObject, err = objectStorage.objectFactory(key); err != nil {
+					if storableObject, err, _ = objectStorage.objectFactory(key); err != nil {
 						return
 					}
 				} else {
@@ -716,7 +716,7 @@ func (objectStorage *ObjectStorage) loadObjectFromBadger(key []byte) StorableObj
 		}
 	} else {
 		if objectStorage.options.keysOnly {
-			if object, err := objectStorage.objectFactory(key); err != nil {
+			if object, err, _ := objectStorage.objectFactory(key); err != nil {
 				panic(err)
 			} else {
 				return object
@@ -748,12 +748,12 @@ func (objectStorage *ObjectStorage) objectExistsInBadger(key []byte) bool {
 }
 
 func (objectStorage *ObjectStorage) unmarshalObject(key []byte, data []byte) StorableObject {
-	object, err := objectStorage.objectFactory(key)
+	object, err, _ := objectStorage.objectFactory(key)
 	if err != nil {
 		panic(err)
 	}
 
-	if err = object.UnmarshalObjectStorageValue(data); err != nil {
+	if err, _ = object.UnmarshalObjectStorageValue(data); err != nil {
 		panic(err)
 	}
 
@@ -953,4 +953,4 @@ func (objectStorage *ObjectStorage) forEachCachedElementWithPrefix(consumer Cons
 	return seenElements
 }
 
-type StorableObjectFromKey func(key []byte) (StorableObject, error)
+type StorableObjectFromKey func(key []byte) (result StorableObject, err error, consumedBytes int)

--- a/objectstorage/storable_object.go
+++ b/objectstorage/storable_object.go
@@ -33,5 +33,5 @@ type StorableObject interface {
 	ObjectStorageValue() []byte
 
 	// UnmarshalStorageValue parses the value part of the k/v store.
-	UnmarshalObjectStorageValue(valueBytes []byte) error
+	UnmarshalObjectStorageValue(valueBytes []byte) (err error, consumedBytes int)
 }

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -25,8 +25,8 @@ func init() {
 	testDatabase = database.GetBadgerInstance("objectsdb")
 }
 
-func testObjectFactory(key []byte) (objectstorage.StorableObject, error) {
-	return &TestObject{id: key}, nil
+func testObjectFactory(key []byte) (objectstorage.StorableObject, error, int) {
+	return &TestObject{id: key}, nil, len(key)
 }
 
 func TestPrefixIteration(t *testing.T) {

--- a/objectstorage/test/test_object.go
+++ b/objectstorage/test/test_object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"sync"
 
+	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 )
 
@@ -43,10 +44,10 @@ func (testObject *TestObject) Update(object objectstorage.StorableObject) {
 	}
 }
 
-func (testObject *TestObject) UnmarshalObjectStorageValue(data []byte) error {
+func (testObject *TestObject) UnmarshalObjectStorageValue(data []byte) (err error, consumedBytes int) {
 	testObject.value = binary.LittleEndian.Uint32(data)
 
-	return nil
+	return nil, marshalutil.UINT32_SIZE
 }
 
 // ThreeLevelObj is an object stored on a 3 partition chunked object storage.
@@ -86,7 +87,7 @@ func (t ThreeLevelObj) ObjectStorageValue() []byte {
 	return []byte{t.id3}
 }
 
-func (t ThreeLevelObj) UnmarshalObjectStorageValue(data []byte) error {
+func (t ThreeLevelObj) UnmarshalObjectStorageValue(data []byte) (error, int) {
 	t.id3 = data[0]
-	return nil
+	return nil, len(data)
 }


### PR DESCRIPTION
This PR allows us to use the parsing methods of the object storage to read from a sequence of bytes.