### PR TITLE
Adds dependency injection container to plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.dedis.ch/kyber/v3 v3.0.13
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/atomic v1.9.0
+	go.uber.org/dig v1.12.0 // indirect
 	go.uber.org/zap v1.19.0
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,8 @@ go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/dig v1.12.0 h1:l1GQeZpEbss0/M4l/ZotuBndCrkMdjnygzgcuOjAdaY=
+go.uber.org/dig v1.12.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
@@ -398,6 +400,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190327201419-c70d86f8b7cf/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20191030062658-86caa796c7ab/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa h1:5E4dL8+NgFOgjwbTKz+OOEGGhP+ectTmF842l6KjupQ=

--- a/node/events.go
+++ b/node/events.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/iotaledger/hive.go/events"
+	"go.uber.org/dig"
 )
 
 type pluginEvents struct {
@@ -12,6 +13,10 @@ type pluginEvents struct {
 
 func pluginCaller(handler interface{}, params ...interface{}) {
 	handler.(func(*Plugin))(params[0].(*Plugin))
+}
+
+func pluginAndDepCaller(handler interface{}, params ...interface{}) {
+	handler.(func(*Plugin, *dig.Container))(params[0].(*Plugin), params[1].(*dig.Container))
 }
 
 func pluginParameterCaller(handler interface{}, params ...interface{}) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,0 +1,43 @@
+package node_test
+
+import (
+	"testing"
+
+	"github.com/iotaledger/hive.go/configuration"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
+)
+
+func TestDependencyInjection(t *testing.T) {
+	type PluginADeps struct {
+		dig.In
+		DepFromB string `name:"providedByB"`
+	}
+
+	stringVal := "到月球"
+
+	depsA := &PluginADeps{}
+	pluginA := node.NewPlugin("A", node.Enabled, depsA,
+		func(plugin *node.Plugin) {
+			require.Equal(t, stringVal, depsA.DepFromB)
+		},
+	)
+
+	pluginB := node.NewPlugin("B", node.Enabled, depsA,
+		func(plugin *node.Plugin) {
+
+		},
+	)
+
+	pluginB.Events.Init.Attach(events.NewClosure(func(_ *node.Plugin, container *dig.Container) {
+		require.NoError(t, container.Provide(func() string {
+			return stringVal
+		}, dig.Name("providedByB")))
+	}))
+
+	require.NoError(t, logger.InitGlobalLogger(configuration.New()))
+	node.Run(node.Plugins(pluginA, pluginB))
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -26,11 +26,7 @@ func TestDependencyInjection(t *testing.T) {
 		},
 	)
 
-	pluginB := node.NewPlugin("B", node.Enabled, depsA,
-		func(plugin *node.Plugin) {
-
-		},
-	)
+	pluginB := node.NewPlugin("B", node.Enabled, nil)
 
 	pluginB.Events.Init.Attach(events.NewClosure(func(_ *node.Plugin, container *dig.Container) {
 		require.NoError(t, container.Provide(func() string {

--- a/node/plugin.go
+++ b/node/plugin.go
@@ -22,17 +22,19 @@ type Plugin struct {
 	Events  pluginEvents
 	log     *logger.Logger
 	logOnce sync.Once
+	deps    interface{}
 	wg      *sync.WaitGroup
 }
 
-// Creates a new plugin with the given name, default status and callbacks.
+// NewPlugin creates a new plugin with the given name, default status and callbacks.
 // The last specified callback is the mandatory run callback, while all other callbacks are configure callbacks.
-func NewPlugin(name string, status int, callbacks ...Callback) *Plugin {
+func NewPlugin(name string, status int, deps interface{}, callbacks ...Callback) *Plugin {
 	plugin := &Plugin{
 		Name:   name,
 		Status: status,
+		deps:   deps,
 		Events: pluginEvents{
-			Init:      events.NewEvent(pluginCaller),
+			Init:      events.NewEvent(pluginAndDepCaller),
 			Configure: events.NewEvent(pluginCaller),
 			Run:       events.NewEvent(pluginCaller),
 		},


### PR DESCRIPTION
# Description of change

Makes it so that plugins can provide a struct of any type containing their dependencies (struct needs to embed `dig.In`) which gets populated before the plugin's configure callback is executed.

Plugins are supposed to `Provide` singletons etc. they provide by using the `*dig.Container` instance which can they acquire during the `Init` event. Check out the simple test to see how it works.

If the dependency graph can not be populated the `Node` panics.