### PR TITLE
Feat/object storage timed executor

### DIFF
--- a/configuration/getter.go
+++ b/configuration/getter.go
@@ -160,7 +160,7 @@ func (c *Configuration) MapKeys(path string) []string {
 }
 
 // Unmarshal unmarshals a given key path into the given struct using
-// the mapstructure lib. If no path is specified, the whole map is unmarshalled.
+// the mapstructure lib. If no path is specified, the whole map is unmarshaled.
 // `koanf` is the struct field tag used to match field names. To customize,
 // use UnmarshalWithConf(). It uses the mitchellh/mapstructure package.
 func (c *Configuration) Unmarshal(path string, o interface{}) error {

--- a/kvstore/batch_writer.go
+++ b/kvstore/batch_writer.go
@@ -106,6 +106,7 @@ func (bw *BatchedWriter) runBatchWriter() {
 		var batchedMuts BatchedMutations
 
 		writtenValues := make([]BatchWriteObject, BatchWriterBatchSize)
+		batchWriterTimeoutChan := time.After(BatchWriterBatchTimeout)
 		writtenValuesCounter := 0
 	CollectValues:
 		for writtenValuesCounter < BatchWriterBatchSize {
@@ -122,7 +123,8 @@ func (bw *BatchedWriter) runBatchWriter() {
 				objectToPersist.BatchWrite(batchedMuts)
 				writtenValues[writtenValuesCounter] = objectToPersist
 				writtenValuesCounter++
-			case <-time.After(BatchWriterBatchTimeout):
+
+			case <-batchWriterTimeoutChan:
 				break CollectValues
 			}
 		}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -918,8 +918,6 @@ func (objectStorage *ObjectStorage) unmarshalObject(key []byte, data []byte) Sto
 func (objectStorage *ObjectStorage) flush(shutdown bool) {
 	objectStorage.flushMutex.Lock()
 
-	objectStorage.releaseExecutor.Shutdown(timedexecutor.IgnorePendingTimeouts)
-
 	// create a list of objects that shall be flushed (so the BatchWriter can access the cachedObjects mutex and delete)
 	cachedObjects := make([]*CachedObjectImpl, objectStorage.size)
 	var i int
@@ -933,6 +931,9 @@ func (objectStorage *ObjectStorage) flush(shutdown bool) {
 	})
 
 	objectStorage.flushMutex.Unlock()
+
+	// shut down the executor to execute all release tasks
+	objectStorage.releaseExecutor.Shutdown(timedexecutor.IgnorePendingTimeouts)
 
 	// force release the collected objects
 	for j := 0; j < i; j++ {

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -930,7 +930,7 @@ func (objectStorage *ObjectStorage) flush() {
 	// force release the collected objects
 	for j := 0; j < i; j++ {
 		if consumers := atomic.AddInt32(&(cachedObjects[j].consumers), -1); consumers == 0 {
-			objectStorage.options.batchedWriterInstance.Enqueue(cachedObjects[j])
+			cachedObjects[j].evict()
 		}
 	}
 

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/kvstore"
@@ -25,7 +26,7 @@ type ObjectStorage struct {
 	cachedObjectsEmpty sync.WaitGroup
 	shutdown           typeutils.AtomicBool
 	partitionsManager  *PartitionsManager
-	releaseExecutor    *timedexecutor.TimedExecutor
+	releaseExecutor    unsafe.Pointer
 
 	Events Events
 }
@@ -42,13 +43,14 @@ func New(store kvstore.KVStore, objectFactory StorableObjectFactory, optionalOpt
 		objectFactory:     objectFactory,
 		cachedObjects:     make(map[string]interface{}),
 		partitionsManager: NewPartitionsManager(),
-		releaseExecutor:   timedexecutor.New(storageOptions.releaseExecutorWorkerCount),
 		options:           storageOptions,
 
 		Events: Events{
 			ObjectEvicted: events.NewEvent(evictionEvent),
 		},
 	}
+
+	atomic.StorePointer(&result.releaseExecutor, unsafe.Pointer(timedexecutor.New(storageOptions.releaseExecutorWorkerCount)))
 
 	return result
 }
@@ -933,7 +935,9 @@ func (objectStorage *ObjectStorage) flush(shutdown bool) {
 	objectStorage.flushMutex.Unlock()
 
 	// shut down the executor to execute all release tasks
-	objectStorage.releaseExecutor.Shutdown(timedexecutor.IgnorePendingTimeouts)
+	if releaseExecutor := atomic.LoadPointer(&objectStorage.releaseExecutor); releaseExecutor != nil {
+		(*timedexecutor.TimedExecutor)(releaseExecutor).Shutdown(timedexecutor.IgnorePendingTimeouts)
+	}
 
 	// force release the collected objects
 	for j := 0; j < i; j++ {
@@ -946,7 +950,7 @@ func (objectStorage *ObjectStorage) flush(shutdown bool) {
 
 	if !shutdown {
 		// create a new release executor because the other was shut down to flush all objects
-		objectStorage.releaseExecutor = timedexecutor.New(objectStorage.options.releaseExecutorWorkerCount)
+		atomic.StorePointer(&objectStorage.releaseExecutor, unsafe.Pointer(timedexecutor.New(objectStorage.options.releaseExecutorWorkerCount)))
 	}
 }
 
@@ -1113,7 +1117,7 @@ func (objectStorage *ObjectStorage) forEachCachedElementWithPrefix(consumer Cons
 
 // StorableObjectFactory is used to address the factory method that generically creates StorableObjects. It receives the
 // key and the serialized data of the object and returns an "empty" StorableObject that just has its key set. The object
-// is then fully unmarshalled by the ObjectStorage which calls the UnmarshalObjectStorageValue with the data. The data
+// is then fully unmarshaled by the ObjectStorage which calls the UnmarshalObjectStorageValue with the data. The data
 // is anyway provided in this method already to allow the dynamic creation of different object types depending on the
 // stored data.
 type StorableObjectFactory func(key []byte, data []byte) (result StorableObject, err error)

--- a/timedqueue/timedqueue.go
+++ b/timedqueue/timedqueue.go
@@ -167,7 +167,7 @@ func (t *TimedQueue) Poll(waitIfEmpty bool) interface{} {
 			//       They all wait for a new element to arrive, then one retrieves the new elements and the other goroutines
 			//       will still see an empty tangle even if they waited.
 			if !t.IsShutdown() && waitIfEmpty {
-				return t.Poll(waitIfEmpty)
+				continue
 			}
 
 			// ... abort
@@ -201,7 +201,7 @@ func (t *TimedQueue) Poll(waitIfEmpty bool) interface{} {
 			select {
 			// abort waiting for this element and return the next one instead if it was canceled
 			case <-polledElement.cancel:
-				return t.Poll(waitIfEmpty)
+				continue
 
 			// return the result after the time is reached
 			case <-time.After(time.Until(polledElement.ScheduledTime)):


### PR DESCRIPTION
# Description of change

This PR fixes some problems in the object storage.
Non-Persistable object are not passed to the batchwriter anymore, but evicted directly after the cacheTime.
The batchwriter batch timeout now works as expected.
The timed executor is now used for object eviction. This way the object storage doesn't leak go routines anymore.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)