### PR TITLE
Optionally skip parsing flags

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -37,8 +37,10 @@ func PrintConfig(config *viper.Viper, ignoreSettingsAtPrint ...[]string) {
 //
 // It automatically reads in a single config with name defined in "configName"
 // and ending with: .json, .toml, .yaml or .yml (in this sequence).
-func LoadConfigFile(config *viper.Viper, configDir string, configName string, bindFlags bool, loadDefault bool) error {
-	flag.Parse()
+func LoadConfigFile(config *viper.Viper, configDir string, configName string, bindFlags bool, loadDefault bool, dontParseFlags ...bool) error {
+	if len(dontParseFlags) == 0 || !dontParseFlags[0] {
+		flag.Parse()
+	}
 	if bindFlags {
 		err := config.BindPFlags(flag.CommandLine)
 		if err != nil {

--- a/parameter/parameter_test.go
+++ b/parameter/parameter_test.go
@@ -42,8 +42,7 @@ func TestFetchJSONConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	//
-	err := parameter.LoadConfigFile(config, confDir, configName, true, true)
+	err := parameter.LoadConfigFile(config, confDir, configName, true, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestFetchJSONConfigFlagConfigName(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +104,7 @@ func TestFetchYAMLConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parameter/parameter_test.go
+++ b/parameter/parameter_test.go
@@ -42,7 +42,7 @@ func TestFetchJSONConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err := parameter.LoadConfigFile(config, confDir, configName, true, true, true)
+	err := parameter.LoadConfigFile(config, confDir, configName, true, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFetchJSONConfigFlagConfigName(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false, true)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestFetchYAMLConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false, true)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parameter/parameter_test.go
+++ b/parameter/parameter_test.go
@@ -42,7 +42,7 @@ func TestFetchJSONConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err := parameter.LoadConfigFile(config, confDir, configName, true, true, false)
+	err := parameter.LoadConfigFile(config, confDir, configName, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestFetchJSONConfigFlagConfigName(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false, false)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestFetchYAMLConfig(t *testing.T) {
 	config := viper.New()
 	config.SetFs(memFS)
 
-	err = parameter.LoadConfigFile(config, confDir, configName, false, false, false)
+	err = parameter.LoadConfigFile(config, confDir, configName, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Adds an optional parameter to `LoadConfigFile` to skip parsing flags. This is useful if there are multiple invocations of `LoadConfigFile` since it currently causes `StringSlice` parameters to get duplicated by the amount of called `flag.Parse()`.