### PR TITLE
Feat: Changed TimedQueue to use sync.Cond for waiting

### DIFF
--- a/timedqueue/timedqueue.go
+++ b/timedqueue/timedqueue.go
@@ -52,8 +52,6 @@ func (t *TimedQueue) Add(value interface{}, scheduledTime time.Time) (addedEleme
 
 	// acquire locks
 	t.heapMutex.Lock()
-	defer t.heapMutex.Unlock()
-	defer t.waitCond.Signal()
 
 	// add new element
 	addedElement = &QueueElement{
@@ -64,6 +62,12 @@ func (t *TimedQueue) Add(value interface{}, scheduledTime time.Time) (addedEleme
 		index:         0,
 	}
 	heap.Push(&t.heap, addedElement)
+
+	// release locks
+	t.heapMutex.Unlock()
+
+	// signal waiting goroutine to wake up
+	t.waitCond.Signal()
 
 	return
 }


### PR DESCRIPTION
# Description of change

This PR modifies the used syncronization mechanism for TimedQueues to fix a bug with negative WaitGroup counters and to make the logic simpler and work around possible deadlocks.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
