### PR TITLE
chore: Use Go 1.15.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-          go-version: 1.14.4
+          go-version: 1.15.5
     - name: Run tests
       run: go test ./...


### PR DESCRIPTION
# Description of change

Previous versions of Go have an issue where a specially crafted input to a math operation can cause a panic ([CVE-2020-28362](https://security.archlinux.org/CVE-2020-28362)). This bug is fixed in Go 1.15.5.

## Type of change

- Chore

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code