### PR TITLE
RandomUniqueEntries method for RandomMap

### DIFF
--- a/datastructure/randommap/random_map_test.go
+++ b/datastructure/randommap/random_map_test.go
@@ -1,0 +1,42 @@
+package randommap
+
+import (
+	"testing"
+
+	"github.com/iotaledger/hive.go/datastructure/set"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomMap_RandomUniqueEntries(t *testing.T) {
+	testMap := New()
+	// key and value are the same for the sake of the test
+	keysAndValues := []string{"a", "b", "c", "d"}
+	// fill randomMap
+	for _, keyValue := range keysAndValues {
+		testMap.Set(keyValue, keyValue)
+	}
+
+	var emptyResult []interface{}
+
+	result := testMap.RandomUniqueEntries(0)
+	assert.Equal(t, emptyResult, result)
+
+	result = testMap.RandomUniqueEntries(-5)
+	assert.Equal(t, emptyResult, result)
+
+	result = testMap.RandomUniqueEntries(2)
+	assert.Equal(t, 2, len(result))
+	assert.True(t, containsUniqueElements(result))
+
+	result = testMap.RandomUniqueEntries(100)
+	assert.Equal(t, 4, len(result))
+	assert.True(t, containsUniqueElements(result))
+}
+
+func containsUniqueElements(list []interface{}) bool {
+	elementSet := set.New(false)
+	for _, element := range list {
+		elementSet.Add(element)
+	}
+	return elementSet.Size() == len(list)
+}


### PR DESCRIPTION
Next to the already existing `RandomEntry` method, that gets one random entry from the map, `RandomUniqueEntries` gets `n` number of unique entries. If n is bigger than the size of the map, all entries are returned.

Needed for refactored tip selection in GoShimmer.

