### PR TITLE
Batched db commit operation should be atomic

### DIFF
--- a/kvstore/mapdb/mapdb.go
+++ b/kvstore/mapdb/mapdb.go
@@ -13,7 +13,7 @@ import (
 
 // mapDB is a simple implementation of KVStore using a map.
 type mapDB struct {
-	sync.Mutex
+	sync.RWMutex
 	m     *syncedKVMap
 	realm []byte
 }
@@ -59,8 +59,8 @@ func (s *mapDB) Clear() error {
 }
 
 func (s *mapDB) Get(key kvstore.Key) (kvstore.Value, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	value, contains := s.m.get(byteutils.ConcatBytes(s.realm, key))
 	if !contains {
@@ -82,8 +82,8 @@ func (s *mapDB) set(key kvstore.Key, value kvstore.Value) error {
 }
 
 func (s *mapDB) Has(key kvstore.Key) (bool, error) {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	contains := s.m.has(byteutils.ConcatBytes(s.realm, key))
 	return contains, nil


### PR DESCRIPTION
# Description of change

Batched db commit operation is supposed to be atomic, however during the commit external processes can read/write the backing database. This change locks db for reads/writes during the commit.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I ran all the test of Hive and they passed.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] Existing unit tests pass locally with my changes
