### PR TITLE
Fix: Avoid accidental BackgroundWorker collisions

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -163,7 +163,7 @@ func (d *OrderedDaemon) BackgroundWorker(name string, handler WorkerFunc, order 
 	defer d.lock.Unlock()
 
 	if _, workerExistsAlready := d.workers[name]; workerExistsAlready {
-		return xerrors.Errorf("tried to overwrite existing background worker (%s): %w", ErrDuplicateBackgroundWorker)
+		return xerrors.Errorf("tried to overwrite existing background worker (%s): %w", name, ErrDuplicateBackgroundWorker)
 	}
 
 	var shutdownOrder int

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -180,11 +180,11 @@ func TestReRun(t *testing.T) {
 	time.Sleep(graceTime)
 
 	var wasStarted typeutils.AtomicBool
-	require.NoError(t, d.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
+	require.Error(t, d.BackgroundWorker("A", func(shutdownSignal <-chan struct{}) {
 		wasStarted.Set()
 		<-shutdownSignal
 	}))
 
 	d.ShutdownAndWait()
-	assert.True(t, wasStarted.IsSet())
+	assert.False(t, wasStarted.IsSet())
 }


### PR DESCRIPTION
# Description of change

To prevent accidental collisions in the BackgroundWorker naming due to i.e. copy and paste, we now always throw an error if a BackgroundWorker is created that uses a similar name as another BackgroundWorker.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
