### PR TITLE
Fix: StoreIfAbsent should  be concurrency-safe

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -284,6 +284,15 @@ func (objectStorage *ObjectStorage) StoreIfAbsent(object StorableObject) (result
 					newCachedObject.Release()
 				}
 			} else {
+				// abort if the object exists in the database already - an object might have been written and evicted
+				// since our last check so even though the object was not found in the cache, it still exists already
+				if loadedObject := objectStorage.LoadObjectFromStore(key); !typeutils.IsInterfaceNil(loadedObject) {
+					newCachedObject.publishResult(loadedObject)
+					newCachedObject.Release()
+
+					return
+				}
+
 				newCachedObject.publishResult(object)
 
 				stored = true


### PR DESCRIPTION
# Description of change

StoreIfAbsent should only return true for a single caller of a set of concurrent callers that all try to store the same object.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I have added a unit test that checks if StoreIfAbsent really returns true once in a concurrent scenario.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
