### PR TITLE
Fix: Race condition in Protocol.Read

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,6 +1,8 @@
 package protocol
 
 import (
+	"sync"
+
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/protocol/message"
@@ -22,17 +24,18 @@ type Protocol struct {
 	Events Events
 	// message registry
 	msgRegistry *message.Registry
+	// lock during concurrent reads
+	readMutex sync.Mutex
 	// the current receiving message
-	receivingMessage *message.Definition
+	readMessage *message.Definition
 	// the buffer holding the receiving message data
-	receiveBuffer []byte
+	readBuffer []byte
 	// the current offset within the receiving buffer
-	receiveBufferOffset int
+	readBufferOffset int
 }
 
 // New generates a new protocol instance which is ready to read a first message header.
 func New(r *message.Registry) *Protocol {
-
 	// load message definitions
 	definitions := r.Definitions()
 
@@ -54,8 +57,8 @@ func New(r *message.Registry) *Protocol {
 			Error:    events.NewEvent(events.ErrorCaller),
 		},
 		// the first message on the protocol is a TLV header
-		receiveBuffer:    make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength),
-		receivingMessage: tlv.HeaderMessageDefinition,
+		readBuffer:  make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength),
+		readMessage: tlv.HeaderMessageDefinition,
 	}
 
 	return protocol
@@ -63,53 +66,56 @@ func New(r *message.Registry) *Protocol {
 
 // Read acts as an event handler for received data.
 func (p *Protocol) Read(data []byte) (int, error) {
+	p.readMutex.Lock()
+	defer p.readMutex.Unlock()
+
 	offset := 0
 	length := len(data)
 
 	// continue to parse messages as long as we have data to consume
-	for offset < length && p.receivingMessage != nil {
+	for offset < length && p.readMessage != nil {
 
 		// read in data into the receive buffer for the current message type
-		bytesRead := byteutils.ReadAvailableBytesToBuffer(p.receiveBuffer, p.receiveBufferOffset, data, offset, length)
+		bytesRead := byteutils.ReadAvailableBytesToBuffer(p.readBuffer, p.readBufferOffset, data, offset, length)
 
-		p.receiveBufferOffset += bytesRead
+		p.readBufferOffset += bytesRead
 
 		// advance consumed offset of received data
 		offset += bytesRead
 
 		// we din't receive the full message yet
-		if p.receiveBufferOffset != len(p.receiveBuffer) {
+		if p.readBufferOffset != len(p.readBuffer) {
 			return offset, nil
 		}
 
 		// message fully received
-		p.receiveBufferOffset = 0
+		p.readBufferOffset = 0
 
 		// interpret the next message type if we received a header
-		if p.receivingMessage.ID == tlv.HeaderMessageDefinition.ID {
+		if p.readMessage.ID == tlv.HeaderMessageDefinition.ID {
 
-			header, err := tlv.ParseHeader(p.receiveBuffer, p.msgRegistry)
+			header, err := tlv.ParseHeader(p.readBuffer, p.msgRegistry)
 			if err != nil {
 				p.Events.Error.Trigger(err)
 				return offset, err
 			}
 
 			// advance to handle the message type the header says we are receiving
-			p.receivingMessage = header.Definition
+			p.readMessage = header.Definition
 
 			// allocate enough space for it
-			p.receiveBuffer = make([]byte, header.MessageBytesLength)
+			p.readBuffer = make([]byte, header.MessageBytesLength)
 			continue
 		}
 
 		// fire the message type's event handler.
 		// note that the message id is valid here because we verified that the message type
 		// exists while parsing the TLV header
-		p.Events.Received[p.receivingMessage.ID].Trigger(p.receiveBuffer)
+		p.Events.Received[p.readMessage.ID].Trigger(p.readBuffer)
 
 		// reset to receiving a header
-		p.receivingMessage = tlv.HeaderMessageDefinition
-		p.receiveBuffer = make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength)
+		p.readMessage = tlv.HeaderMessageDefinition
+		p.readBuffer = make([]byte, tlv.HeaderMessageDefinition.MaxBytesLength)
 	}
 
 	return offset, nil


### PR DESCRIPTION
- `Read` must be locked to prevent issues with concurrent reads.