### PR TITLE
Feat/add websockethub filter

### DIFF
--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -65,7 +65,7 @@ type Client struct {
 	sendChan chan interface{}
 
 	// channel of inbound messages.
-	// this will be created by the user if receiving messages needed.
+	// this will be created by the user if receiving messages is needed.
 	ReceiveChan chan *WebsocketMsg
 
 	// onConnect gets called when the client was registered

--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -35,6 +35,9 @@ type Client struct {
 
 	// onConnect gets called when the client was registered
 	onConnect func(*Client)
+
+	// FilterCallback is used to filter messages to clients on BroadcastMsg
+	FilterCallback func(c *Client, data interface{}) bool
 }
 
 // checkPong checks if the client is still available and answers to the ping messages

--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -20,6 +20,37 @@ const (
 	maxMessageSize = 125 // 125 is the maximum payload size for ping pongs
 )
 
+// The message types are defined in RFC 6455, section 11.8.
+const (
+	// TextMessage denotes a text data message. The text message payload is
+	// interpreted as UTF-8 encoded text data.
+	TextMessage = 1
+
+	// BinaryMessage denotes a binary data message.
+	BinaryMessage = 2
+
+	// CloseMessage denotes a close control message. The optional message
+	// payload contains a numeric code and text. Use the FormatCloseMessage
+	// function to format a close message payload.
+	CloseMessage = 8
+
+	// PingMessage denotes a ping control message. The optional message payload
+	// is UTF-8 encoded text.
+	PingMessage = 9
+
+	// PongMessage denotes a pong control message. The optional message payload
+	// is UTF-8 encoded text.
+	PongMessage = 10
+)
+
+// WebsocketMsg is a message received via websocket.
+type WebsocketMsg struct {
+	// MsgType is the type of the message based on RFC 6455.
+	MsgType int
+	// Data is the received data of the message.
+	Data []byte
+}
+
 // Client is a middleman between the node and the websocket connection.
 type Client struct {
 	hub *Hub
@@ -32,6 +63,10 @@ type Client struct {
 
 	// buffered channel of outbound messages.
 	sendChan chan interface{}
+
+	// channel of inbound messages.
+	// this will be created by the user if receiving messages needed.
+	ReceiveChan chan *WebsocketMsg
 
 	// onConnect gets called when the client was registered
 	onConnect func(*Client)
@@ -56,12 +91,27 @@ func (c *Client) checkPong() {
 	c.conn.SetPongHandler(func(string) error { c.conn.SetReadDeadline(time.Now().Add(pongWait)); return nil })
 
 	for {
-		_, _, err := c.conn.ReadMessage()
+		msgType, data, err := c.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				c.hub.logger.Warnf("Websocket error: %v", err)
 			}
 			return
+		}
+
+		if c.ReceiveChan != nil {
+			select {
+
+			case <-c.hub.shutdownSignal:
+				return
+
+			case <-c.ExitSignal:
+				// the Hub closed the channel.
+				return
+
+			case c.ReceiveChan <- &WebsocketMsg{MsgType: msgType, Data: data}:
+				// send the received message to the user.
+			}
 		}
 	}
 }

--- a/websockethub/hub.go
+++ b/websockethub/hub.go
@@ -112,6 +112,13 @@ func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 		case message := <-h.broadcast:
 			if message.dontDrop {
 				for client := range h.clients {
+					if client.FilterCallback != nil {
+						if !client.FilterCallback(client, message.data) {
+							// do not broadcast the message to this client
+							continue
+						}
+					}
+
 					select {
 					case <-shutdownSignal:
 					case <-client.ExitSignal:
@@ -121,6 +128,13 @@ func (h *Hub) Run(shutdownSignal <-chan struct{}) {
 				continue
 			}
 			for client := range h.clients {
+				if client.FilterCallback != nil {
+					if !client.FilterCallback(client, message.data) {
+						// do not broadcast the message to this client
+						continue
+					}
+				}
+
 				select {
 				case <-shutdownSignal:
 				case <-client.ExitSignal:

--- a/websockethub/hub.go
+++ b/websockethub/hub.go
@@ -48,8 +48,8 @@ func NewHub(logger *logger.Logger, upgrader *websocket.Upgrader, broadcastQueueS
 		clientSendChannelSize: clientSendChannelSize,
 		clients:               make(map[*Client]struct{}),
 		broadcast:             make(chan *message, broadcastQueueSize),
-		register:              make(chan *Client),
-		unregister:            make(chan *Client),
+		register:              make(chan *Client, 1),
+		unregister:            make(chan *Client, 1),
 	}
 }
 


### PR DESCRIPTION
# Description of change

This PR adds the possibility to filter messages that should be broadcasted to the clients.
User can also receive messages from clients now if they need to.

It also fixes a deadlock and some race conditions.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Tested with hornet dashboard

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
