### PR TITLE
Feat: Refactored ticker to support more flexible shutdown behavior

### DIFF
--- a/timeutil/ticker.go
+++ b/timeutil/ticker.go
@@ -1,21 +1,79 @@
 package timeutil
 
 import (
+	"sync"
 	"time"
 )
 
-// Ticker calls the handler with a period specified by the duration argument.
-// It returns when the done channel is closed.
-func Ticker(handler func(), interval time.Duration, done <-chan struct{}) {
-	ticker := time.NewTicker(interval)
+// Ticker is task that gets executed repeatedly. It adjusts the intervals or drops ticks to make up for slow executions.
+type Ticker struct {
+	handler                func()
+	interval               time.Duration
+	internalShutdownSignal chan struct{}
+	externalShutdownSignal <-chan struct{}
+	handlerDone            sync.WaitGroup
+	shutdownOnce           sync.Once
+}
+
+// NewTicker creates a new Ticker from the given details. The interval must be greater than zero; if not, NewTicker will
+// panic.
+func NewTicker(handler func(), interval time.Duration, optionalExternalShutdownSignal ...<-chan struct{}) (ticker *Ticker) {
+	ticker = &Ticker{
+		handler:                handler,
+		interval:               interval,
+		internalShutdownSignal: make(chan struct{}, 1),
+	}
+
+	if len(optionalExternalShutdownSignal) >= 1 && optionalExternalShutdownSignal[0] != nil {
+		ticker.externalShutdownSignal = optionalExternalShutdownSignal[0]
+	} else {
+		ticker.externalShutdownSignal = ticker.internalShutdownSignal
+	}
+
+	go ticker.run()
+
+	return
+}
+
+// Shutdown shuts down the Ticker.
+func (t *Ticker) Shutdown() {
+	t.shutdownOnce.Do(func() {
+		close(t.internalShutdownSignal)
+	})
+}
+
+// WaitForShutdown waits until the Ticker was shut down.
+func (t *Ticker) WaitForShutdown() {
+	<-t.internalShutdownSignal
+	return
+}
+
+// WaitForGraceFullShutdown waits until the Ticker was shut down and the last handler has terminated.
+func (t *Ticker) WaitForGraceFullShutdown() {
+	<-t.internalShutdownSignal
+	t.handlerDone.Wait()
+	return
+}
+
+// run is an internal utility function that executes the ticker logic.
+func (t *Ticker) run() {
+	ticker := time.NewTicker(t.interval)
 	defer ticker.Stop() // prevent the ticker from leaking
+
+	t.handlerDone.Add(1)
+	defer t.handlerDone.Done()
 
 	for {
 		select {
-		case <-done:
+		case <-t.externalShutdownSignal:
+			if t.externalShutdownSignal != t.internalShutdownSignal {
+				t.Shutdown()
+			}
+			return
+		case <-t.internalShutdownSignal:
 			return
 		case <-ticker.C:
-			handler()
+			t.handler()
 		}
 	}
 }

--- a/timeutil/ticker.go
+++ b/timeutil/ticker.go
@@ -45,14 +45,12 @@ func (t *Ticker) Shutdown() {
 // WaitForShutdown waits until the Ticker was shut down.
 func (t *Ticker) WaitForShutdown() {
 	<-t.internalShutdownSignal
-	return
 }
 
 // WaitForGraceFullShutdown waits until the Ticker was shut down and the last handler has terminated.
 func (t *Ticker) WaitForGraceFullShutdown() {
 	<-t.internalShutdownSignal
 	t.handlerDone.Wait()
-	return
 }
 
 // run is an internal utility function that executes the ticker logic.

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -1,0 +1,28 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+)
+
+func TestTicker_WaitForShutdown(t *testing.T) {
+	counter := atomic.NewUint64(0)
+
+	shutdownChan := make(chan struct{}, 1)
+	go func() {
+		for {
+			time.Sleep(100 * time.Millisecond)
+			if counter.Load() > 10 {
+				close(shutdownChan)
+				return
+			}
+		}
+	}()
+
+	NewTicker(func() { counter.Inc() }, 100*time.Millisecond, shutdownChan).WaitForShutdown()
+
+	assert.GreaterOrEqual(t, counter.Load(), uint64(10))
+}

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -48,14 +48,14 @@ func TestTicker_ManualShutdown(t *testing.T) {
 	// use counter to track execution state
 	counter := atomic.NewUint64(0)
 
-	// create ticker and wait for external shutdown
+	// create ticker and wait for manual shutdown
 	ticker := NewTicker(func() {
 		counter.Inc()
 		time.Sleep(1 * time.Second)
 		counter.Inc()
 	}, 100*time.Millisecond)
 
-	// create "external" shutdown signal
+	// manual shutdown when threshold is reached
 	go func() {
 		for {
 			time.Sleep(10 * time.Millisecond)
@@ -69,7 +69,7 @@ func TestTicker_ManualShutdown(t *testing.T) {
 	// wait for the shutdown signal
 	ticker.WaitForShutdown()
 
-	// make sure we really waited for the external shutdown signal
+	// make sure we really waited for the shutdown signal
 	assert.GreaterOrEqual(t, counter.Load(), uint64(3))
 
 	// wait for the handler to finish

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -38,7 +38,7 @@ func TestTicker_ExternalShutdownSignal(t *testing.T) {
 	assert.GreaterOrEqual(t, counter.Load(), uint64(3))
 
 	// wait for the handler to finish
-	ticker.WaitForGraceFullShutdown()
+	ticker.WaitForGracefulShutdown()
 
 	// make sure we really waited for the handler to finish
 	assert.GreaterOrEqual(t, counter.Load(), uint64(4))

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -43,3 +43,38 @@ func TestTicker_ExternalShutdownSignal(t *testing.T) {
 	// make sure we really waited for the handler to finish
 	assert.GreaterOrEqual(t, counter.Load(), uint64(4))
 }
+
+func TestTicker_ManualShutdown(t *testing.T) {
+	// use counter to track execution state
+	counter := atomic.NewUint64(0)
+
+	// create ticker and wait for external shutdown
+	ticker := NewTicker(func() {
+		counter.Inc()
+		time.Sleep(1 * time.Second)
+		counter.Inc()
+	}, 100*time.Millisecond)
+
+	// create "external" shutdown signal
+	go func() {
+		for {
+			time.Sleep(10 * time.Millisecond)
+			if counter.Load() > 2 {
+				ticker.Shutdown()
+				return
+			}
+		}
+	}()
+
+	// wait for the shutdown signal
+	ticker.WaitForShutdown()
+
+	// make sure we really waited for the external shutdown signal
+	assert.GreaterOrEqual(t, counter.Load(), uint64(3))
+
+	// wait for the handler to finish
+	ticker.WaitForGracefulShutdown()
+
+	// make sure we really waited for the handler to finish
+	assert.GreaterOrEqual(t, counter.Load(), uint64(4))
+}

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -22,7 +22,8 @@ func TestTicker_WaitForShutdown(t *testing.T) {
 		}
 	}()
 
-	NewTicker(func() { counter.Inc() }, 100*time.Millisecond, shutdownChan).WaitForShutdown()
+	ticker := NewTicker(func() { counter.Inc() }, 100*time.Millisecond, shutdownChan)
+	ticker.WaitForShutdown()
 
 	assert.GreaterOrEqual(t, counter.Load(), uint64(10))
 }


### PR DESCRIPTION
# Description of change

Implemented new object oriented Ticker API for more flexible shutdown handling. Since we sometimes use Tickers in the Background workers of plugins and the workers can take a really long time to finish, we want to offer a way to wait only for the shutdown signal rather than the finishing of the job (i.e. when posting usage statistics to the metrics collecting server).

This speeds up the shutdown and prevents the server from being unnecessarily killed.

Old API:

```
// Always waits until the Ticker is shutdown and the last handler was fully executed
NewTicker(...)
```

New API:

```
// Doesn't wait but simply executes a background task that runs periodically.
ticker := NewTicker(...)

// Ticker can be manually shutdown instead of having to use a shutdown channel in the parameters.
ticker.Shutdown()
```

```
// Waits until the Ticker is shutdown.
NewTicker(...).WaitForShutdown()
```

```
// Waits until the Ticker is shutdown and the last handler was fully executed (the equivalent of the old behavior).
NewTicker(...).WaitForGracefulShutdown()
```

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
