### PR TITLE
refactor node.plugins to expose *Plugin

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// plugins
-	plugins         = make(map[string]int)
+	plugins         = make(map[string]*Plugin)
 	DisabledPlugins = make(map[string]bool)
 	EnabledPlugins  = make(map[string]bool)
 )
@@ -124,16 +124,16 @@ func (node *Node) Run() {
 	node.Logger.Info("Shutdown complete!")
 }
 
-func AddPlugin(name string, status int) {
+func AddPlugin(name string, status int, plugin *Plugin) {
 	if _, exists := plugins[name]; exists {
 		panic("duplicate plugin - \"" + name + "\" was defined already")
 	}
 
-	plugins[name] = status
+	plugins[name] = plugin
 
 	Events.AddPlugin.Trigger(name, status)
 }
 
-func GetPlugins() map[string]int {
+func GetPlugins() map[string]*Plugin {
 	return plugins
 }

--- a/node/node.go
+++ b/node/node.go
@@ -124,7 +124,10 @@ func (node *Node) Run() {
 	node.Logger.Info("Shutdown complete!")
 }
 
-func AddPlugin(name string, status int, plugin *Plugin) {
+func AddPlugin(plugin *Plugin) {
+	name := plugin.Name
+	status := plugin.Status
+
 	if _, exists := plugins[name]; exists {
 		panic("duplicate plugin - \"" + name + "\" was defined already")
 	}

--- a/node/plugin.go
+++ b/node/plugin.go
@@ -35,7 +35,7 @@ func NewPlugin(name string, status int, callbacks ...Callback) *Plugin {
 		},
 	}
 
-	AddPlugin(name, status)
+	AddPlugin(name, status, plugin)
 
 	switch len(callbacks) {
 	case 0:

--- a/node/plugin.go
+++ b/node/plugin.go
@@ -35,7 +35,7 @@ func NewPlugin(name string, status int, callbacks ...Callback) *Plugin {
 		},
 	}
 
-	AddPlugin(name, status, plugin)
+	AddPlugin(plugin)
 
 	switch len(callbacks) {
 	case 0:


### PR DESCRIPTION
# Description of change

Refactor `node.plugins` from `map[string]int` to `map[string]*Plugin` so that we can use `plugin.isSkipped` in `/info` APIs `enabledPlugins` and `disabledPlugins`

See https://github.com/iotaledger/goshimmer/pull/449

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
