### PR TITLE
Removed AccessCallback from the KVStore interface and implementations.

### DIFF
--- a/kvstore/badger/badger.go
+++ b/kvstore/badger/badger.go
@@ -11,10 +11,8 @@ import (
 
 // badgerStore implements the KVStore interface around a BadgerDB instance.
 type badgerStore struct {
-	instance                     *badger.DB
-	dbPrefix                     []byte
-	accessCallback               kvstore.AccessCallback
-	accessCallbackCommandsFilter kvstore.Command
+	instance *badger.DB
+	dbPrefix []byte
 }
 
 // New creates a new KVStore with the underlying BadgerDB.
@@ -22,22 +20,6 @@ func New(db *badger.DB) kvstore.KVStore {
 	return &badgerStore{
 		instance: db,
 	}
-}
-
-// AccessCallback configures the store to pass all requests to the KVStore to the given callback.
-// This can for example be used for debugging and to examine what the KVStore is doing.
-func (s *badgerStore) AccessCallback(callback kvstore.AccessCallback, commandsFilter ...kvstore.Command) {
-	var accessCallbackCommandsFilter kvstore.Command
-	if len(commandsFilter) == 0 {
-		accessCallbackCommandsFilter = kvstore.AllCommands
-	} else {
-		for _, filterCommand := range commandsFilter {
-			accessCallbackCommandsFilter |= filterCommand
-		}
-	}
-
-	s.accessCallback = callback
-	s.accessCallbackCommandsFilter = accessCallbackCommandsFilter
 }
 
 func (s *badgerStore) WithRealm(realm kvstore.Realm) kvstore.KVStore {
@@ -58,16 +40,9 @@ func (s *badgerStore) buildKeyPrefix(prefix kvstore.KeyPrefix) kvstore.KeyPrefix
 
 // Shutdown marks the store as shutdown.
 func (s *badgerStore) Shutdown() {
-	if s.accessCallback != nil {
-		s.accessCallback(kvstore.ShutdownCommand)
-	}
 }
 
 func (s *badgerStore) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.IterateCommand) {
-		s.accessCallback(kvstore.IterateCommand, prefix)
-	}
-
 	return s.instance.View(func(txn *badger.Txn) (err error) {
 		iteratorOptions := badger.DefaultIteratorOptions
 		iteratorOptions.Prefix = s.buildKeyPrefix(prefix)
@@ -91,10 +66,6 @@ func (s *badgerStore) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.Ite
 }
 
 func (s *badgerStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.IterateKeysCommand) {
-		s.accessCallback(kvstore.IterateKeysCommand, prefix)
-	}
-
 	return s.instance.View(func(txn *badger.Txn) (err error) {
 		iteratorOptions := badger.DefaultIteratorOptions
 		iteratorOptions.Prefix = s.buildKeyPrefix(prefix)
@@ -113,18 +84,10 @@ func (s *badgerStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore
 }
 
 func (s *badgerStore) Clear() error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.ClearCommand) {
-		s.accessCallback(kvstore.ClearCommand)
-	}
-
 	return s.DeletePrefix(kvstore.EmptyPrefix)
 }
 
 func (s *badgerStore) Get(key kvstore.Key) (kvstore.Value, error) {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.GetCommand) {
-		s.accessCallback(kvstore.GetCommand, key)
-	}
-
 	var value []byte
 	err := s.instance.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(byteutils.ConcatBytes(s.dbPrefix, key))
@@ -142,20 +105,12 @@ func (s *badgerStore) Get(key kvstore.Key) (kvstore.Value, error) {
 }
 
 func (s *badgerStore) Set(key kvstore.Key, value kvstore.Value) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.SetCommand) {
-		s.accessCallback(kvstore.SetCommand, key, value)
-	}
-
 	return s.instance.Update(func(txn *badger.Txn) error {
 		return txn.Set(byteutils.ConcatBytes(s.dbPrefix, key), value)
 	})
 }
 
 func (s *badgerStore) Has(key kvstore.Key) (bool, error) {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.HasCommand) {
-		s.accessCallback(kvstore.HasCommand, key)
-	}
-
 	err := s.instance.View(func(txn *badger.Txn) error {
 		_, err := txn.Get(byteutils.ConcatBytes(s.dbPrefix, key))
 		return err
@@ -170,10 +125,6 @@ func (s *badgerStore) Has(key kvstore.Key) (bool, error) {
 }
 
 func (s *badgerStore) Delete(key kvstore.Key) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.DeleteCommand) {
-		s.accessCallback(kvstore.DeleteCommand, key)
-	}
-
 	err := s.instance.Update(func(txn *badger.Txn) error {
 		return txn.Delete(byteutils.ConcatBytes(s.dbPrefix, key))
 	})
@@ -184,10 +135,6 @@ func (s *badgerStore) Delete(key kvstore.Key) error {
 }
 
 func (s *badgerStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.DeletePrefixCommand) {
-		s.accessCallback(kvstore.DeletePrefixCommand, prefix)
-	}
-
 	return s.instance.Update(func(txn *badger.Txn) (err error) {
 		iteratorOptions := badger.DefaultIteratorOptions
 		iteratorOptions.Prefix = s.buildKeyPrefix(prefix)
@@ -235,10 +182,6 @@ type batchedMutations struct {
 }
 
 func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
-	if b.kvStore.accessCallback != nil && b.kvStore.accessCallbackCommandsFilter.HasBits(kvstore.SetCommand) {
-		b.kvStore.accessCallback(kvstore.SetCommand, key, value)
-	}
-
 	stringKey := byteutils.ConcatBytesToString(b.dbPrefix, key)
 
 	b.operationsMutex.Lock()
@@ -251,10 +194,6 @@ func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
 }
 
 func (b *batchedMutations) Delete(key kvstore.Key) error {
-	if b.kvStore.accessCallback != nil && b.kvStore.accessCallbackCommandsFilter.HasBits(kvstore.DeleteCommand) {
-		b.kvStore.accessCallback(kvstore.DeleteCommand, key)
-	}
-
 	stringKey := byteutils.ConcatBytesToString(b.dbPrefix, key)
 
 	b.operationsMutex.Lock()

--- a/kvstore/debug/debug.go
+++ b/kvstore/debug/debug.go
@@ -1,0 +1,204 @@
+package debug
+
+import (
+	"github.com/iotaledger/hive.go/bitmask"
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+// Command is a type that represents a specific method in the KVStore.
+type Command = bitmask.BitMask
+
+// AccessCallback is the type of the callback function that can be used to hook the access to the callback.
+type AccessCallback func(command Command, parameters ...[]byte)
+
+const (
+	// IterateCommand represents a call to the Iterate method of the store.
+	IterateCommand Command = 1 << iota
+
+	// IterateKeysCommand represents a call to the IterateKeys method of the store.
+	IterateKeysCommand
+
+	// ClearCommand represents a call to the Clear method of the store.
+	ClearCommand
+
+	// GetCommand represents a call to the Get method of the store.
+	GetCommand
+
+	// SetCommand represents a call to the Set method of the store.
+	SetCommand
+
+	// HasCommand represents a call to the Has method of the store.
+	HasCommand
+
+	// DeleteCommand represents a call to the Delete method of the store.
+	DeleteCommand
+
+	// DeletePrefixCommand represents a call to the DeletePrefix method of the store.
+	DeletePrefixCommand
+
+	// AllCommands represents the collection of all commands.
+	AllCommands = IterateCommand | IterateKeysCommand | ClearCommand | GetCommand | SetCommand | HasCommand | DeleteCommand | DeletePrefixCommand
+
+	// ShutdownCommand represents a call to the Shutdown method of the store.
+	ShutdownCommand Command = 0
+)
+
+// CommandNames contains a map from the command to its human readable name.
+var CommandNames = map[Command]string{
+	ShutdownCommand:     "Shutdown",
+	IterateCommand:      "Iterate",
+	IterateKeysCommand:  "IterateKeys",
+	ClearCommand:        "Clear",
+	GetCommand:          "Get",
+	SetCommand:          "Set",
+	HasCommand:          "Has",
+	DeleteCommand:       "Delete",
+	DeletePrefixCommand: "DeletePrefix",
+}
+
+// DebugStore implements the KVStore interface wrapping another KVStore to provide access callbacks for debug purposes.
+type debugStore struct {
+	underlying                   kvstore.KVStore
+	accessCallback               AccessCallback
+	accessCallbackCommandsFilter Command
+}
+
+// New creates a new KVStore with debug callbacks. This can for example be used for debugging and to examine what the KVStore is doing.
+// store is the underlying store to which all methods will be forwarded.
+// callback will be called for all requests to the KVStore.
+// commandsFilter optional filter to only report certain requests to the callback.
+func New(store kvstore.KVStore, callback AccessCallback, commandsFilter ...Command) kvstore.KVStore {
+	var accessCallbackCommandsFilter Command
+	if len(commandsFilter) == 0 {
+		accessCallbackCommandsFilter = AllCommands
+	} else {
+		for _, filterCommand := range commandsFilter {
+			accessCallbackCommandsFilter |= filterCommand
+		}
+	}
+
+	return &debugStore{
+		underlying:                   store,
+		accessCallback:               callback,
+		accessCallbackCommandsFilter: accessCallbackCommandsFilter,
+	}
+}
+
+func (s *debugStore) WithRealm(realm kvstore.Realm) kvstore.KVStore {
+	return &debugStore{
+		underlying:                   s.underlying.WithRealm(realm),
+		accessCallback:               s.accessCallback,
+		accessCallbackCommandsFilter: s.accessCallbackCommandsFilter,
+	}
+}
+
+func (s *debugStore) Realm() kvstore.Realm {
+	return s.underlying.Realm()
+}
+
+func (s *debugStore) Shutdown() {
+	if s.accessCallback != nil {
+		s.accessCallback(ShutdownCommand)
+	}
+	s.underlying.Shutdown()
+}
+
+func (s *debugStore) Iterate(prefix kvstore.KeyPrefix, kvConsumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(IterateCommand) {
+		s.accessCallback(IterateCommand, prefix)
+	}
+	return s.underlying.Iterate(prefix, kvConsumerFunc)
+}
+
+func (s *debugStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(IterateKeysCommand) {
+		s.accessCallback(IterateKeysCommand, prefix)
+	}
+	return s.underlying.IterateKeys(prefix, consumerFunc)
+}
+
+func (s *debugStore) Clear() error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(ClearCommand) {
+		s.accessCallback(ClearCommand)
+	}
+	return s.underlying.Clear()
+}
+
+func (s *debugStore) Get(key kvstore.Key) (value kvstore.Value, err error) {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(GetCommand) {
+		s.accessCallback(GetCommand, key)
+	}
+	return s.underlying.Get(key)
+}
+
+func (s *debugStore) Set(key kvstore.Key, value kvstore.Value) error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(SetCommand) {
+		s.accessCallback(SetCommand, key, value)
+	}
+	return s.underlying.Set(key, value)
+}
+
+func (s *debugStore) Has(key kvstore.Key) (bool, error) {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(HasCommand) {
+		s.accessCallback(HasCommand, key)
+	}
+	return s.underlying.Has(key)
+}
+
+func (s *debugStore) Delete(key kvstore.Key) error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(DeleteCommand) {
+		s.accessCallback(DeleteCommand, key)
+	}
+	return s.underlying.Delete(key)
+}
+
+func (s *debugStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(DeletePrefixCommand) {
+		s.accessCallback(DeletePrefixCommand, prefix)
+	}
+	return s.underlying.DeletePrefix(prefix)
+}
+
+func (s *debugStore) Flush() error {
+	return s.underlying.Flush()
+}
+
+func (s *debugStore) Close() error {
+	return s.underlying.Close()
+}
+
+type batchedMutations struct {
+	underlying                   kvstore.BatchedMutations
+	accessCallback               AccessCallback
+	accessCallbackCommandsFilter Command
+}
+
+func (s *debugStore) Batched() kvstore.BatchedMutations {
+	return &batchedMutations{
+		underlying:                   s.underlying.Batched(),
+		accessCallback:               s.accessCallback,
+		accessCallbackCommandsFilter: s.accessCallbackCommandsFilter,
+	}
+}
+
+func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
+	if b.accessCallback != nil && b.accessCallbackCommandsFilter.HasBits(SetCommand) {
+		b.accessCallback(SetCommand, key, value)
+	}
+	return b.underlying.Set(key, value)
+}
+
+func (b *batchedMutations) Delete(key kvstore.Key) error {
+	if b.accessCallback != nil && b.accessCallbackCommandsFilter.HasBits(DeleteCommand) {
+		b.accessCallback(DeleteCommand, key)
+	}
+	return b.underlying.Delete(key)
+}
+
+func (b *batchedMutations) Cancel() {
+	b.underlying.Cancel()
+}
+
+func (b *batchedMutations) Commit() error {
+	return b.underlying.Commit()
+}

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -2,8 +2,6 @@ package kvstore
 
 import (
 	"errors"
-
-	"github.com/iotaledger/hive.go/bitmask"
 )
 
 var (
@@ -44,63 +42,9 @@ type BatchedMutations interface {
 	Commit() error
 }
 
-// Command is a type that represents a specific method in the KVStore.
-type Command = bitmask.BitMask
-
-// AccessCallback is the type of the callback function that can be used to hook the access to the callback.
-type AccessCallback func(command Command, parameters ...[]byte)
-
-const (
-	// IterateCommand represents a call to the Iterate method of the store.
-	IterateCommand Command = 1 << iota
-
-	// IterateKeysCommand represents a call to the IterateKeys method of the store.
-	IterateKeysCommand
-
-	// ClearCommand represents a call to the Clear method of the store.
-	ClearCommand
-
-	// GetCommand represents a call to the Get method of the store.
-	GetCommand
-
-	// SetCommand represents a call to the Set method of the store.
-	SetCommand
-
-	// HasCommand represents a call to the Has method of the store.
-	HasCommand
-
-	// DeleteCommand represents a call to the Delete method of the store.
-	DeleteCommand
-
-	// DeletePrefixCommand represents a call to the DeletePrefix method of the store.
-	DeletePrefixCommand
-
-	// AllCommands represents the collection of all commands.
-	AllCommands = IterateCommand | IterateKeysCommand | ClearCommand | GetCommand | SetCommand | HasCommand | DeleteCommand | DeletePrefixCommand
-
-	// ShutdownCommand represents a call to the Shutdown method of the store.
-	ShutdownCommand Command = 0
-)
-
-// CommandNames contains a map from the command to its human readable name.
-var CommandNames = map[Command]string{
-	ShutdownCommand:     "Shutdown",
-	IterateCommand:      "Iterate",
-	IterateKeysCommand:  "IterateKeys",
-	ClearCommand:        "Clear",
-	GetCommand:          "Get",
-	SetCommand:          "Set",
-	HasCommand:          "Has",
-	DeleteCommand:       "Delete",
-	DeletePrefixCommand: "DeletePrefix",
-}
 
 // KVStore persists, deletes and retrieves data.
 type KVStore interface {
-	// AccessCallback configures the store to pass all requests to the KVStore to the given callback.
-	// This can for example be used for debugging and to examine what the KVStore is doing.
-	AccessCallback(callback AccessCallback, commandsFilter ...Command)
-
 	// WithRealm is a factory method for using the same underlying storage with a different realm.
 	WithRealm(realm Realm) KVStore
 

--- a/kvstore/mapdb/mapdb.go
+++ b/kvstore/mapdb/mapdb.go
@@ -13,10 +13,8 @@ import (
 
 // mapDB is a simple implementation of KVStore using a map.
 type mapDB struct {
-	m                            *syncedKVMap
-	realm                        []byte
-	accessCallback               kvstore.AccessCallback
-	accessCallbackCommandsFilter kvstore.Command
+	m     *syncedKVMap
+	realm []byte
 }
 
 // NewMapDB creates a kvstore.KVStore implementation purely based on a go map.
@@ -24,22 +22,6 @@ func NewMapDB() kvstore.KVStore {
 	return &mapDB{
 		m: &syncedKVMap{m: make(map[string][]byte)},
 	}
-}
-
-// AccessCallback configures the store to pass all requests to the KVStore to the given callback.
-// This can for example be used for debugging and to examine what the KVStore is doing.
-func (s *mapDB) AccessCallback(callback kvstore.AccessCallback, commandsFilter ...kvstore.Command) {
-	var accessCallbackCommandsFilter kvstore.Command
-	if len(commandsFilter) == 0 {
-		accessCallbackCommandsFilter = kvstore.AllCommands
-	} else {
-		for _, filterCommand := range commandsFilter {
-			accessCallbackCommandsFilter |= filterCommand
-		}
-	}
-
-	s.accessCallback = callback
-	s.accessCallbackCommandsFilter = accessCallbackCommandsFilter
 }
 
 func (s *mapDB) WithRealm(realm kvstore.Realm) kvstore.KVStore {
@@ -55,43 +37,24 @@ func (s *mapDB) Realm() kvstore.Realm {
 
 // Shutdown marks the store as shutdown.
 func (s *mapDB) Shutdown() {
-	if s.accessCallback != nil {
-		s.accessCallback(kvstore.ShutdownCommand)
-	}
 }
 
 func (s *mapDB) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.IterateCommand) {
-		s.accessCallback(kvstore.IterateCommand, prefix)
-	}
-
 	s.m.iterate(s.realm, prefix, consumerFunc)
 	return nil
 }
 
 func (s *mapDB) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.IterateKeysCommand) {
-		s.accessCallback(kvstore.IterateKeysCommand, prefix)
-	}
-
 	s.m.iterateKeys(s.realm, prefix, consumerFunc)
 	return nil
 }
 
 func (s *mapDB) Clear() error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.ClearCommand) {
-		s.accessCallback(kvstore.ClearCommand)
-	}
-
 	s.m.deletePrefix(s.realm)
 	return nil
 }
 
 func (s *mapDB) Get(key kvstore.Key) (kvstore.Value, error) {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.GetCommand) {
-		s.accessCallback(kvstore.GetCommand, key)
-	}
-
 	value, contains := s.m.get(byteutils.ConcatBytes(s.realm, key))
 	if !contains {
 		return nil, kvstore.ErrKeyNotFound
@@ -100,37 +63,21 @@ func (s *mapDB) Get(key kvstore.Key) (kvstore.Value, error) {
 }
 
 func (s *mapDB) Set(key kvstore.Key, value kvstore.Value) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.SetCommand) {
-		s.accessCallback(kvstore.SetCommand, key, value)
-	}
-
 	s.m.set(byteutils.ConcatBytes(s.realm, key), value)
 	return nil
 }
 
 func (s *mapDB) Has(key kvstore.Key) (bool, error) {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.HasCommand) {
-		s.accessCallback(kvstore.HasCommand, key)
-	}
-
 	contains := s.m.has(byteutils.ConcatBytes(s.realm, key))
 	return contains, nil
 }
 
 func (s *mapDB) Delete(key kvstore.Key) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.DeleteCommand) {
-		s.accessCallback(kvstore.DeleteCommand, key)
-	}
-
 	s.m.delete(byteutils.ConcatBytes(s.realm, key))
 	return nil
 }
 
 func (s *mapDB) DeletePrefix(prefix kvstore.KeyPrefix) error {
-	if s.accessCallback != nil && s.accessCallbackCommandsFilter.HasBits(kvstore.DeletePrefixCommand) {
-		s.accessCallback(kvstore.DeletePrefixCommand, prefix)
-	}
-
 	s.m.deletePrefix(byteutils.ConcatBytes(s.realm, prefix))
 	return nil
 }
