### PR TITLE
ObjectStorage "StoreOnCreation"

### DIFF
--- a/kvstore/mapdb/mapdb.go
+++ b/kvstore/mapdb/mapdb.go
@@ -62,12 +62,12 @@ func (db *MapDB) DeletePrefix(keyPrefix kvstore.KeyPrefix) error {
 }
 
 func (db *MapDB) Iterate(keyPrefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
-	db.m.iterate(append(db.realm, keyPrefix...), consumerFunc)
+	db.m.iterate(db.realm, keyPrefix, consumerFunc)
 	return nil
 }
 
 func (db *MapDB) IterateKeys(keyPrefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
-	db.m.iterateKeys(append(db.realm, keyPrefix...), consumerFunc)
+	db.m.iterateKeys(db.realm, keyPrefix, consumerFunc)
 	return nil
 }
 

--- a/kvstore/mapdb/synced_map.go
+++ b/kvstore/mapdb/synced_map.go
@@ -52,26 +52,26 @@ func (s *syncedKVMap) deletePrefix(keyPrefix []byte) {
 	}
 }
 
-func (s *syncedKVMap) iterate(keyPrefix []byte, consume func(key, value []byte) bool) {
+func (s *syncedKVMap) iterate(realm []byte, keyPrefix []byte, consume func(key, value []byte) bool) {
 	s.RLock()
 	defer s.RUnlock()
-	prefix := string(keyPrefix)
+	prefix := string(append(realm, keyPrefix...))
 	for key, value := range s.m {
 		if strings.HasPrefix(key, prefix) {
-			if !consume([]byte(key), append([]byte{}, value...)) {
+			if !consume([]byte(key)[len(realm):], append([]byte{}, value...)) {
 				break
 			}
 		}
 	}
 }
 
-func (s *syncedKVMap) iterateKeys(keyPrefix []byte, consume func(key []byte) bool) {
+func (s *syncedKVMap) iterateKeys(realm []byte, keyPrefix []byte, consume func(key []byte) bool) {
 	s.RLock()
 	defer s.RUnlock()
-	prefix := string(keyPrefix)
+	prefix := string(append(realm, keyPrefix...))
 	for key := range s.m {
 		if strings.HasPrefix(key, prefix) {
-			if !consume([]byte(key)) {
+			if !consume([]byte(key)[len(realm):]) {
 				break
 			}
 		}

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -96,8 +96,8 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 	storableObject := cachedObject.Get()
 
 	if typeutils.IsInterfaceNil(storableObject) {
+		// only blind delete if there are no consumers
 		if consumers == 0 && cachedObject.blindDelete.IsSet() {
-			// only blind delete if there are no consumers
 			if err := batchedMuts.Delete(cachedObject.key); err != nil {
 				panic(err)
 			}
@@ -107,8 +107,8 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 	}
 
 	if storableObject.IsDeleted() {
+		// only delete if there are no consumers
 		if consumers == 0 {
-			// only delete if there are no consumers
 			storableObject.SetModified(false)
 
 			if err := batchedMuts.Delete(cachedObject.key); err != nil {
@@ -119,8 +119,8 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 		return
 	}
 
+	// only store if there are no consumers anymore or the object should be stored on creation
 	if consumers != 0 && !cachedObject.objectStorage.options.storeOnCreation {
-		// only store if there are no consumers anymore or the object should be stored on creation
 		return
 	}
 

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -96,7 +96,11 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 	storableObject := cachedObject.Get()
 
 	if typeutils.IsInterfaceNil(storableObject) {
-		// delete even if there are consumers
+		if consumers != 0 {
+			// only blind delete if there are no consumers
+			return
+		}
+
 		if cachedObject.blindDelete.IsSet() {
 			if err := batchedMuts.Delete(cachedObject.key); err != nil {
 				panic(err)
@@ -106,7 +110,11 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 	}
 
 	if storableObject.IsDeleted() {
-		// delete even if there are consumers
+		if consumers != 0 {
+			// only delete if there are no consumers
+			return
+		}
+
 		storableObject.SetModified(false)
 
 		if err := batchedMuts.Delete(cachedObject.key); err != nil {

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -88,33 +88,47 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 		return
 	}
 
-	if consumers := atomic.LoadInt32(&(cachedObject.consumers)); consumers == 0 {
-		if storableObject := cachedObject.Get(); !typeutils.IsInterfaceNil(storableObject) {
-			if storableObject.IsDeleted() {
-				storableObject.SetModified(false)
+	consumers := atomic.LoadInt32(&(cachedObject.consumers))
+	if consumers < 0 {
+		panic("too many unregistered consumers of cached object")
+	}
 
-				if err := batchedMuts.Delete(cachedObject.key); err != nil {
-					panic(err)
-				}
-			} else if storableObject.ShouldPersist() && storableObject.IsModified() {
-				storableObject.SetModified(false)
+	storableObject := cachedObject.Get()
 
-				var marshaledValue []byte
-				if !objectStorage.options.keysOnly {
-					marshaledValue = storableObject.ObjectStorageValue()
-				}
-
-				if err := batchedMuts.Set(cachedObject.key, marshaledValue); err != nil {
-					panic(err)
-				}
-			}
-		} else if cachedObject.blindDelete.IsSet() {
+	if typeutils.IsInterfaceNil(storableObject) {
+		// delete even if there are consumers
+		if cachedObject.blindDelete.IsSet() {
 			if err := batchedMuts.Delete(cachedObject.key); err != nil {
 				panic(err)
 			}
 		}
-	} else if consumers < 0 {
-		panic("too many unregistered consumers of cached object")
+		return
+	}
+
+	if storableObject.IsDeleted() {
+		// delete even if there are consumers
+		storableObject.SetModified(false)
+
+		if err := batchedMuts.Delete(cachedObject.key); err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	if consumers == 0 || cachedObject.objectStorage.options.storeOnCreation {
+		// only store if there are no consumers anymore or the object should be stored on creation
+		if storableObject.ShouldPersist() && storableObject.IsModified() {
+			storableObject.SetModified(false)
+
+			var marshaledValue []byte
+			if !objectStorage.options.keysOnly {
+				marshaledValue = storableObject.ObjectStorageValue()
+			}
+
+			if err := batchedMuts.Set(cachedObject.key, marshaledValue); err != nil {
+				panic(err)
+			}
+		}
 	}
 }
 

--- a/objectstorage/batch_writer.go
+++ b/objectstorage/batch_writer.go
@@ -96,7 +96,7 @@ func (bw *BatchedWriter) writeObject(batchedMuts kvstore.BatchedMutations, cache
 				if err := batchedMuts.Delete(cachedObject.key); err != nil {
 					panic(err)
 				}
-			} else if storableObject.PersistenceEnabled() && storableObject.IsModified() {
+			} else if storableObject.ShouldPersist() && storableObject.IsModified() {
 				storableObject.SetModified(false)
 
 				var marshaledValue []byte

--- a/objectstorage/cached_object.go
+++ b/objectstorage/cached_object.go
@@ -157,7 +157,7 @@ func (cachedObject *CachedObjectImpl) updateResult(object StorableObject) {
 		cachedObject.blindDelete.UnSet()
 	} else {
 		cachedObject.value.SetModified(object.IsModified())
-		cachedObject.value.Persist(object.PersistenceEnabled())
+		cachedObject.value.Persist(object.ShouldPersist())
 		cachedObject.value.Delete(object.IsDeleted())
 		cachedObject.value.Update(object)
 		cachedObject.blindDelete.UnSet()

--- a/objectstorage/cached_object.go
+++ b/objectstorage/cached_object.go
@@ -187,8 +187,6 @@ func (cachedObject *CachedObjectImpl) updateEmptyResult(update interface{}) (upd
 				cachedObject.blindDelete.UnSet()
 			}
 
-			cachedObject.storeOnCreation()
-
 			updated = true
 		}
 		cachedObject.valueMutex.Unlock()

--- a/objectstorage/cached_object.go
+++ b/objectstorage/cached_object.go
@@ -139,6 +139,13 @@ func (cachedObject *CachedObjectImpl) Exists() bool {
 	return !typeutils.IsInterfaceNil(storableObject) && !storableObject.IsDeleted()
 }
 
+func (cachedObject *CachedObjectImpl) storeOnCreation() {
+	if cachedObject.objectStorage.options.persistenceEnabled && cachedObject.objectStorage.options.storeOnCreation && !typeutils.IsInterfaceNil(cachedObject.value) && cachedObject.value.IsModified() && cachedObject.value.ShouldPersist() {
+		// store the object immediately
+		cachedObject.objectStorage.options.batchedWriterInstance.batchWrite(cachedObject)
+	}
+}
+
 func (cachedObject *CachedObjectImpl) publishResult(result StorableObject) bool {
 	if atomic.AddInt32(&(cachedObject.published), 1) == 1 {
 		cachedObject.value = result
@@ -179,6 +186,8 @@ func (cachedObject *CachedObjectImpl) updateEmptyResult(update interface{}) (upd
 				cachedObject.value = updater()
 				cachedObject.blindDelete.UnSet()
 			}
+
+			cachedObject.storeOnCreation()
 
 			updated = true
 		}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -157,6 +157,7 @@ func (objectStorage *ObjectStorage) ComputeIfAbsent(key []byte, remappingFunctio
 			cachedObject.publishResult(loadedObject)
 		} else {
 			cachedObject.publishResult(remappingFunction(key))
+			cachedObject.storeOnCreation()
 		}
 	}
 
@@ -300,6 +301,7 @@ func (objectStorage *ObjectStorage) StoreIfAbsent(object StorableObject) (result
 	object.Persist()
 	object.SetModified()
 	existingCachedObject.publishResult(object)
+	existingCachedObject.storeOnCreation()
 
 	// construct result
 	stored = true
@@ -777,6 +779,7 @@ func (objectStorage *ObjectStorage) putObjectInCache(object StorableObject) Cach
 
 	// publish the result to the cached object and return
 	cachedObject.publishResult(object)
+	cachedObject.storeOnCreation()
 	return wrapCachedObject(cachedObject, 0)
 }
 

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -146,9 +146,11 @@ func (objectStorage *ObjectStorage) ComputeIfAbsent(key []byte, remappingFunctio
 	if cacheHit {
 		cachedObject.wg.Wait()
 
-		cachedObject.updateEmptyResult(func() StorableObject {
+		if cachedObject.updateEmptyResult(func() StorableObject {
 			return remappingFunction(key)
-		})
+		}) {
+			cachedObject.storeOnCreation()
+		}
 	} else {
 		loadedObject := objectStorage.LoadObjectFromStore(key)
 		if !typeutils.IsInterfaceNil(loadedObject) {
@@ -669,6 +671,8 @@ func (objectStorage *ObjectStorage) updateEmptyCachedObject(cachedObject *Cached
 
 		return
 	}
+
+	cachedObject.storeOnCreation()
 
 	// construct result
 	result = wrapCachedObject(cachedObject, 0)

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -131,7 +131,7 @@ func (objectStorage *ObjectStorage) Contains(key []byte) (result bool) {
 
 		cachedObject.Release()
 	} else {
-		result = objectStorage.objectExistsInStore(key)
+		result = objectStorage.ObjectExistsInStore(key)
 	}
 
 	return
@@ -200,7 +200,7 @@ func (objectStorage *ObjectStorage) DeleteIfPresent(key []byte) bool {
 	cachedObject.publishResult(nil)
 	cachedObject.Release(true)
 
-	if objectStorage.objectExistsInStore(key) {
+	if objectStorage.ObjectExistsInStore(key) {
 		cachedObject.blindDelete.Set()
 
 		return true
@@ -273,7 +273,7 @@ func (objectStorage *ObjectStorage) StoreIfAbsent(object StorableObject) (result
 	}
 
 	// abort if the object already exists in our database
-	objectExists := objectStorage.objectExistsInStore(key)
+	objectExists := objectStorage.ObjectExistsInStore(key)
 	if objectExists {
 		return
 	}
@@ -856,7 +856,7 @@ func (objectStorage *ObjectStorage) DeleteEntriesFromStore(keys [][]byte) {
 	}
 }
 
-func (objectStorage *ObjectStorage) objectExistsInStore(key []byte) bool {
+func (objectStorage *ObjectStorage) ObjectExistsInStore(key []byte) bool {
 	if !objectStorage.options.persistenceEnabled {
 		return false
 	}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -210,6 +210,7 @@ func (objectStorage *ObjectStorage) DeleteIfPresent(key []byte) bool {
 }
 
 // Performs a "blind delete", where we do not check the objects existence.
+// blindDelete is used to delete without accessing the value log.
 func (objectStorage *ObjectStorage) Delete(key []byte) {
 	if objectStorage.shutdown.IsSet() {
 		panic("trying to access shutdown object storage")

--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -10,6 +10,7 @@ type Options struct {
 	keyPartitions         []int
 	persistenceEnabled    bool
 	keysOnly              bool
+	storeOnCreation       bool
 	leakDetectionOptions  *LeakDetectionOptions
 	leakDetectionWrapper  func(cachedObject *CachedObjectImpl) LeakDetectionWrapper
 }
@@ -58,6 +59,12 @@ func PersistenceEnabled(persistenceEnabled bool) Option {
 func KeysOnly(keysOnly bool) Option {
 	return func(args *Options) {
 		args.keysOnly = keysOnly
+	}
+}
+
+func StoreOnCreation(store bool) Option {
+	return func(args *Options) {
+		args.storeOnCreation = store
 	}
 }
 

--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -62,6 +62,7 @@ func KeysOnly(keysOnly bool) Option {
 	}
 }
 
+// StoreOnCreation writes an object directly to the persistence layer on creation.
 func StoreOnCreation(store bool) Option {
 	return func(args *Options) {
 		args.storeOnCreation = store

--- a/objectstorage/storable_object.go
+++ b/objectstorage/storable_object.go
@@ -21,7 +21,7 @@ type StorableObject interface {
 	Persist(enabled ...bool)
 
 	// Returns "true" if this object is going to be persisted.
-	PersistenceEnabled() bool
+	ShouldPersist() bool
 
 	// Updates the object with the values of another object "in place" (so it should use a pointer receiver)
 	Update(other StorableObject)

--- a/objectstorage/storable_object_flags.go
+++ b/objectstorage/storable_object_flags.go
@@ -50,6 +50,7 @@ func (testObject *StorableObjectFlags) Persist(persist ...bool) {
 	}
 }
 
+// ShouldPersist returns "true" if this object is going to be persisted.
 func (testObject *StorableObjectFlags) ShouldPersist() bool {
 	return testObject.persist.IsSet()
 }

--- a/objectstorage/storable_object_flags.go
+++ b/objectstorage/storable_object_flags.go
@@ -50,6 +50,6 @@ func (testObject *StorableObjectFlags) Persist(persist ...bool) {
 	}
 }
 
-func (testObject *StorableObjectFlags) PersistenceEnabled() bool {
+func (testObject *StorableObjectFlags) ShouldPersist() bool {
 	return testObject.persist.IsSet()
 }

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -177,13 +177,13 @@ func TestStorableObjectFlags(t *testing.T) {
 	testObject.Delete(true)
 	assert.Equal(t, true, testObject.IsDeleted())
 
-	assert.Equal(t, false, testObject.PersistenceEnabled())
+	assert.Equal(t, false, testObject.ShouldPersist())
 	testObject.Persist()
-	assert.Equal(t, true, testObject.PersistenceEnabled())
+	assert.Equal(t, true, testObject.ShouldPersist())
 	testObject.Persist(false)
-	assert.Equal(t, false, testObject.PersistenceEnabled())
+	assert.Equal(t, false, testObject.ShouldPersist())
 	testObject.Persist(true)
-	assert.Equal(t, true, testObject.PersistenceEnabled())
+	assert.Equal(t, true, testObject.ShouldPersist())
 }
 
 func BenchmarkStore(b *testing.B) {

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -398,7 +398,7 @@ func TestConcurrency(t *testing.T) {
 func TestStoreIfAbsentTriggersOnce(t *testing.T) {
 	for k := 0; k < 10; k++ {
 		// define test parameters
-		objectCount := 1000
+		objectCount := 200
 		workerCount := 50
 
 		// initialize object storage


### PR DESCRIPTION
# Description of change

This PR adds an option to ObjectStorage to persist objects directly to the persistence layer on creation of the object.
That can be used for objects that are never modified and should be stored immediately.

It also fixes a bug in the iteration of syncedKVMap.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a testcase to object storage.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
