### PR TITLE
Daemon early return

### DIFF
--- a/bitmask/bitmask.go
+++ b/bitmask/bitmask.go
@@ -31,3 +31,11 @@ func (bitmask BitMask) HasBit(pos uint) bool {
 func (bitmask BitMask) HasBits(bits BitMask) bool {
 	return bitmask&(bits) > 0
 }
+
+// ModifyBit sets or clears the bit at the given position, given the supplied state bool.
+func (bitmask BitMask) ModifyBit(pos uint, state bool) BitMask {
+	if state {
+		return bitmask.SetBit(pos)
+	}
+	return bitmask.ClearBit(pos)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -125,12 +125,13 @@ func (d *OrderedDaemon) runBackgroundWorker(name string, backgroundWorker Worker
 // Use order to define in which shutdown order this particular
 // background worker is shut down (higher = earlier).
 func (d *OrderedDaemon) BackgroundWorker(name string, handler WorkerFunc, order ...int) error {
-	d.lock.Lock()
-	defer d.lock.Unlock()
 
 	if d.IsStopped() {
 		return ErrDaemonAlreadyStopped
 	}
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
 	exWorker, has := d.workers[name]
 	if has {
@@ -186,13 +187,13 @@ func (d *OrderedDaemon) BackgroundWorker(name string, handler WorkerFunc, order 
 
 // Start starts the daemon.
 func (d *OrderedDaemon) Start() {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-
 	// do not allow restarts
 	if d.IsStopped() {
 		return
 	}
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
 
 	if !d.IsRunning() {
 		d.running.Set()


### PR DESCRIPTION
# Description of change

This PR changes the behavior of starting a new "BackgroundWorker".
If the daemon is already shutting down (waiting in "stopWorkers"), it doesn't wait to acquire the lock, but does an early return if the IsStopped flag is already set. This will prevent deadlocks on application level (like a shutdown deadlock in HORNET if a peer is handshaked and therefore starts a new BackgroundWorker exactly in the moment the shutdown signal is received.). Checking the IsStopped flag is thread safe because it is an atomicBool.
   
It also adds ModifyBit what got removed by Hans at refactoring for whatever reason.


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Daemon tests still pass.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