@@ -168,10 +115,6 @@ type batchedMutations struct {
 }
 
 func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
-	if b.kvStore.accessCallback != nil && b.kvStore.accessCallbackCommandsFilter.HasBits(kvstore.SetCommand) {
-		b.kvStore.accessCallback(kvstore.SetCommand, key, value)
-	}
-
 	stringKey := byteutils.ConcatBytesToString(key)
 
 	b.Lock()
@@ -184,10 +127,6 @@ func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
 }
 
 func (b *batchedMutations) Delete(key kvstore.Key) error {
-	if b.kvStore.accessCallback != nil && b.kvStore.accessCallbackCommandsFilter.HasBits(kvstore.DeleteCommand) {
-		b.kvStore.accessCallback(kvstore.DeleteCommand, key)
-	}
-
 	stringKey := byteutils.ConcatBytesToString(key)
 
 	b.Lock()

--- a/kvstore/test/kvstore_test.go
+++ b/kvstore/test/kvstore_test.go
@@ -3,9 +3,12 @@ package test
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"testing"
+
+	"github.com/iotaledger/hive.go/kvstore/debug"
 
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/kvstore/badger"
@@ -55,6 +58,17 @@ func testStore(t require.TestingT, dbImplementation string, realm []byte) kvstor
 		db, err := pebble.CreateDB(dir)
 		require.NoError(t, err, "used db: %s", dbImplementation)
 		return pebble.New(db).WithRealm(realm)
+
+	case "debug":
+		return debug.New(mapdb.NewMapDB(), func(command debug.Command, parameters ...[]byte) {
+			s := []string{
+				debug.CommandNames[command],
+			}
+			for _, p := range parameters {
+				s = append(s, string(p))
+			}
+			fmt.Println(s)
+		}).WithRealm(realm)
 	}
 
 	panic("unknown database")

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -39,7 +39,7 @@ func New(store kvstore.KVStore, objectFactory StorableObjectFactory, optionalOpt
 	storageOptions := newOptions(store, optionalOptions)
 
 	result := &ObjectStorage{
-		store:             store,
+		store:             storageOptions.store,
 		objectFactory:     objectFactory,
 		cachedObjects:     make(map[string]interface{}),
 		partitionsManager: NewPartitionsManager(),

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -16,7 +16,6 @@ import (
 
 // ObjectStorage is a manual cache which keeps objects as long as consumers are using it.
 type ObjectStorage struct {
-	store              kvstore.KVStore
 	objectFactory      StorableObjectFactory
 	cachedObjects      map[string]interface{}
 	cacheMutex         syncutils.RWMutex
@@ -39,7 +38,6 @@ func New(store kvstore.KVStore, objectFactory StorableObjectFactory, optionalOpt
 	storageOptions := newOptions(store, optionalOptions)
 
 	result := &ObjectStorage{
-		store:             storageOptions.store,
 		objectFactory:     objectFactory,
 		cachedObjects:     make(map[string]interface{}),
 		partitionsManager: NewPartitionsManager(),
@@ -411,13 +409,13 @@ func (objectStorage *ObjectStorage) ForEach(consumer func(key []byte, cachedObje
 	}
 
 	if objectStorage.options.keysOnly {
-		_ = objectStorage.store.IterateKeys(opts.optionalPrefix, func(key kvstore.Key) bool {
+		_ = objectStorage.options.store.IterateKeys(opts.optionalPrefix, func(key kvstore.Key) bool {
 			return consumeFunc(key, []byte{})
 		})
 		return
 	}
 
-	_ = objectStorage.store.Iterate(opts.optionalPrefix, consumeFunc)
+	_ = objectStorage.options.store.Iterate(opts.optionalPrefix, consumeFunc)
 }
 
 // ForEachKeyOnly calls the consumer function on every storage key residing within the cache and the underlying persistence layer.
@@ -461,7 +459,7 @@ func (objectStorage *ObjectStorage) ForEachKeyOnly(consumer func(key []byte) boo
 		return
 	}
 
-	_ = objectStorage.store.IterateKeys(opts.optionalPrefix,
+	_ = objectStorage.options.store.IterateKeys(opts.optionalPrefix,
 		func(key kvstore.Key) bool {
 			if _, elementSeen := seenElements[string(key)]; elementSeen {
 				return true
@@ -492,7 +490,7 @@ func (objectStorage *ObjectStorage) Prune() error {
 	})
 
 	objectStorage.cacheMutex.Lock()
-	if err := objectStorage.store.Clear(); err != nil {
+	if err := objectStorage.options.store.Clear(); err != nil {
 		objectStorage.cacheMutex.Unlock()
 		objectStorage.flushMutex.Unlock()
 		return err
@@ -843,7 +841,7 @@ func (objectStorage *ObjectStorage) LoadObjectFromStore(key []byte) StorableObje
 	}
 
 	if objectStorage.options.keysOnly {
-		contains, err := objectStorage.store.Has(key)
+		contains, err := objectStorage.options.store.Has(key)
 		if err != nil {
 			// No need to check for kvstore.ErrKeyNotFound here
 			panic(err)
@@ -862,7 +860,7 @@ func (objectStorage *ObjectStorage) LoadObjectFromStore(key []byte) StorableObje
 	}
 
 	var marshaledData []byte
-	value, err := objectStorage.store.Get(key)
+	value, err := objectStorage.options.store.Get(key)
 	if err != nil {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
 			return nil
@@ -883,7 +881,7 @@ func (objectStorage *ObjectStorage) DeleteEntryFromStore(key []byte) {
 		return
 	}
 
-	if err := objectStorage.store.Delete(key); err != nil {
+	if err := objectStorage.options.store.Delete(key); err != nil {
 		if !errors.Is(err, kvstore.ErrKeyNotFound) {
 			panic(err)
 		}
@@ -896,7 +894,7 @@ func (objectStorage *ObjectStorage) DeleteEntriesFromStore(keys [][]byte) {
 		return
 	}
 
-	batchedMuts := objectStorage.store.Batched()
+	batchedMuts := objectStorage.options.store.Batched()
 	for i := 0; i < len(keys); i++ {
 		if err := batchedMuts.Delete(keys[i]); err != nil {
 			batchedMuts.Cancel()
@@ -914,7 +912,7 @@ func (objectStorage *ObjectStorage) ObjectExistsInStore(key []byte) bool {
 		return false
 	}
 
-	has, err := objectStorage.store.Has(key)
+	has, err := objectStorage.options.store.Has(key)
 	if err != nil {
 		if !errors.Is(err, kvstore.ErrKeyNotFound) {
 			panic(err)

--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -42,9 +42,7 @@ func newOptions(store kvstore.KVStore, optionalOptions []Option) *Options {
 		result.leakDetectionWrapper = newLeakDetectionWrapperImpl
 	}
 
-	if result.batchedWriterInstance == nil {
-		result.batchedWriterInstance = kvstore.NewBatchedWriter(result.store)
-	}
+	result.batchedWriterInstance = kvstore.NewBatchedWriter(result.store)
 
 	return result
 }
@@ -127,12 +125,6 @@ func LogAccess(fileName string, commandsFilter ...debug.Command) Option {
 		args.store = debug.New(args.store, func(command debug.Command, parameters ...[]byte) {
 			logChannel <- logEntry{time.Now(), command, parameters}
 		}, commandsFilter...)
-	}
-}
-
-func BatchedWriterInstance(batchedWriterInstance *kvstore.BatchedWriter) Option {
-	return func(args *Options) {
-		args.batchedWriterInstance = batchedWriterInstance
 	}
 }
 


### PR DESCRIPTION
# Description of change

Added new debug KVStore that wraps a given KVStore and accepts an AccessCallback and CommandFilter. This can be used instead of adding the AccessCallback on all KVStore implementations

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested
- The kvstore_test.go was executed with the new KVStore interface and all tests passed. The new store is not by default added to the kvstore_test.go dbImplementations to avoid spamming the test-log.

## Change checklist

- [ x] My code follows the contribution guidelines for this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
