### PR TITLE
Add ForEachKeyOnly to object storage

### DIFF
--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -62,6 +62,19 @@ func TestPrefixIteration(t *testing.T) {
 
 	expectedKeys["12"] = types.Void
 	expectedKeys["13"] = types.Void
+	objects.ForEachKeyOnly(func(key []byte) bool {
+		if _, elementExists := expectedKeys[string(key)]; !elementExists {
+			t.Error("found an unexpected key")
+		}
+
+		delete(expectedKeys, string(key))
+		return true
+	}, false)
+
+	assert.Equal(t, 0, len(expectedKeys))
+
+	expectedKeys["12"] = types.Void
+	expectedKeys["13"] = types.Void
 	objects.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
 		if _, elementExists := expectedKeys[string(key)]; !elementExists {
 			t.Error("found an unexpected key")


### PR DESCRIPTION
# Description of change

This PR adds a function to iterate over all keys in the object storage.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
