### PR TITLE
Feat: Use interface for autopeering connection

### DIFF
--- a/autopeering/selection/manager_test.go
+++ b/autopeering/selection/manager_test.go
@@ -155,6 +155,7 @@ func (e *eventMock) outgoingPeering(ev *PeeringEvent) {
 		e.m[ev.Self] = s
 	}
 	assert.NotContains(e.t, s.out, ev.Peer)
+	assert.Less(e.t, len(s.out), 2)
 	s.out[ev.Peer.ID()] = ev.Peer
 }
 
@@ -170,6 +171,7 @@ func (e *eventMock) incomingPeering(ev *PeeringEvent) {
 		e.m[ev.Self] = s
 	}
 	assert.NotContains(e.t, s.in, ev.Peer)
+	assert.Less(e.t, len(s.in), 2)
 	s.in[ev.Peer.ID()] = ev.Peer
 }
 

--- a/autopeering/server/server.go
+++ b/autopeering/server/server.go
@@ -20,10 +20,24 @@ const (
 	ResponseTimeout = 500 * time.Millisecond
 )
 
+// NetConn defines the interface required for a connection.
+type NetConn interface {
+	// Close closes the connection.
+	Close() error
+
+	// LocalAddr returns the local network address.
+	LocalAddr() net.Addr
+
+	// ReadFromUDP acts like ReadFrom but returns a UDPAddr.
+	ReadFromUDP([]byte) (int, *net.UDPAddr, error)
+	// WriteToUDP acts like WriteTo but takes a UDPAddr.
+	WriteToUDP([]byte, *net.UDPAddr) (int, error)
+}
+
 // Server offers the functionality to start a server that handles requests and responses from peers.
 type Server struct {
 	local    *peer.Local
-	conn     *net.UDPConn
+	conn     NetConn
 	handlers []Handler
 	log      *logger.Logger
 	network  string
@@ -68,7 +82,7 @@ type reply struct {
 // Serve starts a new peer server using the given transport layer for communication.
 // Sent data is signed using the identity of the local peer,
 // received data with a valid peer signature is handled according to the provided Handler.
-func Serve(local *peer.Local, conn *net.UDPConn, log *logger.Logger, h ...Handler) *Server {
+func Serve(local *peer.Local, conn NetConn, log *logger.Logger, h ...Handler) *Server {
 	srv := &Server{
 		local:           local,
 		conn:            conn,


### PR DESCRIPTION
Replace `*net.UDPConn` in the autopeering server with an interface only containing the required methods. This greatly simplifies tests and simulations as no full UDPConn is needed.