### PR TITLE
Allow providing config path with file extension

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -36,7 +37,7 @@ func PrintConfig(config *viper.Viper, ignoreSettingsAtPrint ...[]string) {
 // into a given viper instance.
 //
 // It automatically reads in a single config with name defined in "configName"
-// and ending with: .json, .toml, .yaml or .yml (in this sequence).
+// and ending with: .json, .toml, .yaml or .yml (in this sequence) or the file extension in configName if available.
 func LoadConfigFile(config *viper.Viper, configDir string, configName string, bindFlags bool, loadDefault bool, dontParseFlags ...bool) error {
 	if len(dontParseFlags) == 0 || !dontParseFlags[0] {
 		flag.Parse()
@@ -48,18 +49,53 @@ func LoadConfigFile(config *viper.Viper, configDir string, configName string, bi
 		}
 	}
 
+	// We want to check whether the extension is valid and supported.
+	// When a file called config.default.json exists and we get config.default passed that is not a valid extension
+	// and we don't want to try to read a file with that name.
+	supportedExtension := isExtensionSupported(filepath.Ext(configName))
+
 	// adjust viper to wanted locations
-	config.SetConfigName(configName)
-	config.AddConfigPath(configDir)
+	if supportedExtension {
+		// If the file has an valid extension use the file directly
+		file := filepath.Join(configDir, configName)
+		config.SetConfigFile(file)
+	} else {
+		// No vlaid extension available, set the base config name and viper will try .json, .yaml, etc.
+		config.SetConfigName(configName)
+		config.AddConfigPath(configDir)
+	}
 
 	// read in the config file (whatever it finds)
 	if err := config.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok && loadDefault {
-			log.Printf("No config file found via '%s/%s.[json,toml,yaml,yml]'. Loading default settings.", configDir, configName)
+			if supportedExtension {
+				log.Printf("No config file found via '%s/%s'. Loading default settings.", configDir, configName)
+			} else {
+				log.Printf("No config file found via '%s/%s.[json,toml,yaml,yml]'. Loading default settings.", configDir, configName)
+			}
 		} else {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// isExtensionSupported checks whether the passed extension is supported by viper.
+// Extension passed must have a preceding dot, e.g. ".json"
+func isExtensionSupported(extension string) bool {
+	if len(extension) == 0 {
+		// Empty string => no extension available
+		return false
+	}
+
+	// The extension is passed with the dot in front which we don't want for checking
+	extensionWithoutDot := extension[1:]
+
+	for _, ext := range viper.SupportedExts {
+		if ext == extensionWithoutDot {
+			return true
+		}
+	}
+	return false
 }

--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -60,7 +60,7 @@ func LoadConfigFile(config *viper.Viper, configDir string, configName string, bi
 		file := filepath.Join(configDir, configName)
 		config.SetConfigFile(file)
 	} else {
-		// No vlaid extension available, set the base config name and viper will try .json, .yaml, etc.
+		// No valid extension available, set the base config name and viper will try .json, .yaml, etc.
 		config.SetConfigName(configName)
 		config.AddConfigPath(configDir)
 	}

--- a/parameter/parameter_test.go
+++ b/parameter/parameter_test.go
@@ -62,11 +62,11 @@ func TestFetchJSONConfigFlagConfigName(t *testing.T) {
 	}
 	defer memFS.Remove(filename)
 
-	if _, err := jsonConfFile.WriteString(`{"b": 321}`); err != nil {
+	if _, err = jsonConfFile.WriteString(`{"b": 321}`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := jsonConfFile.Close(); err != nil {
+	if err = jsonConfFile.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,11 +124,11 @@ func TestFetchJSONConfigWithFileExtension(t *testing.T) {
 	}
 	defer memFS.Remove(filename)
 
-	if _, err := jsonConfFile.WriteString(`{"b": 321}`); err != nil {
+	if _, err = jsonConfFile.WriteString(`{"b": 321}`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := jsonConfFile.Close(); err != nil {
+	if err = jsonConfFile.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/parameter/parameter_test.go
+++ b/parameter/parameter_test.go
@@ -114,3 +114,34 @@ func TestFetchYAMLConfig(t *testing.T) {
 		t.Fatalf("expected read config value to be %d, but was %d", 321, val)
 	}
 }
+
+func TestFetchJSONConfigWithFileExtension(t *testing.T) {
+	filename := fmt.Sprintf("%s/%s.json", confDir, configName)
+
+	jsonConfFile, err := memFS.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memFS.Remove(filename)
+
+	if _, err := jsonConfFile.WriteString(`{"b": 321}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := jsonConfFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	config := viper.New()
+	config.SetFs(memFS)
+
+	err = parameter.LoadConfigFile(config, confDir, configName+".json", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val := config.GetInt("b")
+	if val != 321 {
+		t.Fatalf("expected read config value to be %d, but was %d", 321, val)
+	}
+}


### PR DESCRIPTION
# Description of change

Some people on discord, including me, have provided the file path with the extension during the Chrysalis part 1 tests on Comnet because it is normal to provide a full file path with extension and also comes up when trying to tab-auto-complete.

This PR allows config paths to optionally have the file extension.
E.g. 
```shell
$ ./hornet -c config_comnet.json
```

Providing just the file name without the extension is still perfectly fine after this change.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Added a unit test for it
- Building Hornet and Goshimmer with this patch and manually testing configs with and without file extensions

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
