### PR TITLE
Fix: New ShutdownFlag for the TimedExecutor + deadlock fix

### DIFF
--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -926,7 +926,7 @@ func (objectStorage *ObjectStorage) flush(shutdown bool) {
 	objectStorage.flushMutex.Lock()
 
 	// cancel all pending release tasks (we flush manually) and create a new executor if we didn't shut down
-	objectStorage.ReleaseExecutor().Shutdown(timedexecutor.CancelPendingTasks)
+	objectStorage.ReleaseExecutor().Shutdown(timedexecutor.CancelPendingTasks, timedexecutor.DontWaitForShutdown)
 	if !shutdown {
 		atomic.StorePointer(&objectStorage.releaseExecutor, unsafe.Pointer(timedexecutor.New(objectStorage.options.releaseExecutorWorkerCount)))
 	}

--- a/timedexecutor/timedexecutor.go
+++ b/timedexecutor/timedexecutor.go
@@ -59,9 +59,11 @@ func (t *TimedExecutor) Shutdown(optionalShutdownFlags ...timedqueue.ShutdownFla
 
 	t.queue.Shutdown(shutdownFlags)
 
-	if !shutdownFlags.HasBits(CancelPendingTasks) {
-		t.shutdownWG.Wait()
+	if shutdownFlags.HasBits(DontWaitForShutdown) {
+		return
 	}
+
+	t.shutdownWG.Wait()
 }
 
 // startBackgroundWorkers is an internal utility function that spawns the background workers that execute the queued tasks.
@@ -99,6 +101,10 @@ const (
 	// IgnorePendingTimeouts defines a shutdown flag, that makes the queue ignore the timeouts of the remaining queued
 	// elements. Consecutive calls to Poll will immediately return these elements.
 	IgnorePendingTimeouts = timedqueue.IgnorePendingTimeouts
+
+	// DontWaitForShutdown causes the TimedExecutor to not wait for all tasks to be executed before returning from the
+	// Shutdown method.
+	DontWaitForShutdown timedqueue.ShutdownFlag = 1 << 7
 )
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/timedexecutor/timedexecutor.go
+++ b/timedexecutor/timedexecutor.go
@@ -59,7 +59,9 @@ func (t *TimedExecutor) Shutdown(optionalShutdownFlags ...timedqueue.ShutdownFla
 
 	t.queue.Shutdown(shutdownFlags)
 
-	t.shutdownWG.Wait()
+	if !shutdownFlags.HasBits(CancelPendingTasks) {
+		t.shutdownWG.Wait()
+	}
 }
 
 // startBackgroundWorkers is an internal utility function that spawns the background workers that execute the queued tasks.


### PR DESCRIPTION
# Description of change

Added a new ShutdownFlag for the TimedExecutor, that allows it to not wait for all Tasks to be completed before returning from the Shutdown method.

This is used i.e. by the objectStorage to prevent deadlocks.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
