### PR TITLE
Add OnEvictionCallback option to object storage

### DIFF
--- a/objectstorage/cached_object.go
+++ b/objectstorage/cached_object.go
@@ -395,6 +395,11 @@ func (cachedObject *CachedObjectImpl) BatchWriteDone() {
 		return
 	}
 
+	// fire the eviction callback if registered
+	if objectStorage.options.onEvictionCallback != nil {
+		objectStorage.options.onEvictionCallback(cachedObject)
+	}
+
 	// abort if the storage is not empty
 	if objectStorage.size != 0 {
 		return

--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/mr-tron/base58"
+
+	"github.com/iotaledger/hive.go/kvstore"
 )
 
 type Options struct {
@@ -21,6 +22,7 @@ type Options struct {
 	leakDetectionOptions       *LeakDetectionOptions
 	leakDetectionWrapper       func(cachedObject *CachedObjectImpl) LeakDetectionWrapper
 	delayedOptions             []func()
+	onEvictionCallback         func(cachedObject CachedObject)
 }
 
 func newOptions(store kvstore.KVStore, optionalOptions []Option) *Options {
@@ -202,5 +204,12 @@ func OverrideLeakDetectionWrapper(wrapperFunc func(cachedObject *CachedObjectImp
 func PartitionKey(keyPartitions ...int) Option {
 	return func(args *Options) {
 		args.keyPartitions = keyPartitions
+	}
+}
+
+// OnEvictionCallback sets a function that is called on eviction of the object.
+func OnEvictionCallback(cb func(cachedObject CachedObject)) Option {
+	return func(args *Options) {
+		args.onEvictionCallback = cb
 	}
 }


### PR DESCRIPTION
# Description of change

This PR adds the option to the object storage, to pass a callback that is called if an object is evicted.
This can be useful in situations where you want to do a special action after no one needs this object anymore.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested if the callback is fired by using the option in hornet.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
