### PR TITLE
Add JSON marshalling methods to PublicKey type

### DIFF
--- a/crypto/ed25519/public_key.go
+++ b/crypto/ed25519/public_key.go
@@ -1,6 +1,7 @@
 package ed25519
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -88,4 +89,21 @@ func (publicKey *PublicKey) UnmarshalBinary(bytes []byte) (err error) {
 	copy(publicKey[:], bytes[:])
 
 	return
+}
+
+func (publicKey PublicKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(publicKey.String())
+}
+
+func (publicKey *PublicKey) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	pk, err := PublicKeyFromString(s)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key from JSON: %w", err)
+	}
+	*publicKey = pk
+	return nil
 }

--- a/crypto/ed25519/public_key.go
+++ b/crypto/ed25519/public_key.go
@@ -91,10 +91,12 @@ func (publicKey *PublicKey) UnmarshalBinary(bytes []byte) (err error) {
 	return
 }
 
+// MarshalJSON serializes public key to JSON as base58 encoded string.
 func (publicKey PublicKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(publicKey.String())
 }
 
+// UnmarshalJSON parses public key from JSON in base58 encoding.
 func (publicKey *PublicKey) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/crypto/ed25519/public_key_test.go
+++ b/crypto/ed25519/public_key_test.go
@@ -1,6 +1,7 @@
 package ed25519
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,24 @@ func TestPublicKey_VerifySignature(t *testing.T) {
 	sig := privateKey.Sign(data)
 
 	assert.True(t, publicKey.VerifySignature(data, sig))
+}
+
+func TestPublicKey_MarshalJSON(t *testing.T) {
+	pk, err := PublicKeyFromString("CHfU1NUf6ZvUKDQHTG2df53GR7CvuMFtyt7YymJ6DwS3")
+	require.NoError(t, err)
+	b, err := json.Marshal(pk)
+	require.NoError(t, err)
+	got := string(b)
+	assert.Equal(t, `"CHfU1NUf6ZvUKDQHTG2df53GR7CvuMFtyt7YymJ6DwS3"`, got)
+}
+
+func TestPublicKey_UnmarshalJSON(t *testing.T) {
+	jsonData := `"CHfU1NUf6ZvUKDQHTG2df53GR7CvuMFtyt7YymJ6DwS3"`
+	var got PublicKey
+	err := json.Unmarshal([]byte(jsonData), &got)
+	require.NoError(t, err)
+
+	expected, err := PublicKeyFromString("CHfU1NUf6ZvUKDQHTG2df53GR7CvuMFtyt7YymJ6DwS3")
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
 }


### PR DESCRIPTION
Now `PublicKey` marshals to JSON as base58 encoded string to be consistent with all other forms of representation.

Without that change the `PublicKey` was serializing to JSON as a list of integers for each byte from the key. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

Covered with unit tests

