### PR TITLE
Do not send messages if websockethub was already shut down

### DIFF
--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -203,6 +203,11 @@ func (c *Client) writePump() {
 
 // Send sends a message to the client
 func (c *Client) Send(msg interface{}, dontDrop ...bool) {
+	if c.hub.shutdownFlag {
+		// hub was already shut down
+		return
+	}
+
 	if len(dontDrop) > 0 && dontDrop[0] {
 		select {
 		case <-c.hub.shutdownSignal:


### PR DESCRIPTION
# Description of change

If someone tries to send a message to a client directly while hub is shutting down, it could panic.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
