### PR TITLE
Remove global autopeering events

### DIFF
--- a/autopeering/discover/events.go
+++ b/autopeering/discover/events.go
@@ -6,14 +6,11 @@ import (
 )
 
 // Events contains all the events that are triggered during the peer discovery.
-var Events = struct {
+type Events struct {
 	// A PeerDiscovered event is triggered, when a new peer has been discovered and verified.
 	PeerDiscovered *events.Event
-	// A PeerDeleted event is triggered, when a discovered and verified peer could not be reverified.
+	// A PeerDeleted event is triggered, when a discovered and verified peer could not be re-verified.
 	PeerDeleted *events.Event
-}{
-	PeerDiscovered: events.NewEvent(peerDiscovered),
-	PeerDeleted:    events.NewEvent(peerDeleted),
 }
 
 // DiscoveredEvent bundles the information of the discovered peer.

--- a/autopeering/discover/protocol.go
+++ b/autopeering/discover/protocol.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	maxRetries = 2
-	logSends   = true
+	backoffInterval = 500 * time.Millisecond
+	maxRetries      = 2
+	logSends        = true
 )
 
 //  policy for retrying failed network calls
-var retryPolicy = backoff.ExponentialBackOff(500*time.Millisecond, 1.5).With(
+var retryPolicy = backoff.ExponentialBackOff(backoffInterval, 1.5).With(
 	backoff.Jitter(0.5), backoff.MaxRetries(maxRetries))
 
 // The Protocol handles the peer discovery.
@@ -82,6 +83,11 @@ func (p *Protocol) Close() {
 		p.running.UnSet()
 		p.mgr.close()
 	})
+}
+
+// Events returns all the events that are triggered during the peer discovery.
+func (p *Protocol) Events() Events {
+	return p.mgr.events
 }
 
 // IsVerified checks whether the given peer has recently been verified a recent enough endpoint proof.

