### PR TITLE
Peer JSON serialization/deserialization

### DIFF
--- a/autopeering/peer/peer.go
+++ b/autopeering/peer/peer.go
@@ -131,17 +131,18 @@ func Unmarshal(data []byte) (*Peer, error) {
 }
 
 type peerJSON struct {
-	PublicKey []byte          `json:"publicKey"`
+	PublicKey string          `json:"publicKey"`
 	IP        net.IP          `json:"ip"`
 	Services  *service.Record `json:"services"`
 }
 
+// UnmarshalJSON de-serializes given json data into a Peer struct.
 func (p *Peer) UnmarshalJSON(b []byte) error {
 	pj := &peerJSON{}
 	if err := json.Unmarshal(b, pj); err != nil {
 		return xerrors.Errorf("%w", err)
 	}
-	publicKey, _, err := ed25519.PublicKeyFromBytes(pj.PublicKey)
+	publicKey, err := ed25519.PublicKeyFromString(pj.PublicKey)
 	if err != nil {
 		return xerrors.Errorf("can't parse public key: %w", err)
 	}
@@ -153,9 +154,10 @@ func (p *Peer) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON serializes Peer into json data.
 func (p *Peer) MarshalJSON() ([]byte, error) {
 	pj := &peerJSON{
-		PublicKey: p.PublicKey().Bytes(),
+		PublicKey: p.PublicKey().String(),
 		IP:        p.ip,
 		Services:  p.services,
 	}

--- a/autopeering/peer/peer.go
+++ b/autopeering/peer/peer.go
@@ -136,7 +136,7 @@ type peerJSON struct {
 	Services  *service.Record `json:"services"`
 }
 
-// UnmarshalJSON de-serializes given json data into a Peer struct.
+// UnmarshalJSON deserializes given json data into a Peer struct.
 func (p *Peer) UnmarshalJSON(b []byte) error {
 	pj := &peerJSON{}
 	if err := json.Unmarshal(b, pj); err != nil {

--- a/autopeering/peer/peer.go
+++ b/autopeering/peer/peer.go
@@ -1,9 +1,12 @@
 package peer
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+
+	"golang.org/x/xerrors"
 
 	pb "github.com/iotaledger/hive.go/autopeering/peer/proto"
 	"github.com/iotaledger/hive.go/autopeering/peer/service"
@@ -125,4 +128,36 @@ func Unmarshal(data []byte) (*Peer, error) {
 		return nil, err
 	}
 	return FromProto(s)
+}
+
+type peerJSON struct {
+	PublicKey []byte          `json:"publicKey"`
+	IP        net.IP          `json:"ip"`
+	Services  *service.Record `json:"services"`
+}
+
+func (p *Peer) UnmarshalJSON(b []byte) error {
+	pj := &peerJSON{}
+	if err := json.Unmarshal(b, pj); err != nil {
+		return xerrors.Errorf("%w", err)
+	}
+	publicKey, _, err := ed25519.PublicKeyFromBytes(pj.PublicKey)
+	if err != nil {
+		return xerrors.Errorf("can't parse public key: %w", err)
+	}
+	id := identity.New(publicKey)
+	if pj.Services.Get(service.PeeringKey) == nil {
+		return xerrors.Errorf("invalid services json: %w", ErrNeedsPeeringService)
+	}
+	*p = *NewPeer(id, pj.IP, pj.Services)
+	return nil
+}
+
+func (p *Peer) MarshalJSON() ([]byte, error) {
+	pj := &peerJSON{
+		PublicKey: p.PublicKey().Bytes(),
+		IP:        p.ip,
+		Services:  p.services,
+	}
+	return json.Marshal(pj)
 }

--- a/autopeering/peer/peer_test.go
+++ b/autopeering/peer/peer_test.go
@@ -1,6 +1,7 @@
 package peer
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -59,6 +60,32 @@ func TestMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, p, got)
+}
+
+func TestMarshalUnmarshalJSON(t *testing.T) {
+	p := newTestPeer("test")
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	got := &Peer{}
+	err = json.Unmarshal(data, got)
+	require.NoError(t, err)
+
+	assert.Equal(t, p, got)
+}
+
+func TestMarshalUnmarshalJSONSlice(t *testing.T) {
+	peers := []*Peer{newTestPeer("test2"), newTestPeer("test2"), newTestPeer("test2")}
+
+	data, err := json.Marshal(peers)
+	require.NoError(t, err)
+
+	var got []*Peer
+	err = json.Unmarshal(data, &got)
+	require.NoError(t, err)
+
+	assert.Equal(t, peers, got)
 }
 
 func TestRecoverKeyFromSignedData(t *testing.T) {

--- a/autopeering/peer/service/record.go
+++ b/autopeering/peer/service/record.go
@@ -116,6 +116,7 @@ type endpointJSON struct {
 	Port    int    `json:"port"`
 }
 
+// UnmarshalJSON deserializes JSON data into Record struct.
 func (s *Record) UnmarshalJSON(b []byte) error {
 	m := map[string]endpointJSON{}
 	if err := json.Unmarshal(b, &m); err != nil {
@@ -129,6 +130,7 @@ func (s *Record) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON serializes Record struct into JSON data.
 func (s *Record) MarshalJSON() ([]byte, error) {
 	m := make(map[string]endpointJSON, len(s.m))
 	for service, addr := range s.m {

--- a/autopeering/peer/service/record.go
+++ b/autopeering/peer/service/record.go
@@ -1,7 +1,10 @@
 package service
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"golang.org/x/xerrors"
 
 	pb "github.com/iotaledger/hive.go/autopeering/peer/service/proto"
 	"google.golang.org/protobuf/proto"
@@ -106,6 +109,35 @@ func (s *Record) ToProto() *pb.ServiceMap {
 	return &pb.ServiceMap{
 		Map: services,
 	}
+}
+
+type endpointJSON struct {
+	Network string `json:"network"`
+	Port    int    `json:"port"`
+}
+
+func (s *Record) UnmarshalJSON(b []byte) error {
+	m := map[string]endpointJSON{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return xerrors.Errorf("failed to parse services map: %w", err)
+	}
+	services := New()
+	for service, addr := range m {
+		services.m[service] = endpoint{network: addr.Network, port: addr.Port}
+	}
+	*s = *services
+	return nil
+}
+
+func (s *Record) MarshalJSON() ([]byte, error) {
+	m := make(map[string]endpointJSON, len(s.m))
+	for service, addr := range s.m {
+		m[service] = endpointJSON{
+			Network: addr.network,
+			Port:    addr.port,
+		}
+	}
+	return json.Marshal(m)
 }
 
 // Marshal serializes a given Peer (p) into a slice of bytes.

--- a/crypto/ed25519/public_key.go
+++ b/crypto/ed25519/public_key.go
@@ -18,7 +18,7 @@ type PublicKey [PublicKeySize]byte
 func PublicKeyFromString(s string) (publicKey PublicKey, err error) {
 	b, err := base58.Decode(s)
 	if err != nil {
-		return publicKey, xerrors.Errorf("failed to parse public key from bas58 string")
+		return publicKey, xerrors.Errorf("failed to parse public key %s from base58 string: %w", s, err)
 	}
 	publicKey, _, err = PublicKeyFromBytes(b)
 	return publicKey, err

--- a/crypto/ed25519/public_key.go
+++ b/crypto/ed25519/public_key.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/xerrors"
+
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/mr-tron/base58"
 	"github.com/oasisprotocol/ed25519"
@@ -11,6 +13,16 @@ import (
 
 // PublicKey is the type of Ed25519 public keys.
 type PublicKey [PublicKeySize]byte
+
+// PublicKeyFromString parses give string with base58 encoding and returns a PublicKey.
+func PublicKeyFromString(s string) (publicKey PublicKey, err error) {
+	b, err := base58.Decode(s)
+	if err != nil {
+		return publicKey, xerrors.Errorf("failed to parse public key from bas58 string")
+	}
+	publicKey, _, err = PublicKeyFromBytes(b)
+	return publicKey, err
+}
 
 // PublicKeyFromBytes creates a PublicKey from the given bytes.
 func PublicKeyFromBytes(bytes []byte) (result PublicKey, consumedBytes int, err error) {

--- a/crypto/ed25519/public_key.go
+++ b/crypto/ed25519/public_key.go
@@ -14,7 +14,7 @@ import (
 // PublicKey is the type of Ed25519 public keys.
 type PublicKey [PublicKeySize]byte
 
-// PublicKeyFromString parses give string with base58 encoding and returns a PublicKey.
+// PublicKeyFromString parses the given string with base58 encoding and returns a PublicKey.
 func PublicKeyFromString(s string) (publicKey PublicKey, err error) {
 	b, err := base58.Decode(s)
 	if err != nil {


### PR DESCRIPTION
# Description of change

This PR adds JSON serialization/deserialization methods to `Peer` struct. The original need for this is the ability to manually pass neighbors to the gossip layer via JSON HTTP API or configuration file in Goshimmer, see https://github.com/iotaledger/goshimmer/pull/1191.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement


## How the change has been tested

The code is covered with unittests 

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
