### PR TITLE
Use KeyCopy instead of Key because the slices are reused

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -201,7 +201,7 @@ func (pdb *prefixDb) ForEach(consumer func(Entry) bool) error {
 			}
 
 			if consumer(Entry{
-				Key:   pdb.keyWithoutPrefix(item.Key()),
+				Key:   pdb.keyWithoutPrefix(item.KeyCopy(nil)),
 				Value: value,
 				Meta:  meta,
 			}) {
@@ -230,7 +230,7 @@ func (pdb *prefixDb) ForEachPrefix(keyPrefix KeyPrefix, consumer func(Entry) boo
 			}
 
 			if consumer(Entry{
-				Key:   pdb.keyWithoutPrefix(item.Key()).keyWithoutKeyPrefix(keyPrefix),
+				Key:   pdb.keyWithoutPrefix(item.KeyCopy(nil)).keyWithoutKeyPrefix(keyPrefix),
 				Value: value,
 				Meta:  meta,
 			}) {
@@ -255,7 +255,7 @@ func (pdb *prefixDb) ForEachPrefixKeyOnly(keyPrefix KeyPrefix, consumer func(Key
 			meta := item.UserMeta()
 
 			if consumer(KeyOnlyEntry{
-				Key:  pdb.keyWithoutPrefix(item.Key()).keyWithoutKeyPrefix(keyPrefix),
+				Key:  pdb.keyWithoutPrefix(item.KeyCopy(nil)).keyWithoutKeyPrefix(keyPrefix),
 				Meta: meta,
 			}) {
 				break

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -337,7 +337,7 @@ func (objectStorage *ObjectStorage) ForEach(consumer func(key []byte, cachedObje
 		it := txn.NewIterator(iteratorOptions)
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
-			key := item.Key()[len(objectStorage.storageId):]
+			key := item.KeyCopy(nil)[len(objectStorage.storageId):]
 
 			if _, elementSeen := seenElements[typeutils.BytesToString(key)]; elementSeen {
 				continue
@@ -427,7 +427,7 @@ func (objectStorage *ObjectStorage) ForEachKeyOnly(consumer func(key []byte) boo
 		it := txn.NewIterator(iteratorOptions)
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
-			key := item.Key()[len(objectStorage.storageId):]
+			key := item.KeyCopy(nil)[len(objectStorage.storageId):]
 
 			if _, elementSeen := seenElements[typeutils.BytesToString(key)]; elementSeen {
 				continue

--- a/objectstorage/test/test_object.go
+++ b/objectstorage/test/test_object.go
@@ -31,8 +31,10 @@ func (testObject *TestObject) ObjectStorageKey() []byte {
 func (testObject *TestObject) ObjectStorageValue() []byte {
 	result := make([]byte, 4)
 
-	binary.LittleEndian.PutUint32(result, testObject.value)
+	testObject.Lock()
+	defer testObject.Unlock()
 
+	binary.LittleEndian.PutUint32(result, testObject.value)
 	return result
 }
 
@@ -40,13 +42,18 @@ func (testObject *TestObject) Update(object objectstorage.StorableObject) {
 	if obj, ok := object.(*TestObject); !ok {
 		panic("invalid object passed to testObject.Update()")
 	} else {
+		testObject.Lock()
+		defer testObject.Unlock()
+
 		testObject.value = obj.value
 	}
 }
 
 func (testObject *TestObject) UnmarshalObjectStorageValue(data []byte) (consumedBytes int, err error) {
-	testObject.value = binary.LittleEndian.Uint32(data)
+	testObject.Lock()
+	defer testObject.Unlock()
 
+	testObject.value = binary.LittleEndian.Uint32(data)
 	return marshalutil.UINT32_SIZE, nil
 }
 

--- a/objectstorage/test/test_object.go
+++ b/objectstorage/test/test_object.go
@@ -57,6 +57,18 @@ func (testObject *TestObject) UnmarshalObjectStorageValue(data []byte) (consumed
 	return marshalutil.UINT32_SIZE, nil
 }
 
+func (testObject *TestObject) get() uint32 {
+	testObject.Lock()
+	defer testObject.Unlock()
+	return testObject.value
+}
+
+func (testObject *TestObject) set(v uint32) {
+	testObject.Lock()
+	defer testObject.Unlock()
+	testObject.value = v
+}
+
 // ThreeLevelObj is an object stored on a 3 partition chunked object storage.
 // ID3 corresponds to ThreeLevelObj's value.
 type ThreeLevelObj struct {


### PR DESCRIPTION
# Description of change

This PR uses badger's KeyCopy function instead of Key, because the key slice is reused in the seenElements map or highly likely in the consumer function.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
