### PR TITLE
Add DeleteEntryFromBadger

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -789,6 +789,21 @@ func (objectStorage *ObjectStorage) LoadObjectFromBadger(key []byte) StorableObj
 	}
 }
 
+// DeleteEntryFromBadger deletes an entry from the persistance layer.
+func (objectStorage *ObjectStorage) DeleteEntryFromBadger(key []byte) {
+	if !objectStorage.options.persistenceEnabled {
+		return
+	}
+
+	if err := objectStorage.badgerInstance.Update(func(txn *badger.Txn) error {
+		return txn.Delete(objectStorage.generatePrefix([][]byte{key}))
+	}); err != nil {
+		if err != badger.ErrKeyNotFound {
+			panic(err)
+		}
+	}
+}
+
 func (objectStorage *ObjectStorage) objectExistsInBadger(key []byte) bool {
 	if !objectStorage.options.persistenceEnabled {
 		return false


### PR DESCRIPTION
# Description of change

This PR adds a function to delete a key directly from the persistence layer without accessing the object storage cache.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
