### PR TITLE
TLV Message Protocol

### DIFF
--- a/protocol/message/message.go
+++ b/protocol/message/message.go
@@ -7,26 +7,26 @@ import (
 var (
 	// ErrTypeAlreadyDefined is returned when an already defined message type is redefined.
 	ErrTypeAlreadyDefined = errors.New("message type is already defined")
-	// ErrUnknownType is returned when a definition for an unknown message type is is requested.
+	// ErrUnknownType is returned when a definition for an unknown message type is requested.
 	ErrUnknownType = errors.New("message type unknown")
 )
 
 // Type denotes the byte ID of a given message type.
 type Type byte
 
-// Definition describes a message's ID and its max byte length (and whether the length variable).
+// Definition describes a message's ID, its max byte length and whether its size can be variable.
 type Definition struct {
 	ID             Type
 	MaxBytesLength uint16
 	VariableLength bool
 }
 
-// Registry holds message definitions
+// Registry holds message definitions.
 type Registry struct {
 	definitions []*Definition
 }
 
-// NewRegistry create an empty message registry
+// NewRegistry create an empty message registry.
 func NewRegistry() *Registry {
 	return &Registry{definitions: make([]*Definition, 0)}
 }

--- a/protocol/message/message.go
+++ b/protocol/message/message.go
@@ -1,0 +1,62 @@
+package message
+
+import (
+	"errors"
+)
+
+var (
+	// ErrTypeAlreadyDefined is returned when an already defined message type is redefined.
+	ErrTypeAlreadyDefined = errors.New("message type is already defined")
+	// ErrUnknownType is returned when a definition for an unknown message type is is requested.
+	ErrUnknownType = errors.New("message type unknown")
+)
+
+// Type denotes the byte ID of a given message type.
+type Type byte
+
+// Definition describes a message's ID and its max byte length (and whether the length variable).
+type Definition struct {
+	ID             Type
+	MaxBytesLength uint16
+	VariableLength bool
+}
+
+// TODO: make definitions a struct so that we can have multiple instances
+var definitions = make([]*Definition, 0)
+
+// Definitions returns all registered message definitions.
+func Definitions() []*Definition {
+	return definitions
+}
+
+// RegisterType registers the given message type with its definition.
+func RegisterType(msgType Type, def *Definition) error {
+	// grow definitions slice appropriately
+	if len(definitions)-1 < int(msgType) {
+		definitionsCopy := make([]*Definition, int(msgType)+1)
+		copy(definitionsCopy, definitions)
+		definitions = definitionsCopy
+	}
+	if definitions[msgType] != nil {
+		return ErrTypeAlreadyDefined
+	}
+	definitions[msgType] = def
+	return nil
+}
+
+// DefinitionForType returns the definition for the given message type.
+func DefinitionForType(msgType Type) (*Definition, error) {
+	if len(definitions)-1 < int(msgType) {
+		return nil, ErrUnknownType
+	}
+	def := definitions[msgType]
+	if def == nil {
+		return nil, ErrUnknownType
+	}
+	return def, nil
+}
+
+// ClearDefinitions clears out the definitions registry
+func ClearDefinitions() {
+	definitions = make([]*Definition, 0)
+}

--- a/protocol/message/message.go
+++ b/protocol/message/message.go
@@ -62,7 +62,7 @@ func (r *Registry) DefinitionForType(msgType Type) (*Definition, error) {
 	return def, nil
 }
 
-// ClearDefinitions clears out the definitions registry
-func (r *Registry) ClearDefinitions() {
+// Clear clears definitions of the registry
+func (r *Registry) Clear() {
 	r.definitions = make([]*Definition, 0)
 }

--- a/protocol/message/message.go
+++ b/protocol/message/message.go
@@ -21,35 +21,41 @@ type Definition struct {
 	VariableLength bool
 }
 
-// TODO: make definitions a struct so that we can have multiple instances
-var definitions = make([]*Definition, 0)
+type Registry struct {
+	definitions []*Definition
+}
+
+// NewRegistry create an empty message registry
+func NewRegistry() *Registry {
+	return &Registry{definitions: make([]*Definition, 0)}
+}
 
 // Definitions returns all registered message definitions.
-func Definitions() []*Definition {
-	return definitions
+func (r *Registry) Definitions() []*Definition {
+	return r.definitions
 }
 
 // RegisterType registers the given message type with its definition.
-func RegisterType(msgType Type, def *Definition) error {
+func (r *Registry) RegisterType(msgType Type, def *Definition) error {
 	// grow definitions slice appropriately
-	if len(definitions)-1 < int(msgType) {
+	if len(r.definitions)-1 < int(msgType) {
 		definitionsCopy := make([]*Definition, int(msgType)+1)
-		copy(definitionsCopy, definitions)
-		definitions = definitionsCopy
+		copy(definitionsCopy, r.definitions)
+		r.definitions = definitionsCopy
 	}
-	if definitions[msgType] != nil {
+	if r.definitions[msgType] != nil {
 		return ErrTypeAlreadyDefined
 	}
-	definitions[msgType] = def
+	r.definitions[msgType] = def
 	return nil
 }
 
 // DefinitionForType returns the definition for the given message type.
-func DefinitionForType(msgType Type) (*Definition, error) {
-	if len(definitions)-1 < int(msgType) {
+func (r *Registry) DefinitionForType(msgType Type) (*Definition, error) {
+	if len(r.definitions)-1 < int(msgType) {
 		return nil, ErrUnknownType
 	}
-	def := definitions[msgType]
+	def := r.definitions[msgType]
 	if def == nil {
 		return nil, ErrUnknownType
 	}
@@ -57,6 +63,6 @@ func DefinitionForType(msgType Type) (*Definition, error) {
 }
 
 // ClearDefinitions clears out the definitions registry
-func ClearDefinitions() {
-	definitions = make([]*Definition, 0)
+func (r *Registry) ClearDefinitions() {
+	r.definitions = make([]*Definition, 0)
 }

--- a/protocol/message/message.go
+++ b/protocol/message/message.go
@@ -21,6 +21,7 @@ type Definition struct {
 	VariableLength bool
 }
 
+// Registry holds message definitions
 type Registry struct {
 	definitions []*Definition
 }

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -9,79 +9,52 @@ import (
 
 // message definition for testing
 var (
-	DummyMessageType         message.Type = 0
-	DummyMessageDefinition = &message.Definition{
+	DummyMessageType       message.Type = 0
+	DummyMessageDefinition              = &message.Definition{
 		ID:             DummyMessageType,
 		MaxBytesLength: 10,
 		VariableLength: false,
 	}
 )
 
-func TestMessage_Register(t *testing.T) {
-	r := message.NewRegistry()
-	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
-	assert.NoError(t, err)
-
+func TestMessage_NewRegistry(t *testing.T) {
+	r := message.NewRegistry([]*message.Definition{DummyMessageDefinition})
 	definitions := r.Definitions()
 	assert.Equal(t, definitions[0], DummyMessageDefinition)
-}
 
-func TestMessage_RegisterTypeAlready(t *testing.T) {
-	r := message.NewRegistry()
-	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
-	assert.NoError(t, err)
-	err = r.RegisterType(DummyMessageType, DummyMessageDefinition)
-	if assert.Error(t, err) {
-		assert.Equal(t, message.ErrTypeAlreadyDefined, err)
-	}
-}
-
-func TestMessage_DefinitionForType(t *testing.T) {
-	r := message.NewRegistry()
-	// registry is empty, len(definitions) = 0
-	_, err := r.DefinitionForType(DummyMessageType)
-	if assert.Error(t, err) {
-		assert.Equal(t, message.ErrUnknownType, err)
-	}
-
-	// happy path
-	err = r.RegisterType(DummyMessageType, DummyMessageDefinition)
-	assert.NoError(t, err)
-
-	var def *message.Definition
-	def, err = r.DefinitionForType(DummyMessageType)
-	assert.NoError(t, err)
-	assert.Equal(t, DummyMessageDefinition, def)
-}
-
-func TestMessage_DefinitionForTypeBig(t *testing.T) {
-	r := message.NewRegistry()
-	// register a message with big type number
-	var BigMessageType message.Type = 5
-	var BigMessageDefinition = &message.Definition{
-		ID:             BigMessageType,
+	// start with msg type 1 instead of 0
+	DummyMessageDefinition1 := &message.Definition{
+		ID:             1,
 		MaxBytesLength: 10,
 		VariableLength: false,
 	}
-	// grows definitions to size of the message type (5)
-	err := r.RegisterType(BigMessageType, BigMessageDefinition)
-	assert.NoError(t, err)
-	// Dummy was not registered
-	_, err = r.DefinitionForType(DummyMessageType)
-	if assert.Error(t, err) {
-		assert.Equal(t, message.ErrUnknownType, err)
+	assert.Panics(t, func() {
+		r = message.NewRegistry([]*message.Definition{DummyMessageDefinition1})
+	})
+
+	// skip one index
+	DummyMessageDefinition3 := &message.Definition{
+		ID:             3,
+		MaxBytesLength: 10,
+		VariableLength: false,
 	}
+	assert.Panics(t, func() {
+		r = message.NewRegistry([]*message.Definition{
+			DummyMessageDefinition,
+			DummyMessageDefinition1,
+			DummyMessageDefinition3,
+		})
+	})
+
+	// try to init with empty
+	assert.Panics(t, func() {
+		r = message.NewRegistry([]*message.Definition{})
+	})
 }
 
-func TestMessage_Clear(t *testing.T) {
-	r := message.NewRegistry()
-	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
+func TestMessage_DefinitionForType(t *testing.T) {
+	r := message.NewRegistry([]*message.Definition{DummyMessageDefinition})
+	def, err := r.DefinitionForType(DummyMessageType)
 	assert.NoError(t, err)
-
-	definitions := r.Definitions()
-	assert.Equal(t, definitions[0], DummyMessageDefinition)
-
-	r.Clear()
-	definitions = r.Definitions()
-	assert.Equal(t, 0, len(definitions))
+	assert.Equal(t, DummyMessageDefinition, def)
 }

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -1,0 +1,73 @@
+package message_test
+
+import(
+	"testing"
+
+	"github.com/iotaledger/hive.go/protocol/message"
+	"github.com/stretchr/testify/assert"
+)
+
+// message definition for testing
+var DummyMessageType message.Type = 0
+var DummyMessageDefinition = &message.Definition{
+	ID:             DummyMessageType,
+	MaxBytesLength: 10,
+	VariableLength: false,
+}
+
+func TestMessage_Register(t *testing.T) {
+	err := message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	assert.NoError(t, err)
+
+	definitions := message.Definitions()
+	assert.Equal(t, definitions[0], DummyMessageDefinition)
+	message.ClearDefinitions()
+}
+
+func TestMessage_RegisterTypeAlready(t *testing.T) {
+	err := message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	assert.NoError(t, err)
+	err = message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	if assert.Error(t, err) {
+		assert.Equal(t, message.ErrTypeAlreadyDefined, err)
+	}
+	message.ClearDefinitions()
+}
+
+func TestMessage_DefinitionForType(t *testing.T) {
+	// registry is empty, len(definitions) = 0
+	_, err := message.DefinitionForType(DummyMessageType)
+	if assert.Error(t, err) {
+		assert.Equal(t, message.ErrUnknownType, err)
+	}
+
+	// happy path
+	err = message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	assert.NoError(t, err)
+
+	var def *message.Definition
+	def, err = message.DefinitionForType(DummyMessageType)
+	assert.NoError(t, err)
+	assert.Equal(t, DummyMessageDefinition, def)
+	message.ClearDefinitions()
+
+}
+
+func TestMessage_DefinitionForTypeBig(t *testing.T) {
+	// register a message with big type number
+	var BigMessageType message.Type = 5
+	var BigMessageDefinition = &message.Definition{
+		ID:             BigMessageType,
+		MaxBytesLength: 10,
+		VariableLength: false,
+	}
+	// grows definitions to size of the message type (5)
+	err := message.RegisterType(BigMessageType, BigMessageDefinition)
+	assert.NoError(t, err)
+	// Dummy was not registered
+	_, err = message.DefinitionForType(DummyMessageType)
+	if assert.Error(t, err) {
+		assert.Equal(t, message.ErrUnknownType, err)
+	}
+	message.ClearDefinitions()
+}

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -16,44 +16,45 @@ var DummyMessageDefinition = &message.Definition{
 }
 
 func TestMessage_Register(t *testing.T) {
-	err := message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	r := message.NewRegistry()
+	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
 	assert.NoError(t, err)
 
-	definitions := message.Definitions()
+	definitions := r.Definitions()
 	assert.Equal(t, definitions[0], DummyMessageDefinition)
-	message.ClearDefinitions()
+	r.ClearDefinitions()
 }
 
 func TestMessage_RegisterTypeAlready(t *testing.T) {
-	err := message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	r := message.NewRegistry()
+	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
 	assert.NoError(t, err)
-	err = message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	err = r.RegisterType(DummyMessageType, DummyMessageDefinition)
 	if assert.Error(t, err) {
 		assert.Equal(t, message.ErrTypeAlreadyDefined, err)
 	}
-	message.ClearDefinitions()
 }
 
 func TestMessage_DefinitionForType(t *testing.T) {
+	r := message.NewRegistry()
 	// registry is empty, len(definitions) = 0
-	_, err := message.DefinitionForType(DummyMessageType)
+	_, err := r.DefinitionForType(DummyMessageType)
 	if assert.Error(t, err) {
 		assert.Equal(t, message.ErrUnknownType, err)
 	}
 
 	// happy path
-	err = message.RegisterType(DummyMessageType, DummyMessageDefinition)
+	err = r.RegisterType(DummyMessageType, DummyMessageDefinition)
 	assert.NoError(t, err)
 
 	var def *message.Definition
-	def, err = message.DefinitionForType(DummyMessageType)
+	def, err = r.DefinitionForType(DummyMessageType)
 	assert.NoError(t, err)
 	assert.Equal(t, DummyMessageDefinition, def)
-	message.ClearDefinitions()
-
 }
 
 func TestMessage_DefinitionForTypeBig(t *testing.T) {
+	r := message.NewRegistry()
 	// register a message with big type number
 	var BigMessageType message.Type = 5
 	var BigMessageDefinition = &message.Definition{
@@ -62,12 +63,11 @@ func TestMessage_DefinitionForTypeBig(t *testing.T) {
 		VariableLength: false,
 	}
 	// grows definitions to size of the message type (5)
-	err := message.RegisterType(BigMessageType, BigMessageDefinition)
+	err := r.RegisterType(BigMessageType, BigMessageDefinition)
 	assert.NoError(t, err)
 	// Dummy was not registered
-	_, err = message.DefinitionForType(DummyMessageType)
+	_, err = r.DefinitionForType(DummyMessageType)
 	if assert.Error(t, err) {
 		assert.Equal(t, message.ErrUnknownType, err)
 	}
-	message.ClearDefinitions()
 }

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -1,6 +1,6 @@
 package message_test
 
-import(
+import (
 	"testing"
 
 	"github.com/iotaledger/hive.go/protocol/message"
@@ -8,12 +8,14 @@ import(
 )
 
 // message definition for testing
-var DummyMessageType message.Type = 0
-var DummyMessageDefinition = &message.Definition{
-	ID:             DummyMessageType,
-	MaxBytesLength: 10,
-	VariableLength: false,
-}
+var (
+	DummyMessageType         message.Type = 0
+	DummyMessageDefinition = &message.Definition{
+		ID:             DummyMessageType,
+		MaxBytesLength: 10,
+		VariableLength: false,
+	}
+)
 
 func TestMessage_Register(t *testing.T) {
 	r := message.NewRegistry()
@@ -81,5 +83,5 @@ func TestMessage_Clear(t *testing.T) {
 
 	r.Clear()
 	definitions = r.Definitions()
-	assert.Equal(t, 0 ,len(definitions))
+	assert.Equal(t, 0, len(definitions))
 }

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -22,7 +22,6 @@ func TestMessage_Register(t *testing.T) {
 
 	definitions := r.Definitions()
 	assert.Equal(t, definitions[0], DummyMessageDefinition)
-	r.ClearDefinitions()
 }
 
 func TestMessage_RegisterTypeAlready(t *testing.T) {

--- a/protocol/message/message_test.go
+++ b/protocol/message/message_test.go
@@ -70,3 +70,16 @@ func TestMessage_DefinitionForTypeBig(t *testing.T) {
 		assert.Equal(t, message.ErrUnknownType, err)
 	}
 }
+
+func TestMessage_Clear(t *testing.T) {
+	r := message.NewRegistry()
+	err := r.RegisterType(DummyMessageType, DummyMessageDefinition)
+	assert.NoError(t, err)
+
+	definitions := r.Definitions()
+	assert.Equal(t, definitions[0], DummyMessageDefinition)
+
+	r.Clear()
+	definitions = r.Definitions()
+	assert.Equal(t, 0 ,len(definitions))
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -27,7 +27,7 @@ type Events struct {
 
 // Protocol encapsulates the logic of parsing and sending protocol messages.
 type Protocol struct {
-	// Holds events for sent and received messages, handshake completion and generic errors.
+	// Holds events for sent/received messages and generic errors.
 	Events Events
 	// the underlying connection
 	conn io.ReadWriteCloser

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/syncutils"
 	"github.com/iotaledger/hive.go/protocol/message"
 	"github.com/iotaledger/hive.go/protocol/tlv"
+	"github.com/iotaledger/hive.go/syncutils"
 )
-
 
 // Events holds protocol related events.
 type Events struct {
@@ -62,12 +61,12 @@ func New(conn io.ReadWriteCloser, r *message.Registry) *Protocol {
 	}
 
 	protocol := &Protocol{
-		conn: conn,
+		conn:        conn,
 		msgRegistry: r,
 		Events: Events{
-			Received:           receiveHandlers,
-			Sent:               sentHandlers,
-			Error:              events.NewEvent(events.ErrorCaller),
+			Received: receiveHandlers,
+			Sent:     sentHandlers,
+			Error:    events.NewEvent(events.ErrorCaller),
 		},
 		// the first message on the protocol is a TLV header
 		receiveBuffer:    make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength),
@@ -153,6 +152,9 @@ func (p *Protocol) Send(message []byte) error {
 }
 
 // CloseConnection closes the underlying connection
-func (p *Protocol) CloseConnection() {
-	p.conn.Close()
+func (p *Protocol) CloseConnection() error {
+	if err := p.conn.Close(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,0 +1,155 @@
+package protocol
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/iotaledger/hive.go/byteutils"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/syncutils"
+	"github.com/iotaledger/hive.go/protocol/message"
+	"github.com/iotaledger/hive.go/protocol/tlv"
+)
+
+
+// Events holds protocol related events.
+type Events struct {
+	// Holds event instances to attach to for received messages.
+	// Use a message's ID to get the corresponding event.
+	Received []*events.Event
+	// Holds event instances to attach to for sent messages.
+	// Use a message's ID to get the corresponding event.
+	Sent []*events.Event
+	// Fired for generic protocol errors.
+	// It is suggested to close the underlying ReadWriteCloser of the Protocol instance
+	// if any error occurs.
+	Error *events.Event
+}
+
+// Protocol encapsulates the logic of parsing and sending protocol messages.
+type Protocol struct {
+	// Holds events for sent and received messages, handshake completion and generic errors.
+	Events Events
+	// the underlying connection
+	conn io.ReadWriteCloser
+	// the current receiving message
+	receivingMessage *message.Definition
+	// the buffer holding the receiving message data
+	receiveBuffer []byte
+	// the current offset within the receiving buffer
+	receiveBufferOffset int
+	// mutex to synchronize multiple sends
+	sendMutex syncutils.Mutex
+}
+
+// New generates a new protocol instance which is ready to read a first message header.
+func New(conn io.ReadWriteCloser) *Protocol {
+
+	// load message definitions
+	definitions := message.Definitions()
+
+	// allocate event handlers for all message types
+	receiveHandlers := make([]*events.Event, len(definitions))
+	sentHandlers := make([]*events.Event, len(definitions))
+	for i, def := range definitions {
+		if def == nil {
+			continue
+		}
+		receiveHandlers[i] = events.NewEvent(events.ByteSliceCaller)
+		sentHandlers[i] = events.NewEvent(events.CallbackCaller)
+	}
+
+	protocol := &Protocol{
+		conn: conn,
+		Events: Events{
+			Received:           receiveHandlers,
+			Sent:               sentHandlers,
+			Error:              events.NewEvent(events.ErrorCaller),
+		},
+		// the first message on the protocol is a TLV header
+		receiveBuffer:    make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength),
+		receivingMessage: tlv.HeaderMessageDefinition,
+	}
+
+	return protocol
+}
+
+// Start kicks off the protocol by starting to read from the connection.
+func (p *Protocol) Start() {
+	// start reading from the connection
+	_, _ = p.conn.Read(make([]byte, 2048))
+}
+
+// Receive acts as an event handler for received data.
+func (p *Protocol) Receive(data []byte) {
+	offset := 0
+	length := len(data)
+
+	// continue to parse messages as long as we have data to consume
+	for offset < length && p.receivingMessage != nil {
+
+		// read in data into the receive buffer for the current message type
+		bytesRead := byteutils.ReadAvailableBytesToBuffer(p.receiveBuffer, p.receiveBufferOffset, data, offset, length)
+
+		p.receiveBufferOffset += bytesRead
+
+		// advance consumed offset of received data
+		offset += bytesRead
+
+		if p.receiveBufferOffset != len(p.receiveBuffer) {
+			return
+		}
+
+		// message fully received
+		p.receiveBufferOffset = 0
+
+		// interpret the next message type if we received a header
+		if p.receivingMessage.ID == tlv.HeaderMessageDefinition.ID {
+
+			header, err := tlv.ParseHeader(p.receiveBuffer)
+			if err != nil {
+				p.Events.Error.Trigger(err)
+				_ = p.conn.Close()
+				return
+			}
+
+			// advance to handle the message type the header says we are receiving
+			p.receivingMessage = header.Definition
+
+			// allocate enough space for it
+			p.receiveBuffer = make([]byte, header.MessageBytesLength)
+			continue
+		}
+
+		// fire the message type's event handler.
+		// note that the message id is valid here because we verified that the message type
+		// exists while parsing the TLV header
+		p.Events.Received[p.receivingMessage.ID].Trigger(p.receiveBuffer)
+
+		// reset to receiving a header
+		p.receivingMessage = tlv.HeaderMessageDefinition
+		p.receiveBuffer = make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength)
+	}
+}
+
+// Send sends the given message (including the message header) to the underlying writer.
+// It fires the corresponding send event for the specific message type.
+func (p *Protocol) Send(message []byte) error {
+	p.sendMutex.Lock()
+	defer p.sendMutex.Unlock()
+
+	// write message
+	if _, err := p.conn.Write(message); err != nil {
+		return fmt.Errorf("failed to send message: %w", err)
+	}
+
+	// fire event handler for sent message
+	p.Events.Sent[message[0]].Trigger()
+
+	return nil
+}
+
+// CloseConnection closes the underlying connection
+func (p *Protocol) CloseConnection() {
+	p.conn.Close()
+}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,0 +1,138 @@
+package protocol_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/protocol"
+	"github.com/iotaledger/hive.go/protocol/message"
+	"github.com/iotaledger/hive.go/protocol/tlv"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeconn struct {
+	writer io.WriteCloser
+	reader io.ReadCloser
+}
+
+func (f fakeconn) Read(p []byte) (n int, err error) {
+	return f.reader.Read(p)
+}
+
+func (f fakeconn) Write(p []byte) (n int, err error) {
+	return f.writer.Write(p)
+}
+
+func (f fakeconn) Close() error {
+	if err := f.writer.Close(); err != nil {
+		return err
+	}
+	if err := f.reader.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newFakeConn() *fakeconn {
+	r, w := io.Pipe()
+	return &fakeconn{writer: w, reader: r}
+}
+
+func consume(t *testing.T, p *protocol.Protocol, conn io.Reader, expectedLength int) *sync.WaitGroup {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		data := make([]byte, expectedLength)
+		read, err := conn.Read(data)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedLength, read)
+		p.Receive(data[:read])
+	}()
+	return &wg
+}
+
+const(
+	MessageTypeTest message.Type = 1
+
+	// length of a test message in bytes
+	TestMaxBytesLength = 5
+)
+
+var (
+	TestMessageDefinition = &message.Definition{
+		ID:             MessageTypeTest,
+		MaxBytesLength: TestMaxBytesLength,
+		VariableLength: false,
+	}
+)
+
+func NewTestMessage() ([]byte,error) {
+	packet := []byte{'t', 'e', 's', 't', '!'}
+	// create a buffer for tlv header plus the packet
+	buf := bytes.NewBuffer(make([]byte, 0, tlv.HeaderMessageDefinition.MaxBytesLength+uint16(TestMaxBytesLength)))
+	// write tlv header into buffer
+	if err := tlv.WriteHeader(buf, MessageTypeTest, uint16(TestMaxBytesLength)); err != nil {
+		return nil, err
+	}
+	// write serialized packet bytes into the buffer
+	if err := binary.Write(buf, binary.BigEndian, packet); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func init() {
+	if err := message.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
+		panic(err)
+	}
+}
+
+func TestProtocol_Receive(t *testing.T) {
+	conn := newFakeConn()
+	defer conn.Close()
+	p := protocol.New(conn)
+
+	var TestMessageReceived bool
+	var testPacketString string
+	p.Events.Received[TestMessageDefinition.ID].Attach(events.NewClosure(func(data []byte) {
+		TestMessageReceived = true
+		testPacketString = string(data)
+	}))
+
+	testMsg, err := NewTestMessage()
+	assert.NoError(t, err)
+
+	wg := consume(t, p, conn, len(testMsg))
+	_, err = conn.Write(testMsg)
+	assert.NoError(t, err)
+
+	wg.Wait()
+	assert.True(t, TestMessageReceived)
+	assert.Equal(t, "test!", testPacketString)
+}
+
+func TestProtocol_Send(t *testing.T) {
+	conn := newFakeConn()
+	defer conn.Close()
+	p := protocol.New(conn)
+
+	var TestMessageSent bool
+	p.Events.Sent[TestMessageDefinition.ID].Attach(events.NewClosure(func() {
+		TestMessageSent = true
+	}))
+
+	testMsg, err := NewTestMessage()
+	assert.NoError(t, err)
+
+	wg := consume(t, p, conn, len(testMsg))
+	assert.NoError(t, p.Send(testMsg))
+
+	wg.Wait()
+	assert.True(t, TestMessageSent)
+}

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -56,7 +56,7 @@ func consume(t *testing.T, p *protocol.Protocol, conn io.Reader, expectedLength 
 	return &wg
 }
 
-const(
+const (
 	MessageTypeTest message.Type = 1
 
 	// length of a test message in bytes
@@ -72,7 +72,7 @@ var (
 	msgRegistry = message.NewRegistry()
 )
 
-func NewTestMessage() ([]byte,error) {
+func NewTestMessage() ([]byte, error) {
 	packet := []byte{'t', 'e', 's', 't', '!'}
 	// create a buffer for tlv header plus the packet
 	buf := bytes.NewBuffer(make([]byte, 0, tlv.HeaderMessageDefinition.MaxBytesLength+uint16(TestMaxBytesLength)))

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -69,6 +69,7 @@ var (
 		MaxBytesLength: TestMaxBytesLength,
 		VariableLength: false,
 	}
+	msgRegistry = message.NewRegistry()
 )
 
 func NewTestMessage() ([]byte,error) {
@@ -88,7 +89,7 @@ func NewTestMessage() ([]byte,error) {
 }
 
 func init() {
-	if err := message.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
+	if err := msgRegistry.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
 		panic(err)
 	}
 }
@@ -96,7 +97,7 @@ func init() {
 func TestProtocol_Receive(t *testing.T) {
 	conn := newFakeConn()
 	defer conn.Close()
-	p := protocol.New(conn)
+	p := protocol.New(conn, msgRegistry)
 
 	var TestMessageReceived bool
 	var testPacketString string
@@ -120,7 +121,7 @@ func TestProtocol_Receive(t *testing.T) {
 func TestProtocol_Send(t *testing.T) {
 	conn := newFakeConn()
 	defer conn.Close()
-	p := protocol.New(conn)
+	p := protocol.New(conn, msgRegistry)
 
 	var TestMessageSent bool
 	p.Events.Sent[TestMessageDefinition.ID].Attach(events.NewClosure(func() {

--- a/protocol/tlv/tlv.go
+++ b/protocol/tlv/tlv.go
@@ -16,7 +16,7 @@ var (
 )
 
 const (
-	// MessageTypeHeader is the unique id of a tlv header
+	// MessageTypeHeader is the unique id of a tlv header.
 	MessageTypeHeader message.Type = 0
 
 	// The amount of bytes dedicated for the message type in the packet header.

--- a/protocol/tlv/tlv.go
+++ b/protocol/tlv/tlv.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	// The message header sent in each message denoting the TLV fields.
+	// HeaderMessageDefinition is the message header sent in each message denoting the TLV fields.
 	HeaderMessageDefinition = &message.Definition{
 		ID:             MessageTypeHeader,
 		MaxBytesLength: HeaderBytesLength,

--- a/protocol/tlv/tlv.go
+++ b/protocol/tlv/tlv.go
@@ -16,6 +16,7 @@ var (
 )
 
 const (
+	// MessageTypeHeader is the unique id of a tlv header
 	MessageTypeHeader message.Type = 0
 
 	// The amount of bytes dedicated for the message type in the packet header.
@@ -47,10 +48,10 @@ type Header struct {
 
 // WriteHeader writes a TLV header into the given Writer.
 func WriteHeader(buf io.Writer, msgType message.Type, msgBytesLength uint16) error {
-	if err := binary.Write(buf, binary.BigEndian, byte(msgType)); err != nil {
+	if err := binary.Write(buf, binary.LittleEndian, byte(msgType)); err != nil {
 		return err
 	}
-	return binary.Write(buf, binary.BigEndian, msgBytesLength)
+	return binary.Write(buf, binary.LittleEndian, msgBytesLength)
 }
 
 // ParseHeader parses the given buffer to a Header.
@@ -63,8 +64,7 @@ func ParseHeader(buf []byte, r *message.Registry) (*Header, error) {
 	}
 
 	// extract length of message
-	advMsgBytesLength := binary.BigEndian.Uint16(buf[1:3])
-
+	advMsgBytesLength := binary.LittleEndian.Uint16(buf[1:3])
 	if (advMsgBytesLength > def.MaxBytesLength) || (!def.VariableLength && (advMsgBytesLength < def.MaxBytesLength)) {
 		return nil, fmt.Errorf("%s: advertised length: %d bytes; max length: %d bytes", ErrInvalidMessageLength.Error(), advMsgBytesLength, def.MaxBytesLength)
 	}

--- a/protocol/tlv/tlv.go
+++ b/protocol/tlv/tlv.go
@@ -1,0 +1,79 @@
+package tlv
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/iotaledger/hive.go/protocol/message"
+)
+
+func init() {
+	if err := message.RegisterType(MessageTypeHeader, HeaderMessageDefinition); err != nil {
+		panic(err)
+	}
+}
+
+var (
+	// ErrInvalidMessageLength is returned when a packet advertises a message length which
+	// is invalid for the given message type.
+	ErrInvalidMessageLength = errors.New("invalid message length")
+)
+
+const (
+	MessageTypeHeader message.Type = 0
+
+	// The amount of bytes dedicated for the message type in the packet header.
+	HeaderTypeBytesLength = 1
+
+	// The amount of bytes dedicated for the message length denotation in the packet header.
+	HeaderLengthByteLength = 2
+
+	// The amount of bytes making up the protocol TLV packet header.
+	HeaderBytesLength = HeaderLengthByteLength + HeaderTypeBytesLength
+)
+
+var (
+	// The message header sent in each message denoting the TLV fields.
+	HeaderMessageDefinition = &message.Definition{
+		ID:             MessageTypeHeader,
+		MaxBytesLength: HeaderBytesLength,
+		VariableLength: false,
+	}
+)
+
+// Header includes the definition of the message and its bytes length.
+type Header struct {
+	// The definition of the message.
+	Definition *message.Definition
+	// The length in bytes of the message.
+	MessageBytesLength uint16
+}
+
+// WriteHeader writes a TLV header into the given Writer.
+func WriteHeader(buf io.Writer, msgType message.Type, msgBytesLength uint16) error {
+	if err := binary.Write(buf, binary.BigEndian, byte(msgType)); err != nil {
+		return err
+	}
+	return binary.Write(buf, binary.BigEndian, msgBytesLength)
+}
+
+// ParseHeader parses the given buffer to a Header.
+func ParseHeader(buf []byte) (*Header, error) {
+
+	// get message
+	def, err := message.DefinitionForType(message.Type(buf[0]))
+	if err != nil {
+		return nil, err
+	}
+
+	// extract length of message
+	advMsgBytesLength := binary.BigEndian.Uint16(buf[1:3])
+
+	if (advMsgBytesLength > def.MaxBytesLength) || (!def.VariableLength && (advMsgBytesLength < def.MaxBytesLength)) {
+		return nil, fmt.Errorf("%s: advertised length: %d bytes; max length: %d bytes", ErrInvalidMessageLength.Error(), advMsgBytesLength, def.MaxBytesLength)
+	}
+
+	return &Header{Definition: def, MessageBytesLength: advMsgBytesLength}, nil
+}

--- a/protocol/tlv/tlv.go
+++ b/protocol/tlv/tlv.go
@@ -9,12 +9,6 @@ import (
 	"github.com/iotaledger/hive.go/protocol/message"
 )
 
-func init() {
-	if err := message.RegisterType(MessageTypeHeader, HeaderMessageDefinition); err != nil {
-		panic(err)
-	}
-}
-
 var (
 	// ErrInvalidMessageLength is returned when a packet advertises a message length which
 	// is invalid for the given message type.
@@ -60,10 +54,10 @@ func WriteHeader(buf io.Writer, msgType message.Type, msgBytesLength uint16) err
 }
 
 // ParseHeader parses the given buffer to a Header.
-func ParseHeader(buf []byte) (*Header, error) {
+func ParseHeader(buf []byte, r *message.Registry) (*Header, error) {
 
 	// get message
-	def, err := message.DefinitionForType(message.Type(buf[0]))
+	def, err := r.DefinitionForType(message.Type(buf[0]))
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/tlv/tlv_test.go
+++ b/protocol/tlv/tlv_test.go
@@ -1,0 +1,59 @@
+package tlv_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/iotaledger/hive.go/protocol/message"
+	"github.com/iotaledger/hive.go/protocol/tlv"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	if err := message.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
+		panic(err)
+	}
+}
+
+const(
+	MessageTypeTest message.Type = 1
+
+	// length of a test message in bytes
+	TestMaxBytesLength = 5
+)
+
+var (
+	TestMessageDefinition = &message.Definition{
+		ID:             MessageTypeTest,
+		MaxBytesLength: TestMaxBytesLength,
+		VariableLength: false,
+	}
+)
+
+func TestTLV(t *testing.T) {
+	buf := bytes.NewBuffer(make([]byte, 0, tlv.HeaderMessageDefinition.MaxBytesLength))
+
+	err :=tlv.WriteHeader(buf, MessageTypeTest, uint16(TestMaxBytesLength))
+	assert.NoError(t, err)
+
+	data := buf.Bytes()
+	var header *tlv.Header
+	header, err = tlv.ParseHeader(data)
+	assert.NoError(t, err)
+
+	assert.Equal(t, TestMessageDefinition, header.Definition)
+	assert.Equal(t, uint16(TestMaxBytesLength), header.MessageBytesLength)
+}
+
+func TestTLV_ParseHeader(t *testing.T) {
+	// unknown message type
+	data := []byte{2,0,5}
+	_, err := tlv.ParseHeader(data)
+	assert.Error(t, err)
+
+	// invalid message length
+	data = []byte{byte(MessageTypeTest),0,6}
+	_, err = tlv.ParseHeader(data)
+	assert.Error(t, err)
+
+}

--- a/protocol/tlv/tlv_test.go
+++ b/protocol/tlv/tlv_test.go
@@ -16,7 +16,7 @@ func init() {
 	}
 }
 
-const(
+const (
 	MessageTypeTest message.Type = 1
 
 	// length of a test message in bytes
@@ -24,7 +24,7 @@ const(
 )
 
 var (
-	r *message.Registry
+	r                     *message.Registry
 	TestMessageDefinition = &message.Definition{
 		ID:             MessageTypeTest,
 		MaxBytesLength: TestMaxBytesLength,
@@ -35,7 +35,7 @@ var (
 func TestTLV(t *testing.T) {
 	buf := bytes.NewBuffer(make([]byte, 0, tlv.HeaderMessageDefinition.MaxBytesLength))
 
-	err :=tlv.WriteHeader(buf, MessageTypeTest, uint16(TestMaxBytesLength))
+	err := tlv.WriteHeader(buf, MessageTypeTest, uint16(TestMaxBytesLength))
 	assert.NoError(t, err)
 
 	data := buf.Bytes()
@@ -49,12 +49,12 @@ func TestTLV(t *testing.T) {
 
 func TestTLV_ParseHeader(t *testing.T) {
 	// unknown message type
-	data := []byte{2,0,5}
+	data := []byte{2, 0, 5}
 	_, err := tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 
 	// invalid message length
-	data = []byte{byte(MessageTypeTest),0,6}
+	data = []byte{byte(MessageTypeTest), 0, 6}
 	_, err = tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 

--- a/protocol/tlv/tlv_test.go
+++ b/protocol/tlv/tlv_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func init() {
-	if err := message.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
+	r = message.NewRegistry()
+	if err := r.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
 		panic(err)
 	}
 }
@@ -23,6 +24,7 @@ const(
 )
 
 var (
+	r *message.Registry
 	TestMessageDefinition = &message.Definition{
 		ID:             MessageTypeTest,
 		MaxBytesLength: TestMaxBytesLength,
@@ -38,7 +40,7 @@ func TestTLV(t *testing.T) {
 
 	data := buf.Bytes()
 	var header *tlv.Header
-	header, err = tlv.ParseHeader(data)
+	header, err = tlv.ParseHeader(data, r)
 	assert.NoError(t, err)
 
 	assert.Equal(t, TestMessageDefinition, header.Definition)
@@ -48,12 +50,12 @@ func TestTLV(t *testing.T) {
 func TestTLV_ParseHeader(t *testing.T) {
 	// unknown message type
 	data := []byte{2,0,5}
-	_, err := tlv.ParseHeader(data)
+	_, err := tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 
 	// invalid message length
 	data = []byte{byte(MessageTypeTest),0,6}
-	_, err = tlv.ParseHeader(data)
+	_, err = tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 
 }

--- a/protocol/tlv/tlv_test.go
+++ b/protocol/tlv/tlv_test.go
@@ -9,13 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	r = message.NewRegistry()
-	if err := r.RegisterType(MessageTypeTest, TestMessageDefinition); err != nil {
-		panic(err)
-	}
-}
-
 const (
 	MessageTypeTest message.Type = 1
 
@@ -24,12 +17,15 @@ const (
 )
 
 var (
-	r                     *message.Registry
 	TestMessageDefinition = &message.Definition{
 		ID:             MessageTypeTest,
 		MaxBytesLength: TestMaxBytesLength,
 		VariableLength: false,
 	}
+	r = message.NewRegistry([]*message.Definition{
+		tlv.HeaderMessageDefinition,
+		TestMessageDefinition,
+	})
 )
 
 func TestTLV(t *testing.T) {
@@ -49,12 +45,12 @@ func TestTLV(t *testing.T) {
 
 func TestTLV_ParseHeader(t *testing.T) {
 	// unknown message type
-	data := []byte{2, 0, 5}
+	data := []byte{2, 5, 0}
 	_, err := tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 
 	// invalid message length
-	data = []byte{byte(MessageTypeTest), 0, 6}
+	data = []byte{byte(MessageTypeTest), 6, 0}
 	_, err = tlv.ParseHeader(data, r)
 	assert.Error(t, err)
 


### PR DESCRIPTION
# Description of change

A Type-Length-Value protocol for communicating over streaming protocols (tcp).
Before each actual packet, a `TLV Header` is inserted that denotes the type and length of the following packet. This way the receiver can correctly identify the start end end of a message.

`message.Registry` is used to initially register and provide available packet definitions. `message.NewRegistry()` takes a slice of message definitions and initializes the registry. Once this is done, the registry is immutable. Message definitions should be supplied to the function in a strictly monotonically increasing fashion according to their message type.
A `protocol` is instantiated with a `connection` and a `message registry`.
```go

conn, err := net.Dial("tcp", "goshimmer.org:80")
if err != nil {
	// handle error
}
registry := message.NewRegistry([]*Definition{<msg-definitions>})

p := protocol.New(conn, registry)
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests:
 - `message_test.go`
 - `tlv_test.go`
 - `protocol_test/go`

Also, refactored analysis plugin in GoShimmer and successfully ran using this change.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
