### PR TITLE
Feat: made Closure.ID unique

### DIFF
--- a/events/closure.go
+++ b/events/closure.go
@@ -1,18 +1,21 @@
 package events
 
-import "reflect"
+import (
+	"sync/atomic"
+)
+
+var idCounter uint64
 
 type Closure struct {
-	Id  uintptr
+	ID  uint64
 	Fnc interface{}
 }
 
 func NewClosure(f interface{}) *Closure {
 	closure := &Closure{
+		ID:  atomic.AddUint64(&idCounter, 1),
 		Fnc: f,
 	}
-
-	closure.Id = reflect.ValueOf(closure).Pointer()
 
 	return closure
 }

--- a/events/event.go
+++ b/events/event.go
@@ -6,9 +6,9 @@ import (
 
 type Event struct {
 	triggerFunc     func(handler interface{}, params ...interface{})
-	beforeCallbacks map[uintptr]interface{}
-	callbacks       map[uintptr]interface{}
-	afterCallbacks  map[uintptr]interface{}
+	beforeCallbacks map[uint64]interface{}
+	callbacks       map[uint64]interface{}
+	afterCallbacks  map[uint64]interface{}
 	mutex           syncutils.RWMutex
 }
 
@@ -17,18 +17,18 @@ func (ev *Event) AttachBefore(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
 	if ev.beforeCallbacks == nil {
-		ev.beforeCallbacks = make(map[uintptr]interface{})
+		ev.beforeCallbacks = make(map[uint64]interface{})
 	}
-	ev.beforeCallbacks[closure.Id] = closure.Fnc
+	ev.beforeCallbacks[closure.ID] = closure.Fnc
 }
 
 func (ev *Event) Attach(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
 	if ev.callbacks == nil {
-		ev.callbacks = make(map[uintptr]interface{})
+		ev.callbacks = make(map[uint64]interface{})
 	}
-	ev.callbacks[closure.Id] = closure.Fnc
+	ev.callbacks[closure.ID] = closure.Fnc
 }
 
 // AttachAfter allows to register a Closure that is executed after the Event triggered.
@@ -36,9 +36,9 @@ func (ev *Event) AttachAfter(closure *Closure) {
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
 	if ev.afterCallbacks == nil {
-		ev.afterCallbacks = make(map[uintptr]interface{})
+		ev.afterCallbacks = make(map[uint64]interface{})
 	}
-	ev.afterCallbacks[closure.Id] = closure.Fnc
+	ev.afterCallbacks[closure.ID] = closure.Fnc
 }
 
 func (ev *Event) Detach(closure *Closure) {
@@ -47,15 +47,15 @@ func (ev *Event) Detach(closure *Closure) {
 	}
 	ev.mutex.Lock()
 	defer ev.mutex.Unlock()
-	delete(ev.beforeCallbacks, closure.Id)
+	delete(ev.beforeCallbacks, closure.ID)
 	if len(ev.beforeCallbacks) == 0 {
 		ev.beforeCallbacks = nil
 	}
-	delete(ev.callbacks, closure.Id)
+	delete(ev.callbacks, closure.ID)
 	if len(ev.callbacks) == 0 {
 		ev.callbacks = nil
 	}
-	delete(ev.afterCallbacks, closure.Id)
+	delete(ev.afterCallbacks, closure.ID)
 	if len(ev.afterCallbacks) == 0 {
 		ev.afterCallbacks = nil
 	}


### PR DESCRIPTION
# Description of change

The ID of the Closure was calculated using the pointer of the Closure object. This could lead to rare edge cases where two registered Callbacks received the same ID if the underlying Closure object was garbage collected in the mean time.

This PR fixes this problem by always assigning a new unique ID for every containing Closure.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