--- a/autopeering/selection/events.go
+++ b/autopeering/selection/events.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Events contains all the events that are triggered during the neighbor selection.
-var Events = struct {
+type Events struct {
 	// A SaltUpdated event is triggered, when the private and public salt were updated.
 	SaltUpdated *events.Event
 	// An OutgoingPeering event is triggered, when a valid response of PeeringRequest has been received.
@@ -17,29 +17,21 @@ var Events = struct {
 	IncomingPeering *events.Event
 	// A Dropped event is triggered, when a neighbor is dropped or when a drop message is received.
 	Dropped *events.Event
-}{
-	SaltUpdated:     events.NewEvent(saltUpdatedCaller),
-	OutgoingPeering: events.NewEvent(peeringCaller),
-	IncomingPeering: events.NewEvent(peeringCaller),
-	Dropped:         events.NewEvent(droppedCaller),
 }
 
 // SaltUpdatedEvent bundles the information sent in the SaltUpdated event.
 type SaltUpdatedEvent struct {
-	Self            identity.ID // ID of the peer triggering the event.
-	Public, Private *salt.Salt  // the updated salt
+	Public, Private *salt.Salt // the updated salt
 }
 
 // PeeringEvent bundles the information sent in the OutgoingPeering and IncomingPeering event.
 type PeeringEvent struct {
-	Self   identity.ID // ID of the peer triggering the event.
-	Peer   *peer.Peer  // peering partner
-	Status bool        // true, when the peering partner has accepted the request
+	Peer   *peer.Peer // peering partner
+	Status bool       // true, when the peering partner has accepted the request
 }
 
 // DroppedEvent bundles the information sent in Dropped events.
 type DroppedEvent struct {
-	Self      identity.ID // ID of the peer triggering the event.
 	DroppedID identity.ID // ID of the peer that gets dropped.
 }
 

--- a/autopeering/selection/manager_test.go
+++ b/autopeering/selection/manager_test.go
@@ -34,7 +34,7 @@ func TestMgrNoDuplicates(t *testing.T) {
 	})
 
 	mgrMap := make(map[identity.ID]*manager)
-	runTestNetwork(nNodes, mgrMap)
+	runTestNetwork(nNodes, mgrMap, nil)
 
 	for _, mgr := range mgrMap {
 		assert.NotEmpty(t, mgr.getOutNeighbors())
@@ -56,10 +56,9 @@ func TestEvents(t *testing.T) {
 		OutboundUpdateInterval: testUpdateInterval,
 	})
 
-	e, teardown := newEventMock(t)
-	defer teardown()
+	e := newEventNetwork(t)
 	mgrMap := make(map[identity.ID]*manager)
-	runTestNetwork(nNodes, mgrMap)
+	runTestNetwork(nNodes, mgrMap, e.attach)
 
 	// the events should lead to exactly the same neighbors
 	for _, mgr := range mgrMap {
@@ -79,9 +78,12 @@ func getValues(m map[identity.ID]*peer.Peer) []*peer.Peer {
 	return result
 }
 
-func runTestNetwork(n int, mgrMap map[identity.ID]*manager) {
+func runTestNetwork(n int, mgrMap map[identity.ID]*manager, hook func(*manager)) {
 	for i := 0; i < n; i++ {
-		_ = newTestManager(fmt.Sprintf("%d", i), mgrMap)
+		mgr := newTestManager(fmt.Sprintf("%d", i), mgrMap)
+		if hook != nil {
+			hook(mgr)
+		}
 	}
 	for _, mgr := range mgrMap {
 		mgr.start()
@@ -115,71 +117,64 @@ type neighbors struct {
 	out, in map[identity.ID]*peer.Peer
 }
 
-type eventMock struct {
-	t    *testing.T
-	lock sync.Mutex
-	m    map[identity.ID]neighbors
+// eventNetwork reconstructs the neighbors for the triggered events
+type eventNetwork struct {
+	sync.Mutex
+	t *testing.T
+	m map[identity.ID]neighbors
 }
 
-func newEventMock(t *testing.T) (*eventMock, func()) {
-	e := &eventMock{
+func newEventNetwork(t *testing.T) *eventNetwork {
+	return &eventNetwork{
 		t: t,
 		m: make(map[identity.ID]neighbors),
 	}
-
-	outgoingPeeringC := events.NewClosure(e.outgoingPeering)
-	incomingPeeringC := events.NewClosure(e.incomingPeering)
-	droppedC := events.NewClosure(e.dropped)
-
-	Events.OutgoingPeering.Attach(outgoingPeeringC)
-	Events.IncomingPeering.Attach(incomingPeeringC)
-	Events.Dropped.Attach(droppedC)
-
-	teardown := func() {
-		Events.OutgoingPeering.Detach(outgoingPeeringC)
-		Events.IncomingPeering.Detach(incomingPeeringC)
-		Events.Dropped.Detach(droppedC)
-	}
-	return e, teardown
 }
 
-func (e *eventMock) outgoingPeering(ev *PeeringEvent) {
+func (e *eventNetwork) attach(mgr *manager) {
+	id := mgr.getID()
+	mgr.events.OutgoingPeering.Attach(events.NewClosure(func(ev *PeeringEvent) { e.outgoingPeering(id, ev) }))
+	mgr.events.IncomingPeering.Attach(events.NewClosure(func(ev *PeeringEvent) { e.incomingPeering(id, ev) }))
+	mgr.events.Dropped.Attach(events.NewClosure(func(ev *DroppedEvent) { e.dropped(id, ev) }))
+}
+
+func (e *eventNetwork) outgoingPeering(id identity.ID, ev *PeeringEvent) {
 	if !ev.Status {
 		return
 	}
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	s, ok := e.m[ev.Self]
+	e.Lock()
+	defer e.Unlock()
+	s, ok := e.m[id]
 	if !ok {
 		s = neighbors{out: make(map[identity.ID]*peer.Peer), in: make(map[identity.ID]*peer.Peer)}
-		e.m[ev.Self] = s
+		e.m[id] = s
 	}
 	assert.NotContains(e.t, s.out, ev.Peer)
 	assert.Less(e.t, len(s.out), 2)
 	s.out[ev.Peer.ID()] = ev.Peer
 }
 
-func (e *eventMock) incomingPeering(ev *PeeringEvent) {
+func (e *eventNetwork) incomingPeering(id identity.ID, ev *PeeringEvent) {
 	if !ev.Status {
 		return
 	}
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	s, ok := e.m[ev.Self]
+	e.Lock()
+	defer e.Unlock()
+	s, ok := e.m[id]
 	if !ok {
 		s = neighbors{out: make(map[identity.ID]*peer.Peer), in: make(map[identity.ID]*peer.Peer)}
-		e.m[ev.Self] = s
+		e.m[id] = s
 	}
 	assert.NotContains(e.t, s.in, ev.Peer)
 	assert.Less(e.t, len(s.in), 2)
 	s.in[ev.Peer.ID()] = ev.Peer
 }
 
-func (e *eventMock) dropped(ev *DroppedEvent) {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-	if assert.Contains(e.t, e.m, ev.Self) {
-		s := e.m[ev.Self]
+func (e *eventNetwork) dropped(id identity.ID, ev *DroppedEvent) {
+	e.Lock()
+	defer e.Unlock()
+	if assert.Contains(e.t, e.m, id) {
+		s := e.m[id]
 		delete(s.out, ev.DroppedID)
 		delete(s.in, ev.DroppedID)
 	}

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -90,6 +90,11 @@ func (p *Protocol) Close() {
 	})
 }
 
+// Events returns all the events that are triggered during the neighbor selection.
+func (p *Protocol) Events() Events {
+	return p.mgr.events
+}
+
 // GetNeighbors returns the current neighbors.
 func (p *Protocol) GetNeighbors() []*peer.Peer {
 	return p.mgr.getNeighbors()


### PR DESCRIPTION
Remove the global `Events` variable of the `autopeering` package and make it part of the `manager` struct.