### PR TITLE
Add peer to dropped event

### DIFF
--- a/autopeering/selection/events.go
+++ b/autopeering/selection/events.go
@@ -33,6 +33,7 @@ type PeeringEvent struct {
 
 // DroppedEvent bundles the information sent in Dropped events.
 type DroppedEvent struct {
+	Peer      *peer.Peer
 	DroppedID identity.ID // ID of the peer that gets dropped.
 }
 

--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -380,12 +380,12 @@ func (m *manager) dropPeering(p *peer.Peer) {
 		"#out", m.outbound,
 		"#in", m.inbound,
 	)
-	m.events.Dropped.Trigger(&DroppedEvent{DroppedID: p.ID()})
+	m.events.Dropped.Trigger(&DroppedEvent{Peer: p, DroppedID: p.ID()})
 }
 
 func (m *manager) getConnectedFilter() *Filter {
 	filter := NewFilter()
-	filter.AddPeer(m.getID())              //set filter for oneself
+	filter.AddPeer(m.getID())              // set filter for oneself
 	filter.AddPeers(m.inbound.GetPeers())  // set filter for inbound neighbors
 	filter.AddPeers(m.outbound.GetPeers()) // set filter for outbound neighbors
 	return filter


### PR DESCRIPTION
This PR adds the information about the peer to the autopeering DroppedEvent.