### PR TITLE
Do not bind all CommandLine flags

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -38,12 +38,13 @@ func PrintConfig(config *viper.Viper, ignoreSettingsAtPrint ...[]string) {
 //
 // It automatically reads in a single config with name defined in "configName"
 // and ending with: .json, .toml, .yaml or .yml (in this sequence) or the file extension in configName if available.
-func LoadConfigFile(config *viper.Viper, configDir string, configName string, bindFlags bool, loadDefault bool, dontParseFlags ...bool) error {
+func LoadConfigFile(config *viper.Viper, configDir string, configName string, bindFlagSet *flag.FlagSet, loadDefault bool, dontParseFlags ...bool) error {
 	if len(dontParseFlags) == 0 || !dontParseFlags[0] {
 		flag.Parse()
 	}
-	if bindFlags {
-		err := config.BindPFlags(flag.CommandLine)
+
+	if bindFlagSet != nil {
+		err := config.BindPFlags(bindFlagSet)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description of change

This PR changes the behavior of LoadConfigFile. Its a breaking change.
Instead of passing a bool value which indicates to bind all flags to the config, a FlagSet is passed now.
This allows to bind different flagsets to different config files.

To get the old behavior, just pass `nil` instead of `false` and `flag.CommandLine` instead of `true`

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

I added a testcase.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
