### PR TITLE
Feat/factory receives data

### DIFF
--- a/objectstorage/factory.go
+++ b/objectstorage/factory.go
@@ -20,6 +20,6 @@ func NewFactory(store kvstore.KVStore, packagePrefix byte) *Factory {
 
 // New creates a new ObjectStorage with the given parameters. It combines the store specific prefix with the package
 // prefix, to create a unique realm for the KVStore of the ObjectStorage.
-func (factory *Factory) New(storagePrefix byte, objectFactory StorableObjectFromKey, optionalOptions ...Option) *ObjectStorage {
+func (factory *Factory) New(storagePrefix byte, objectFactory StorableObjectFactory, optionalOptions ...Option) *ObjectStorage {
 	return New(factory.store.WithRealm([]byte{factory.packagePrefix, storagePrefix}), objectFactory, optionalOptions...)
 }

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -358,7 +358,6 @@ func (objectStorage *ObjectStorage) ForEach(consumer func(key []byte, cachedObje
 	}
 
 	consumeFunc := func(key kvstore.Key, value kvstore.Value) bool {
-
 		if _, elementSeen := seenElements[string(key)]; elementSeen {
 			return true
 		}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -15,7 +15,7 @@ import (
 // ObjectStorage is a manual cache which keeps objects as long as consumers are using it.
 type ObjectStorage struct {
 	store              kvstore.KVStore
-	objectFactory      StorableObjectFromKey
+	objectFactory      StorableObjectFactory
 	cachedObjects      map[string]interface{}
 	cacheMutex         syncutils.RWMutex
 	options            *Options
@@ -30,7 +30,7 @@ type ObjectStorage struct {
 
 type ConsumerFunc = func(key []byte, cachedObject *CachedObjectImpl) bool
 
-func New(store kvstore.KVStore, objectFactory StorableObjectFromKey, optionalOptions ...Option) *ObjectStorage {
+func New(store kvstore.KVStore, objectFactory StorableObjectFactory, optionalOptions ...Option) *ObjectStorage {
 	result := &ObjectStorage{
 		store:             store,
 		objectFactory:     objectFactory,
@@ -369,7 +369,7 @@ func (objectStorage *ObjectStorage) ForEach(consumer func(key []byte, cachedObje
 
 			if objectStorage.options.keysOnly {
 				var err error
-				if storableObject, _, err = objectStorage.objectFactory(key); err != nil {
+				if storableObject, _, err = objectStorage.objectFactory(key, nil); err != nil {
 					return true
 				}
 			} else {
@@ -808,7 +808,6 @@ func (objectStorage *ObjectStorage) LoadObjectFromStore(key []byte) StorableObje
 	}
 
 	if objectStorage.options.keysOnly {
-
 		contains, err := objectStorage.store.Has(key)
 		if err != nil {
 			// No need to check for kvstore.ErrKeyNotFound here
@@ -819,10 +818,11 @@ func (objectStorage *ObjectStorage) LoadObjectFromStore(key []byte) StorableObje
 			return nil
 		}
 
-		object, _, err := objectStorage.objectFactory(key)
+		object, _, err := objectStorage.objectFactory(key, nil)
 		if err != nil {
 			panic(err)
 		}
+
 		return object
 	}
 
@@ -832,6 +832,7 @@ func (objectStorage *ObjectStorage) LoadObjectFromStore(key []byte) StorableObje
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil
 		}
+
 		panic(err)
 	}
 
@@ -888,7 +889,7 @@ func (objectStorage *ObjectStorage) ObjectExistsInStore(key []byte) bool {
 }
 
 func (objectStorage *ObjectStorage) unmarshalObject(key []byte, data []byte) StorableObject {
-	object, _, err := objectStorage.objectFactory(key)
+	object, _, err := objectStorage.objectFactory(key, data)
 	if err != nil {
 		panic(err)
 	}
@@ -1088,4 +1089,4 @@ func (objectStorage *ObjectStorage) forEachCachedElementWithPrefix(consumer Cons
 	return seenElements
 }
 
-type StorableObjectFromKey func(key []byte) (result StorableObject, consumedBytes int, err error)
+type StorableObjectFactory func(key []byte, data []byte) (result StorableObject, consumedBytes int, err error)

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -30,6 +30,7 @@ type ObjectStorage struct {
 
 type ConsumerFunc = func(key []byte, cachedObject *CachedObjectImpl) bool
 
+// New is the constructor for the ObjectStorage.
 func New(store kvstore.KVStore, objectFactory StorableObjectFactory, optionalOptions ...Option) *ObjectStorage {
 	result := &ObjectStorage{
 		store:             store,
@@ -1088,4 +1089,9 @@ func (objectStorage *ObjectStorage) forEachCachedElementWithPrefix(consumer Cons
 	return seenElements
 }
 
+// StorableObjectFactory is used to address the factory method that generically creates StorableObjects. It receives the
+// key and the serialized data of the object and returns an "empty" StorableObject that just has its key set. The object
+// is then fully unmarshalled by the ObjectStorage which calls the UnmarshalObjectStorageValue with the data. The data
+// is anyway provided in this method already to allow the dynamic creation of different object types depending on the
+// stored data.
 type StorableObjectFactory func(key []byte, data []byte) (result StorableObject, consumedBytes int, err error)

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -58,7 +58,7 @@ func testStorage(t require.TestingT, realm []byte) kvstore.KVStore {
 	panic("unknown database")
 }
 
-func testObjectFactory(key []byte) (objectstorage.StorableObject, int, error) {
+func testObjectFactory(key []byte, _ []byte) (objectstorage.StorableObject, int, error) {
 	return &testObject{id: key}, len(key), nil
 }
 


### PR DESCRIPTION
# Description of change

Since Chrysalis adds the needs for storing generic objects in the same storage (i.e. different types of Outputs), where the type is stored as the first bytes of the serialized object, the factory method needs to have access to the serialized data of the object.