### PR TITLE
Fix marshalutil with default size value.

### DIFF
--- a/marshalutil/marshalutil.go
+++ b/marshalutil/marshalutil.go
@@ -25,7 +25,7 @@ func New(args ...interface{}) *MarshalUtil {
 	case 0:
 		return &MarshalUtil{
 			bytes: make([]byte, 1024),
-			size:  0,
+			size:  1024,
 		}
 	case 1:
 		switch param := args[0].(type) {
@@ -96,13 +96,13 @@ func (util *MarshalUtil) ReadSeek(offset int) {
 // being returned.
 func (util *MarshalUtil) Bytes(clone ...bool) []byte {
 	if len(clone) >= 1 && clone[0] {
-		clone := make([]byte, util.size)
+		clone := make([]byte, util.writeOffset)
 		copy(clone, util.bytes)
 
 		return clone
 	}
 
-	return util.bytes[:util.size]
+	return util.bytes[:util.writeOffset]
 }
 
 // DoneReading checks if there are any bytes left to read.


### PR DESCRIPTION
# Description of change

Fix internal size value when initializing MarshalUtil with default buffer size.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- 
## How the change has been tested

Ran unit tests of components using MarshalUtil (Goshimmer, reflection based serialization)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
