### PR TITLE
fix bug in BLS public key unmarshalling

### DIFF
--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -41,3 +41,13 @@ func TestSingleSignature(t *testing.T) {
 	assert.True(t, signature.IsValid(dataToSign))
 	assert.False(t, signature.IsValid([]byte("some other data")))
 }
+
+func TestMarshalPublicKey(t *testing.T) {
+	privateKey := PrivateKeyFromRandomness()
+	pubKey := privateKey.PublicKey()
+
+	pubKeyBytes := pubKey.Bytes()
+	pubKeyBack, _, err := PublicKeyFromBytes(pubKeyBytes)
+	require.NoError(t, err)
+	require.EqualValues(t, pubKeyBytes, pubKeyBack.Bytes())
+}

--- a/crypto/bls/publickey.go
+++ b/crypto/bls/publickey.go
@@ -47,7 +47,7 @@ func PublicKeyFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (publicKey P
 		err = xerrors.Errorf("failed to read PublicKey bytes (%v): %w", err, ErrParseBytesFailed)
 		return
 	}
-
+	publicKey.Point = blsSuite.G2().Point()
 	if err = publicKey.Point.UnmarshalBinary(bytes); err != nil {
 		err = xerrors.Errorf("failed to unmarshal PublicKey (%v): %w", err, ErrParseBytesFailed)
 		return


### PR DESCRIPTION
# Description of change

The use of BLS signature in Goshimmer transactions panics while unmarshalling transaction with BLS signature

## Type of change

- Bug fix

## How the change has been tested

Added one unit test for BLS public key marshalling

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x ] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
