### PR TITLE
Fix panic if ignored setting doesn't exist

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -17,13 +17,20 @@ func PrintConfig(config *viper.Viper, ignoreSettingsAtPrint ...[]string) {
 	if len(ignoreSettingsAtPrint) > 0 {
 		for _, ignoredSetting := range ignoreSettingsAtPrint[0] {
 			parameter := settings
-			ignoredSettingSplitted := strings.Split(ignoredSetting, ".")
+			ignoredSettingSplitted := strings.Split(strings.ToLower(ignoredSetting), ".")
 			for lvl, parameterName := range ignoredSettingSplitted {
 				if lvl == len(ignoredSettingSplitted)-1 {
 					delete(parameter, parameterName)
 					continue
 				}
-				parameter = parameter[parameterName].(map[string]interface{})
+
+				par, exists := parameter[parameterName]
+				if !exists {
+					// parameter not found in settings
+					break
+				}
+
+				parameter = par.(map[string]interface{})
 			}
 		}
 	}


### PR DESCRIPTION
# Description of change

This PR fixes a bug in PrintConfig which lead to a panic.
If we wanted to hide a setting and it couldn't be found, the code paniced.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested in hornet.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
