### PR TITLE
Re-order deps para

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -20,13 +20,13 @@ func TestDependencyInjection(t *testing.T) {
 	stringVal := "到月球"
 
 	depsA := &PluginADeps{}
-	pluginA := node.NewPlugin("A", node.Enabled, depsA,
+	pluginA := node.NewPlugin("A", depsA, node.Enabled,
 		func(plugin *node.Plugin) {
 			require.Equal(t, stringVal, depsA.DepFromB)
 		},
 	)
 
-	pluginB := node.NewPlugin("B", node.Enabled, nil)
+	pluginB := node.NewPlugin("B", nil, node.Enabled)
 
 	pluginB.Events.Init.Attach(events.NewClosure(func(_ *node.Plugin, container *dig.Container) {
 		require.NoError(t, container.Provide(func() string {

--- a/node/plugin.go
+++ b/node/plugin.go
@@ -28,7 +28,7 @@ type Plugin struct {
 
 // NewPlugin creates a new plugin with the given name, default status and callbacks.
 // The last specified callback is the mandatory run callback, while all other callbacks are configure callbacks.
-func NewPlugin(name string, status int, deps interface{}, callbacks ...Callback) *Plugin {
+func NewPlugin(name string, deps interface{}, status int, callbacks ...Callback) *Plugin {
 	plugin := &Plugin{
 		Name:   name,
 		Status: status,


### PR DESCRIPTION
As otherwise the phase callbacks could be mistakenly used as the deps struct.