### PR TITLE
feat: Add pebbleDB testutils

### DIFF
--- a/testutil/pebbledb.go
+++ b/testutil/pebbledb.go
@@ -1,0 +1,72 @@
+package testutil
+
+import (
+	"strconv"
+	"testing"
+
+	pebbledb "github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/bloom"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/pebble"
+)
+
+// PebbleDB creates a temporary PebbleKVStore that automatically gets cleaned up when the test finishes.
+func PebbleDB(t *testing.T) (kvstore.KVStore, error) {
+	dir, err := TempDir(t)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := pebbledb.NewCache(1 << 30)
+	defer cache.Unref()
+
+	opts := &pebbledb.Options{
+		Cache:                       cache,
+		DisableWAL:                  false,
+		L0CompactionThreshold:       2,
+		L0StopWritesThreshold:       1000,
+		LBaseMaxBytes:               64 << 20, // 64 MB
+		Levels:                      make([]pebbledb.LevelOptions, 7),
+		MaxConcurrentCompactions:    3,
+		MaxOpenFiles:                16384,
+		MemTableSize:                64 << 20,
+		MemTableStopWritesThreshold: 4,
+	}
+	opts.Experimental.L0SublevelCompactions = true
+
+	for i := 0; i < len(opts.Levels); i++ {
+		l := &opts.Levels[i]
+		l.BlockSize = 32 << 10       // 32 KB
+		l.IndexBlockSize = 256 << 10 // 256 KB
+		l.FilterPolicy = bloom.FilterPolicy(10)
+		l.FilterType = pebbledb.TableFilter
+		if i > 0 {
+			l.TargetFileSize = opts.Levels[i-1].TargetFileSize * 2
+		}
+		l.EnsureDefaults()
+	}
+	opts.Levels[6].FilterPolicy = nil
+	opts.Experimental.FlushSplitBytes = opts.Levels[0].TargetFileSize
+
+	opts.EnsureDefaults()
+
+	db, err := pebble.CreateDB(dir, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Cleanup(func() {
+		err := db.Close()
+		if err != nil {
+			t.Errorf("Closing database: %v", err)
+		}
+	})
+
+	databaseCounterMutex.Lock()
+	databaseCounter[t.Name()]++
+	counter := databaseCounter[t.Name()]
+	databaseCounterMutex.Unlock()
+
+	return pebble.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter))), nil
+}


### PR DESCRIPTION
# Description of change
Add pebble DB in testutils that creates a temporary pebble DB for the GoShimmer unit test.

## Type of change
feature

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
