### PR TITLE
Add done reading function to marshalutil

### DIFF
--- a/marshalutil/marshalutil.go
+++ b/marshalutil/marshalutil.go
@@ -105,7 +105,7 @@ func (util *MarshalUtil) Bytes(clone ...bool) []byte {
 	return util.bytes[:util.size]
 }
 
-// DoneReading checks if there are any bytes left to read
+// DoneReading checks if there are any bytes left to read.
 func (util *MarshalUtil) DoneReading() (bool, error) {
 	_, err := util.checkReadCapacity(0)
 	return util.ReadOffset() == util.size, err

--- a/marshalutil/marshalutil.go
+++ b/marshalutil/marshalutil.go
@@ -105,9 +105,10 @@ func (util *MarshalUtil) Bytes(clone ...bool) []byte {
 	return util.bytes[:util.size]
 }
 
-//DoneReading checks if there are any bytes left to read
-func (util *MarshalUtil) DoneReading() bool {
-	return util.ReadOffset() >= util.size
+// DoneReading checks if there are any bytes left to read
+func (util *MarshalUtil) DoneReading() (bool, error) {
+	_, err := util.checkReadCapacity(0)
+	return util.ReadOffset() == util.size, err
 }
 
 // checkReadCapacity checks if the internal buffer has enough bytes left to successfully read the given length.

--- a/marshalutil/marshalutil.go
+++ b/marshalutil/marshalutil.go
@@ -105,6 +105,11 @@ func (util *MarshalUtil) Bytes(clone ...bool) []byte {
 	return util.bytes[:util.size]
 }
 
+//DoneReading checks if there are any bytes left to read
+func (util *MarshalUtil) DoneReading() bool {
+	return util.ReadOffset() >= util.size
+}
+
 // checkReadCapacity checks if the internal buffer has enough bytes left to successfully read the given length.
 func (util *MarshalUtil) checkReadCapacity(length int) (readEndOffset int, err error) {
 	readEndOffset = util.readOffset + length


### PR DESCRIPTION
# Description of change

Allows clients to check whether we are done reading the bytes to be marshalled
Useful when the size is not known in advanced

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

In goshimmer it seems to work well. I am persisting several transactionIDs concatenated together and it works with no issues

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
