### PR TITLE
Add dontDrop to BroadcastMsg

### DIFF
--- a/websockethub/hub.go
+++ b/websockethub/hub.go
@@ -11,47 +11,73 @@ import (
 // Hub maintains the set of active clients and broadcasts messages to the clients.
 type Hub struct {
 
-	// Websocket Upgrader.
+	// websocket Upgrader.
 	upgrader *websocket.Upgrader
 
-	// Used Logger instance.
+	// used Logger instance.
 	logger *logger.Logger
 
-	// Registered clients.
+	// registered clients.
 	clients map[*Client]struct{}
 
-	// Inbound messages from the clients.
-	broadcast chan interface{}
+	// maximum size of queued messages that should be sent to the peer.
+	clientSendChannelSize int
 
-	// Register requests from the clients.
+	// inbound messages from the clients.
+	broadcast chan *message
+
+	// register requests from the clients.
 	register chan *Client
 
-	// Unregister requests from clients.
+	// unregister requests from clients.
 	unregister chan *Client
 
 	shutdownSignal <-chan struct{}
 }
 
-func NewHub(logger *logger.Logger, upgrader *websocket.Upgrader, broadcastQueueSize int) *Hub {
+// message is a message that is sent to the broadcast channel.
+type message struct {
+	data     interface{}
+	dontDrop bool
+}
+
+func NewHub(logger *logger.Logger, upgrader *websocket.Upgrader, broadcastQueueSize int, clientSendChannelSize int) *Hub {
 	return &Hub{
-		logger:     logger,
-		upgrader:   upgrader,
-		clients:    make(map[*Client]struct{}),
-		broadcast:  make(chan interface{}, broadcastQueueSize),
-		register:   make(chan *Client),
-		unregister: make(chan *Client),
+		logger:                logger,
+		upgrader:              upgrader,
+		clientSendChannelSize: clientSendChannelSize,
+		clients:               make(map[*Client]struct{}),
+		broadcast:             make(chan *message, broadcastQueueSize),
+		register:              make(chan *Client),
+		unregister:            make(chan *Client),
 	}
 }
 
-// BroadcastMsg sends a message to all clients
-func (h *Hub) BroadcastMsg(msg interface{}) {
+// BroadcastMsg sends a message to all clients.
+func (h *Hub) BroadcastMsg(data interface{}, dontDrop ...bool) {
+	notDrop := false
+	if len(dontDrop) > 0 {
+		notDrop = dontDrop[0]
+	}
+
+	msg := &message{data: data, dontDrop: notDrop}
+
+	if notDrop {
+		select {
+		case <-h.shutdownSignal:
+		case h.broadcast <- msg:
+		}
+		return
+	}
+
 	select {
+	case <-h.shutdownSignal:
 	case h.broadcast <- msg:
 	default:
 	}
 }
 
-// Start the hub
+// Run starts the hub.
 func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 
 	for {
@@ -59,6 +85,7 @@ func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 		case <-shutdownSignal:
 			for client := range h.clients {
 				delete(h.clients, client)
+				close(client.exitSignal)
 				close(client.sendChan)
 			}
 			return
@@ -70,14 +97,27 @@ func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
+				close(client.exitSignal)
 				close(client.sendChan)
 				h.logger.Infof("Removed websocket client")
 			}
 
 		case message := <-h.broadcast:
+			if message.dontDrop {
+				for client := range h.clients {
+					select {
+					case <-shutdownSignal:
+					case <-client.exitSignal:
+					case client.sendChan <- message.data:
+					}
+				}
+				continue
+			}
 			for client := range h.clients {
 				select {
-				case client.sendChan <- message:
+				case <-shutdownSignal:
+				case <-client.exitSignal:
+				case client.sendChan <- message.data:
 				default:
 				}
 			}
@@ -87,14 +127,25 @@ func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 
 // ServeWebsocket handles websocket requests from the peer.
 func (h *Hub) ServeWebsocket(w http.ResponseWriter, r *http.Request, onConnect ...func(client *Client)) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Errorf("recovered from ServeWebsocket func: %s", r)
+		}
+	}()
 
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		h.logger.Warnf("Upgrade websocket: %v", err)
+		h.logger.Warnf("upgrade websocket error: %v", err)
 		return
 	}
+	conn.EnableWriteCompression(true)
 
-	client := &Client{hub: h, conn: conn, sendChan: make(chan interface{}, sendChannelSize)}
+	client := &Client{
+		hub:        h,
+		conn:       conn,
+		exitSignal: make(chan struct{}),
+		sendChan:   make(chan interface{}, h.clientSendChannelSize),
+	}
 	h.register <- client
 
 	go client.checkPong()


### PR DESCRIPTION
# Description of change

This PR adds the "dontDrop" variadic parameter to BroadcastMsg.
This way messages won't get lost if the client is too slow.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [X My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
