### PR TITLE
Add reviewdog golangci-lint action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: reviewdog
+
+on: pull_request
+
+jobs:
+  golangci-lint:
+    name: GolangCI-Lint 
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run golangci-lint
+      uses: docker://reviewdog/action-golangci-lint:latest
+      with:
+        github_token: ${{ secrets.github_token }}
+        golangci_lint_flags: "--timeout=10m"
+        reporter: "github-pr-review"


### PR DESCRIPTION
Use reviewdog to run GoLangCI-Linter and report warnings as PR reviews. Replaces the discontinued GolangCI.com bot.