### PR TITLE
Feat: Added events.Queue

### DIFF
--- a/events/queue.go
+++ b/events/queue.go
@@ -1,0 +1,67 @@
+package events
+
+import (
+	"sync"
+)
+
+// region Queue ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Queue represents an Event
+type Queue struct {
+	queuedElements      []*queueElement
+	queuedElementsMutex sync.Mutex
+}
+
+// NewQueue returns an empty Queue.
+func NewQueue() *Queue {
+	return (&Queue{}).clear()
+}
+
+// Queue enqueues an Event to be triggered later (using the Trigger function).
+func (q *Queue) Queue(event *Event, params ...interface{}) {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	q.queuedElements = append(q.queuedElements, &queueElement{
+		event:  event,
+		params: params,
+	})
+}
+
+// Trigger triggers all queued Events and empties the Queue.
+func (q *Queue) Trigger() {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	for _, queuedElement := range q.queuedElements {
+		queuedElement.event.Trigger(queuedElement.params)
+	}
+	q.clear()
+}
+
+// Clear removes all elements from the Queue.
+func (q *Queue) Clear() {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	q.clear()
+}
+
+// clear removes all elements from the Queue without locking it.
+func (q *Queue) clear() *Queue {
+	q.queuedElements = make([]*queueElement, 0)
+
+	return q
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region queueElement /////////////////////////////////////////////////////////////////////////////////////////////////
+
+// queueElement is a struct that holds the information about a triggered Event.
+type queueElement struct {
+	event  *Event
+	params []interface{}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/events/queue_test.go
+++ b/events/queue_test.go
@@ -1,0 +1,34 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	executionResult := ""
+
+	event1 := NewEvent(VoidCaller)
+	event2 := NewEvent(VoidCaller)
+	event3 := NewEvent(VoidCaller)
+
+	event1.Attach(NewClosure(func() {
+		executionResult += "first"
+	}))
+	event2.Attach(NewClosure(func() {
+		executionResult += "second"
+	}))
+	event3.Attach(NewClosure(func() {
+		executionResult += "third"
+	}))
+
+	q := NewQueue()
+	q.Queue(event1)
+	q.Queue(event2)
+
+	event3.Trigger()
+	q.Trigger()
+
+	assert.Equal(t, executionResult, "thirdfirstsecond")
+}


### PR DESCRIPTION
# Description of change

This PR adds an events.Queue that allows to queue Events for later execution. This is needed to delay the execution of events while some entities are locked.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
