### PR TITLE
Add max size to the timed queue and timed executor

### DIFF
--- a/timedqueue/timedqueue_test.go
+++ b/timedqueue/timedqueue_test.go
@@ -1,6 +1,7 @@
 package timedqueue
 
 import (
+	"container/heap"
 	"runtime"
 	"runtime/debug"
 	"sync/atomic"
@@ -45,4 +46,37 @@ func memStats() *runtime.MemStats {
 	runtime.ReadMemStats(&memStats)
 
 	return &memStats
+}
+
+func TestQueueSize(t *testing.T) {
+	const maxSize = 100
+	t1 := time.Now().Add(1 * time.Hour)
+	t2 := time.Now().Add(5 * time.Hour)
+
+	timedQueue := New(WithMaxSize(maxSize))
+	defer timedQueue.Shutdown()
+
+	// start worker (will simply block because times are too far in the future)
+	go func() {
+		for currentElement := timedQueue.Poll(true); currentElement != nil; currentElement = timedQueue.Poll(true) {
+			currentElement.(func())()
+		}
+	}()
+
+	// add element at t2 (far in the future) to the queue
+	timedQueue.Add(func() {}, t2)
+
+	// now fill up queue
+	for i := 0; i < maxSize; i++ {
+		timedQueue.Add(func() {}, t1)
+	}
+
+	// verify that only maxSize elements are in queue
+	assert.Equal(t, maxSize, timedQueue.Size())
+
+	// verify that all elements in the queue have time t1
+	for i := 0; i < timedQueue.Size(); i++ {
+		e := heap.Remove(&timedQueue.heap, 0).(*QueueElement)
+		assert.Equal(t, t1, e.ScheduledTime)
+	}
 }


### PR DESCRIPTION
# Description of change
This PR adds the option to create a timed queue with a max size. In case a new element is added and the size would get bigger than allowed, the last element (furthest in the future) is deleted. 

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Wrote a new unit test and make sure the old tests still pass.


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
