### PR TITLE
Load logger config from Viper one by one

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -3,8 +3,6 @@ package logger
 import "go.uber.org/zap/zapcore"
 
 const (
-	// ViperKey defines the key name under which the logger config is stored.
-	ViperKey                  = "logger"
 	ViperKeyLevel             = "logger.level"
 	ViperKeyDisableCaller     = "logger.disableCaller"
 	ViperKeyDisableStacktrace = "logger.disableStacktrace"

--- a/logger/config.go
+++ b/logger/config.go
@@ -2,8 +2,16 @@ package logger
 
 import "go.uber.org/zap/zapcore"
 
-// ViperKey defines the key name under which the logger config is stored.
-const ViperKey = "logger"
+const (
+	// ViperKey defines the key name under which the logger config is stored.
+	ViperKey                  = "logger"
+	ViperKeyLevel             = "logger.level"
+	ViperKeyDisableCaller     = "logger.disableCaller"
+	ViperKeyDisableStacktrace = "logger.disableStacktrace"
+	ViperKeyEncoding          = "logger.encoding"
+	ViperKeyOutputPaths       = "logger.outputPaths"
+	ViperKeyDisableEvents     = "logger.disableEvents"
+)
 
 // Config holds the settings to configure a root logger instance.
 type Config struct {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -67,10 +67,28 @@ func InitGlobalLogger(config *viper.Viper) error {
 // NewRootLoggerFromViper creates a new root logger from the provided viper configuration.
 func NewRootLoggerFromViper(config *viper.Viper, levelOverride ...zap.AtomicLevel) (*Logger, error) {
 	cfg := defaultCfg
-	err := config.UnmarshalKey(ViperKey, &cfg)
-	if err != nil {
-		return nil, err
+
+	// get config from Viper one by one
+	// config.UnmarshalKey does not recognize a configuration group when defined with pflags
+	if val := config.GetString(ViperKeyLevel); val != "" {
+		cfg.Level = val
 	}
+	if val := config.Get(ViperKeyDisableCaller); val != nil {
+		cfg.DisableCaller = val.(bool)
+	}
+	if val := config.Get(ViperKeyDisableStacktrace); val != nil {
+		cfg.DisableStacktrace = val.(bool)
+	}
+	if val := config.GetString(ViperKeyEncoding); val != "" {
+		cfg.Encoding = val
+	}
+	if val := config.GetStringSlice(ViperKeyOutputPaths); len(val) > 0 {
+		cfg.OutputPaths = val
+	}
+	if val := config.Get(ViperKeyDisableEvents); val != nil {
+		cfg.DisableEvents = val.(bool)
+	}
+
 	return NewRootLogger(cfg, levelOverride...)
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -122,7 +122,12 @@ func TestInitGlobalAfterError(t *testing.T) {
 	cfg.Level = "invalid"
 
 	v := viper.New()
-	v.Set(ViperKey, cfg)
+	v.Set(ViperKeyLevel, cfg.Level)
+	v.Set(ViperKeyDisableCaller, cfg.DisableCaller)
+	v.Set(ViperKeyDisableStacktrace, cfg.DisableStacktrace)
+	v.Set(ViperKeyEncoding, cfg.Encoding)
+	v.Set(ViperKeyOutputPaths, cfg.OutputPaths)
+	v.Set(ViperKeyDisableEvents, cfg.DisableEvents)
 	require.Error(t, InitGlobalLogger(v))
 
 	initGlobal(t, defaultCfg)()
@@ -130,7 +135,12 @@ func TestInitGlobalAfterError(t *testing.T) {
 
 func TestInitGlobalTwice(t *testing.T) {
 	v := viper.New()
-	v.Set(ViperKey, defaultCfg)
+	v.Set(ViperKeyLevel, defaultCfg.Level)
+	v.Set(ViperKeyDisableCaller, defaultCfg.DisableCaller)
+	v.Set(ViperKeyDisableStacktrace, defaultCfg.DisableStacktrace)
+	v.Set(ViperKeyEncoding, defaultCfg.Encoding)
+	v.Set(ViperKeyOutputPaths, defaultCfg.OutputPaths)
+	v.Set(ViperKeyDisableEvents, defaultCfg.DisableEvents)
 
 	require.NoError(t, InitGlobalLogger(v))
 	assert.Errorf(t, InitGlobalLogger(v), ErrGlobalLoggerAlreadyInitialized.Error())
@@ -139,7 +149,12 @@ func TestInitGlobalTwice(t *testing.T) {
 func initGlobal(t require.TestingT, cfg Config) func() {
 	// load into viper
 	v := viper.New()
-	v.Set(ViperKey, cfg)
+	v.Set(ViperKeyLevel, cfg.Level)
+	v.Set(ViperKeyDisableCaller, cfg.DisableCaller)
+	v.Set(ViperKeyDisableStacktrace, cfg.DisableStacktrace)
+	v.Set(ViperKeyEncoding, cfg.Encoding)
+	v.Set(ViperKeyOutputPaths, cfg.OutputPaths)
+	v.Set(ViperKeyDisableEvents, cfg.DisableEvents)
 
 	err := InitGlobalLogger(v)
 	require.NoError(t, err, "Failed to init global logger.")


### PR DESCRIPTION
# Description of change
Viper.UnmarshalKey does not recognize a configuration group when defined with pflags therefore read logger config manually one by one

## Type of change
- Bug fix