### PR TITLE
Add DeleteEntriesFromBadger

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -804,6 +804,26 @@ func (objectStorage *ObjectStorage) DeleteEntryFromBadger(key []byte) {
 	}
 }
 
+// DeleteEntriesFromBadger deletes entries from the persistance layer.
+func (objectStorage *ObjectStorage) DeleteEntriesFromBadger(keys [][]byte) {
+	if !objectStorage.options.persistenceEnabled {
+		return
+	}
+
+	wb := objectStorage.badgerInstance.NewWriteBatch()
+	for _, key := range keys {
+		if err := wb.Delete(objectStorage.generatePrefix([][]byte{key})); err != nil {
+			if err != badger.ErrKeyNotFound {
+				panic(err)
+			}
+		}
+	}
+
+	if err := wb.Flush(); err != nil {
+		panic(err)
+	}
+}
+
 func (objectStorage *ObjectStorage) objectExistsInBadger(key []byte) bool {
 	if !objectStorage.options.persistenceEnabled {
 		return false


### PR DESCRIPTION
# Description of change

This PR adds a function to batch delete keys directly from the persistence layer without accessing the object storage cache.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
