### PR TITLE
Feat: Allow to attach callbacks to before and after triggering an Event

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -5,15 +5,38 @@ import (
 )
 
 type Event struct {
-	triggerFunc func(handler interface{}, params ...interface{})
-	callbacks   map[uintptr]interface{}
-	mutex       syncutils.RWMutex
+	triggerFunc     func(handler interface{}, params ...interface{})
+	beforeCallbacks map[uintptr]interface{}
+	callbacks       map[uintptr]interface{}
+	afterCallbacks  map[uintptr]interface{}
+	mutex           syncutils.RWMutex
+}
+
+func (ev *Event) AttachBefore(closure *Closure) {
+	ev.mutex.Lock()
+	defer ev.mutex.Unlock()
+	if ev.beforeCallbacks == nil {
+		ev.beforeCallbacks = make(map[uintptr]interface{})
+	}
+	ev.beforeCallbacks[closure.Id] = closure.Fnc
 }
 
 func (ev *Event) Attach(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
+	if ev.callbacks == nil {
+		ev.callbacks = make(map[uintptr]interface{})
+	}
 	ev.callbacks[closure.Id] = closure.Fnc
+}
+
+func (ev *Event) AttachAfter(closure *Closure) {
+	ev.mutex.Lock()
+	defer ev.mutex.Unlock()
+	if ev.afterCallbacks == nil {
+		ev.afterCallbacks = make(map[uintptr]interface{})
+	}
+	ev.afterCallbacks[closure.Id] = closure.Fnc
 }
 
 func (ev *Event) Detach(closure *Closure) {
@@ -22,26 +45,50 @@ func (ev *Event) Detach(closure *Closure) {
 	}
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
+	delete(ev.beforeCallbacks, closure.Id)
+	if len(ev.beforeCallbacks) == 0 {
+		ev.beforeCallbacks = nil
+	}
 	delete(ev.callbacks, closure.Id)
+	if len(ev.callbacks) == 0 {
+		ev.callbacks = nil
+	}
+	delete(ev.afterCallbacks, closure.Id)
+	if len(ev.afterCallbacks) == 0 {
+		ev.afterCallbacks = nil
+	}
 }
 
 func (ev *Event) Trigger(params ...interface{}) {
 	ev.mutex.RLock()
 	defer ev.mutex.RUnlock()
-	for _, handler := range ev.callbacks {
-		ev.triggerFunc(handler, params...)
+	if ev.beforeCallbacks != nil {
+		for _, handler := range ev.beforeCallbacks {
+			ev.triggerFunc(handler, params...)
+		}
+	}
+	if ev.callbacks != nil {
+		for _, handler := range ev.callbacks {
+			ev.triggerFunc(handler, params...)
+		}
+	}
+	if ev.afterCallbacks != nil {
+		for _, handler := range ev.afterCallbacks {
+			ev.triggerFunc(handler, params...)
+		}
 	}
 }
 
 func (ev *Event) DetachAll() {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
-	ev.callbacks = make(map[uintptr]interface{})
+	ev.beforeCallbacks = nil
+	ev.callbacks = nil
+	ev.afterCallbacks = nil
 }
 
 func NewEvent(triggerFunc func(handler interface{}, params ...interface{})) *Event {
 	return &Event{
 		triggerFunc: triggerFunc,
-		callbacks:   make(map[uintptr]interface{}),
 	}
 }

--- a/events/event.go
+++ b/events/event.go
@@ -12,6 +12,7 @@ type Event struct {
 	mutex           syncutils.RWMutex
 }
 
+// AttachBefore allows to register a Closure that is executed before the Event triggers.
 func (ev *Event) AttachBefore(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
@@ -30,6 +31,7 @@ func (ev *Event) Attach(closure *Closure) {
 	ev.callbacks[closure.Id] = closure.Fnc
 }
 
+// AttachAfter allows to register a Closure that is executed after the Event triggered.
 func (ev *Event) AttachAfter(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()


### PR DESCRIPTION
# Description of change

Sometimes it is good to be able to trigger callbacks after a certain event has triggered (i.e. for debugging purposes in the tests). This PR adds an AttachAfter and an AttachBefore to every Event.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
