### PR TITLE
This fixes the optional prefix being ignored when iterating over keys when skipCache is set to true

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -413,6 +413,10 @@ func (objectStorage *ObjectStorage) ForEachKeyOnly(consumer func(key []byte) boo
 		}
 	}
 
+	if len(optionalPrefix) > 0 {
+		keyPrefix = optionalPrefix[0]
+	}
+	
 	_ = objectStorage.store.IterateKeys(keyPrefix,
 		func(key kvstore.Key) bool {
 			if _, elementSeen := seenElements[string(key)]; elementSeen {


### PR DESCRIPTION
##Description of change

- This fixes the optional prefix being ignored when iterating over keys when skipCache is set to true
- Added some more test cases covering this

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
