### PR TITLE
Add ReadOptions to object storage

### DIFF
--- a/objectstorage/options.go
+++ b/objectstorage/options.go
@@ -196,11 +196,49 @@ func OnEvictionCallback(cb func(cachedObject CachedObject)) Option {
 	}
 }
 
+// the default options used for object storage Contains calls.
+var defaultReadOptions = []ReadOption{
+	WithReadSkipCache(false),
+	WithReadSkipStorage(false),
+}
+
+// ReadOption is a function setting a read option.
+type ReadOption func(opts *ReadOptions)
+
+// ReadOptions define options for Contains calls in the object storage.
+type ReadOptions struct {
+	// whether to skip the elements in the cache.
+	skipCache bool
+	// whether to skip the elements in the storage.
+	skipStorage bool
+}
+
+// applies the given ReadOption.
+func (o *ReadOptions) apply(opts ...ReadOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// WithReadSkipCache is used to skip the elements in the cache.
+func WithReadSkipCache(skipCache bool) ReadOption {
+	return func(opts *ReadOptions) {
+		opts.skipCache = skipCache
+	}
+}
+
+// WithReadSkipStorage is used to skip the elements in the storage.
+func WithReadSkipStorage(skipStorage bool) ReadOption {
+	return func(opts *ReadOptions) {
+		opts.skipStorage = skipStorage
+	}
+}
+
 // the default options used for object storage iteration.
 var defaultIteratorOptions = []IteratorOption{
-	WithSkipCache(false),
-	WithSkipStorage(false),
-	WithPrefix(kvstore.EmptyPrefix),
+	WithIteratorSkipCache(false),
+	WithIteratorSkipStorage(false),
+	WithIteratorPrefix(kvstore.EmptyPrefix),
 }
 
 // IteratorOption is a function setting an iterator option.
@@ -223,22 +261,22 @@ func (o *IteratorOptions) apply(opts ...IteratorOption) {
 	}
 }
 
-// WithSkipCache is used to skip the elements in the cache.
-func WithSkipCache(skipCache bool) IteratorOption {
+// WithIteratorSkipCache is used to skip the elements in the cache.
+func WithIteratorSkipCache(skipCache bool) IteratorOption {
 	return func(opts *IteratorOptions) {
 		opts.skipCache = skipCache
 	}
 }
 
-// WithSkipStorage is used to skip the elements in the storage.
-func WithSkipStorage(skipStorage bool) IteratorOption {
+// WithIteratorSkipStorage is used to skip the elements in the storage.
+func WithIteratorSkipStorage(skipStorage bool) IteratorOption {
 	return func(opts *IteratorOptions) {
 		opts.skipStorage = skipStorage
 	}
 }
 
-// WithPrefix is used to iterate a subset of elements with a defined prefix.
-func WithPrefix(prefix []byte) IteratorOption {
+// WithIteratorPrefix is used to iterate a subset of elements with a defined prefix.
+func WithIteratorPrefix(prefix []byte) IteratorOption {
 	return func(opts *IteratorOptions) {
 		opts.optionalPrefix = prefix
 	}

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -461,7 +461,7 @@ func TestPrefixIteration(t *testing.T) {
 		delete(expectedKeys, string(key))
 		cachedObject.Release()
 		return true
-	}, objectstorage.WithPrefix([]byte("")))
+	}, objectstorage.WithIteratorPrefix([]byte("")))
 
 	assert.Equal(t, 0, len(expectedKeys))
 
@@ -475,7 +475,7 @@ func TestPrefixIteration(t *testing.T) {
 		delete(expectedKeys, string(key))
 		cachedObject.Release()
 		return true
-	}, objectstorage.WithPrefix([]byte("1")))
+	}, objectstorage.WithIteratorPrefix([]byte("1")))
 
 	assert.Equal(t, 0, len(expectedKeys))
 
@@ -488,7 +488,7 @@ func TestPrefixIteration(t *testing.T) {
 		delete(expectedKeys, string(key))
 		cachedObject.Release()
 		return true
-	}, objectstorage.WithPrefix([]byte("12")))
+	}, objectstorage.WithIteratorPrefix([]byte("12")))
 
 	assert.Equal(t, 0, len(expectedKeys))
 
@@ -917,7 +917,7 @@ func TestForEachWithPrefix(t *testing.T) {
 		delete(expectedKeys, string(key))
 		cachedObject.Release()
 		return true
-	}, objectstorage.WithPrefix([]byte("1")))
+	}, objectstorage.WithIteratorPrefix([]byte("1")))
 
 	assert.Equal(t, 0, len(expectedKeys))
 
@@ -960,7 +960,7 @@ func TestForEachKeyOnlyWithPrefix(t *testing.T) {
 
 		delete(expectedKeys, string(key))
 		return true
-	}, objectstorage.WithPrefix([]byte("1")))
+	}, objectstorage.WithIteratorPrefix([]byte("1")))
 
 	assert.Equal(t, 0, len(expectedKeys))
 
@@ -1003,7 +1003,7 @@ func TestForEachKeyOnlySkippingCacheWithPrefix(t *testing.T) {
 
 		delete(expectedKeys, string(key))
 		return true
-	}, objectstorage.WithPrefix([]byte("1")), objectstorage.WithSkipCache(true))
+	}, objectstorage.WithIteratorPrefix([]byte("1")), objectstorage.WithIteratorSkipCache(true))
 
 	assert.Equal(t, 0, len(expectedKeys))
 


### PR DESCRIPTION
# Description of change

This adds a ReadOption to the `Contains` call in object storage, so we can specify if we want to skip the cache or the storage.
The Iterator options had to be renamed.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Tests still pass.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
