### PR TITLE
Fix leak if cachedObject is empty

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -181,8 +181,8 @@ func (objectStorage *ObjectStorage) DeleteIfPresent(key []byte) bool {
 				return true
 			}
 
-			cachedObject.Release(true)
 		}
+		cachedObject.Release(true)
 
 		return false
 	}
@@ -226,8 +226,8 @@ func (objectStorage *ObjectStorage) Delete(key []byte) {
 				return
 			}
 
-			cachedObject.Release(true)
 		}
+		cachedObject.Release(true)
 	}
 
 	cachedObject, cacheHit := objectStorage.accessCache(key, false)


### PR DESCRIPTION
# Description of change

Object storage leaks if we want to delete a cachedObject that has no stored object.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

We run database pruning in HORNET successfully after that change.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
