### PR TITLE
filteredList is allowed to loop when empty

### DIFF
--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -235,6 +235,11 @@ func (m *manager) updateOutbound(resultChan chan<- peer.PeerDistance) {
 		return
 	}
 
+	// reset rejectionFilter so that in the next call filteredList is full again
+	if len(filteredList) < 2 {
+		m.rejectionFilter.Clean()
+	}
+
 	// select new candidate
 	candidate := m.outbound.Select(filteredList)
 	if candidate.Remote == nil {

--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -231,9 +231,6 @@ func (m *manager) updateOutbound(resultChan chan<- peer.PeerDistance) {
 
 	// filter out previous rejections
 	filteredList := m.rejectionFilter.Apply(filter.Apply(distList))
-	if len(filteredList) == 0 {
-		return
-	}
 
 	// reset rejectionFilter so that in the next call filteredList is full again
 	if len(filteredList) < 2 {


### PR DESCRIPTION
# Description of change

Currently a node iterates through a list of available peers, called filteredList, to identify peers that can be contacted for filling the outgoing neighbor list. If a peer rejects the node, the peer is added to a rejectionFilter. For a large enough salt life time (which is the case with the current settings) it is possible that the node has no more peers left in filteredList, thus stagnating with less than the maximum number of peers until its own salt is reset. With this change the node effectively resets the filteredList once it become empty. This can increase the communication overhead, but it is limited by the OutboundUpdateInterval.

## Type of change

- Enhancement 

## How the change has been tested

The change in the autopeering module was tested only in an isolated simulation environment.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The autopeering module in a simulation environment shows an increased average number of peers
