### PR TITLE
Add ContextStopped to Daemon interface

### DIFF
--- a/daemon/interfaces.go
+++ b/daemon/interfaces.go
@@ -1,5 +1,9 @@
 package daemon
 
+import (
+	"context"
+)
+
 // WorkerFunc is the function to run a worker accepting its shutdown signal handler channel.
 type WorkerFunc = func(shutdownSignal <-chan struct{})
 
@@ -33,4 +37,7 @@ type Daemon interface {
 
 	// IsStopped checks whether the daemon was stopped.
 	IsStopped() bool
+
+	// ContextStopped returns a context that is done when the deamon is stopped.
+	ContextStopped() context.Context
 }


### PR DESCRIPTION
# Description of change

This PR adds a function to get a context that is done when the daemon is stopped to the daemon interface.
It can be used to determine if the node was shutdown.

I have seen this way to do that in go-libp2p.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a test case.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
