### PR TITLE
Refactor daemon shutdown

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -222,7 +222,10 @@ func (d *OrderedDaemon) waitGroupForLastPriority() *sync.WaitGroup {
 }
 
 func (d *OrderedDaemon) shutdown() {
-	d.stopped.Set()
+	// prevent attempting to shutdown twice
+	if !d.stopped.SetToIf(false, true) {
+		return
+	}
 	if !d.IsRunning() {
 		return
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -147,6 +147,7 @@ func TestShutdownTwice(t *testing.T) {
 	d.Shutdown()
 	time.Sleep(graceTime)
 	d.ShutdownAndWait()
+	assert.False(t, d.IsRunning())
 }
 
 func TestReRun(t *testing.T) {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -131,6 +131,24 @@ func TestGetRunningBackgroundWorkers(t *testing.T) {
 	close(blocker)
 }
 
+func TestShutdownTwice(t *testing.T) {
+	d := daemon.New()
+
+	err := d.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
+		<-shutdownSignal
+		// sleep longer than the grace time before shutting down
+		time.Sleep(2 * graceTime)
+	})
+	require.NoError(t, err)
+
+	d.Start()
+	time.Sleep(graceTime)
+
+	d.Shutdown()
+	time.Sleep(graceTime)
+	d.ShutdownAndWait()
+}
+
 func TestReRun(t *testing.T) {
 	d := daemon.New()
 

--- a/syncutils/mutex.go
+++ b/syncutils/mutex.go
@@ -8,3 +8,4 @@ import (
 
 type Mutex = sync.Mutex
 type RWMutex = sync.RWMutex
+type Once = sync.Once


### PR DESCRIPTION
# Description of change
`shutdown()` locked the daemon and blocked reporting the running background processes, hence the node didn't have info on which processes are hanging.

This change introduces `RWMutex` instead of `Mutex` as lock in daemon. A read lock is used in 
`GetRunningBackGroundWorkers()`. `shutdown()` is separated into two stages (while preserving the original logic) so that they can use `Rlock()` and `Lock()` for shutting down workers and clearing the daemon respectively.
## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran with GoShimmer, shutdown is properly carried out. By manually inserting delays between shutting down the workers, the node reports which background workers are still running.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
