### PR TITLE
Add simple key-value store backed sequence

### DIFF
--- a/kvstore/sequence.go
+++ b/kvstore/sequence.go
@@ -1,0 +1,93 @@
+package kvstore
+
+import (
+	"encoding/binary"
+	"sync"
+)
+
+// Sequence represents a simple integer sequence backed by a KVStore.
+// A Sequence can be used to get a list of monotonically increasing integers.
+type Sequence struct {
+	sync.Mutex
+	store    KVStore
+	key      []byte
+	interval uint64 // the interval in which numbers are backed by the store
+	next     uint64 // next number to be returned
+	reserved uint64 // until which number is reserved in the store
+}
+
+// NewSequence initiates a new sequence object backed by the provided store.
+// The interval value defines how many Next() requests can be served from memory without an access to the store.
+// Multiple sequences can be created by providing different keys.
+func NewSequence(store KVStore, key []byte, interval uint64) (*Sequence, error) {
+	if interval == 0 {
+		panic("interval must be greater than zero")
+	}
+
+	seq := &Sequence{
+		store:    store,
+		key:      key,
+		next:     0,
+		reserved: 0,
+		interval: interval,
+	}
+	if err := seq.update(); err != nil {
+		return nil, err
+	}
+	return seq, nil
+}
+
+// Next returns the next integer in the sequence.
+func (seq *Sequence) Next() (uint64, error) {
+	seq.Lock()
+	defer seq.Unlock()
+
+	if seq.next >= seq.reserved {
+		if err := seq.update(); err != nil {
+			return 0, err
+		}
+	}
+
+	val := seq.next
+	seq.next++
+	return val, nil
+}
+
+// Release the leased sequence to avoid wasted integers.
+func (seq *Sequence) Release() error {
+	seq.Lock()
+	defer seq.Unlock()
+
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], seq.next)
+	if err := seq.store.Set(seq.key, buf[:]); err != nil {
+		return err
+	}
+
+	seq.reserved = seq.next
+	return nil
+}
+
+func (seq *Sequence) update() error {
+	value, err := seq.store.Get(seq.key)
+	switch {
+	case err == ErrKeyNotFound:
+		seq.next = 0
+	case err != nil:
+		return err
+	default:
+		num := binary.BigEndian.Uint64(value)
+		seq.next = num
+	}
+
+	// reserve the interval and set in store
+	reserved := seq.next + seq.interval
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], reserved)
+	err = seq.store.Set(seq.key, buf[:])
+	if err != nil {
+		return err
+	}
+	seq.reserved = reserved
+	return nil
+}

--- a/kvstore/sequence_test.go
+++ b/kvstore/sequence_test.go
@@ -1,0 +1,71 @@
+package kvstore_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sequenceKey = []byte("test_sequence")
+
+const sequenceInterval = 100
+
+func TestNewSequence(t *testing.T) {
+	store := mapdb.NewMapDB()
+	s1, err := kvstore.NewSequence(store, sequenceKey, 1)
+	assert.NotNil(t, s1)
+	assert.NoError(t, err)
+
+	// key should exists in the store
+	_, err = store.Get(sequenceKey)
+	require.NoError(t, err)
+}
+
+func TestSequence_Next(t *testing.T) {
+	store := mapdb.NewMapDB()
+	s1, err := kvstore.NewSequence(store, sequenceKey, sequenceInterval)
+	require.NoError(t, err)
+
+	for i := 0; i < sequenceInterval; i++ {
+		next, err := s1.Next()
+		require.NoError(t, err)
+		assert.EqualValues(t, i, next)
+	}
+
+	s2, err := kvstore.NewSequence(store, sequenceKey, sequenceInterval)
+	require.NoError(t, err)
+
+	next2, err := s2.Next()
+	require.NoError(t, err)
+	assert.EqualValues(t, sequenceInterval, next2)
+
+	s3, err := kvstore.NewSequence(store, sequenceKey, sequenceInterval)
+	require.NoError(t, err)
+
+	next3, err := s3.Next()
+	require.NoError(t, err)
+	assert.EqualValues(t, 2*sequenceInterval, next3)
+}
+
+func TestSequence_Release(t *testing.T) {
+	store := mapdb.NewMapDB()
+	s1, err := kvstore.NewSequence(store, sequenceKey, math.MaxUint64)
+	require.NoError(t, err)
+
+	first, err := s1.Next()
+	require.NoError(t, err)
+
+	require.NoError(t, s1.Release())
+
+	s2, err := kvstore.NewSequence(store, sequenceKey, 1)
+	require.NoError(t, err)
+
+	second, err := s2.Next()
+	require.NoError(t, err)
+
+	assert.Equal(t, first+1, second)
+}


### PR DESCRIPTION
- Generate a sequence of integers backed by a key in the store
- Interval to prevent store updates on every query
- Do not generate index twice even after crash