### PR TITLE
Added mock RocksDB KVStore

### DIFF
--- a/kvstore/rocksdb/rocksdb.go
+++ b/kvstore/rocksdb/rocksdb.go
@@ -1,0 +1,70 @@
+package rocksdb
+
+import (
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+type rocksDBStore struct {
+}
+
+// New creates a new KVStore with the underlying RocksDB.
+func New(db *RocksDB) kvstore.KVStore {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) WithRealm(realm kvstore.Realm) kvstore.KVStore {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Realm() []byte {
+	panic(panicMissingRocksDB)
+}
+
+// Shutdown marks the store as shutdown.
+func (s *rocksDBStore) Shutdown() {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc) error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc) error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Clear() error {
+	return s.DeletePrefix(kvstore.EmptyPrefix)
+}
+
+func (s *rocksDBStore) Get(key kvstore.Key) (kvstore.Value, error) {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Set(key kvstore.Key, value kvstore.Value) error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Has(key kvstore.Key) (bool, error) {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Delete(key kvstore.Key) error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Batched() kvstore.BatchedMutations {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Flush() error {
+	panic(panicMissingRocksDB)
+}
+
+func (s *rocksDBStore) Close() error {
+	panic(panicMissingRocksDB)
+}

--- a/kvstore/rocksdb/rocksdb_instance.go
+++ b/kvstore/rocksdb/rocksdb_instance.go
@@ -1,0 +1,59 @@
+package rocksdb
+
+const (
+	panicMissingRocksDB = "For RocksDB use the hive.go feat/RocksDB branch"
+)
+
+type RocksDB struct {
+}
+
+type RocksDBOptions struct {
+	compression bool
+	fillCache   bool
+	sync        bool
+}
+
+type RocksDBOption func(*RocksDBOptions)
+
+// UseCompression sets opts.SetCompression(grocksdb.ZSTDCompression)
+func UseCompression(compression bool) RocksDBOption {
+	return func(args *RocksDBOptions) {
+		args.compression = compression
+	}
+}
+
+// ReadFillCache sets the opts.SetFillCache ReadOption
+func ReadFillCache(fillCache bool) RocksDBOption {
+	return func(args *RocksDBOptions) {
+		args.fillCache = fillCache
+	}
+}
+
+// WriteSync sets the opts.SetSync WriteOption
+func WriteSync(sync bool) RocksDBOption {
+	return func(args *RocksDBOptions) {
+		args.sync = sync
+	}
+}
+
+func dbOptions(optionalOptions []RocksDBOption) *RocksDBOptions {
+	result := &RocksDBOptions{}
+
+	for _, optionalOption := range optionalOptions {
+		optionalOption(result)
+	}
+	return result
+}
+
+// NewRocksDB creates a new RocksDB instance.
+func CreateDB(directory string, options ...RocksDBOption) (*RocksDB, error) {
+	panic(panicMissingRocksDB)
+}
+
+func (r *RocksDB) Flush() error {
+	panic(panicMissingRocksDB)
+}
+
+func (r *RocksDB) Close() error {
+	panic(panicMissingRocksDB)
+}


### PR DESCRIPTION
# Description of change

Added mock RocksDB KVStore that panics if used with a notice to use the `feat/RocksDB` branch.
This way we can have the interfaces and optional RocksDB support without requiring librocksdb even if unused.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
