### PR TITLE
Add SeriSliceLengthType to Serializer SliceOfObjects and String Read/…

### DIFF
--- a/serializer/consts.go
+++ b/serializer/consts.go
@@ -23,10 +23,6 @@ const (
 	TypeDenotationByteSize = UInt32ByteSize
 	// SmallTypeDenotationByteSize is the size of a type denotation for a small range of possible values.
 	SmallTypeDenotationByteSize = OneByte
-	// StructArrayLengthByteSize is the byte size of struct array lengths.
-	StructArrayLengthByteSize = UInt16ByteSize
-	// ByteArrayLengthByteSize is the byte size of byte array lengths.
-	ByteArrayLengthByteSize = UInt32ByteSize
 	// PayloadLengthByteSize is the size of the payload length denoting bytes.
 	PayloadLengthByteSize = UInt32ByteSize
 	// MinPayloadByteSize is the minimum size of a payload (together with its length denotation).

--- a/serializer/serializable.go
+++ b/serializer/serializable.go
@@ -67,15 +67,15 @@ func (av ArrayValidationMode) HasMode(mode ArrayValidationMode) bool {
 // Min and Max at 0 define an unbounded array.
 type ArrayRules struct {
 	// The min array bound.
-	Min uint16
+	Min uint
 	// The max array bound.
-	Max uint16
+	Max uint
 	// The mode of validation.
 	ValidationMode ArrayValidationMode
 }
 
 // CheckBounds checks whether the given count violates the array bounds.
-func (ar *ArrayRules) CheckBounds(count uint16) error {
+func (ar *ArrayRules) CheckBounds(count uint) error {
 	if ar.Min != 0 && count < ar.Min {
 		return fmt.Errorf("%w: min is %d but count is %d", ErrArrayValidationMinElementsNotReached, ar.Min, count)
 	}

--- a/serializer/serializable_test.go
+++ b/serializer/serializable_test.go
@@ -385,9 +385,9 @@ func TestArrayRules_Bounds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			arrayRules.Min = uint16(tt.min)
-			arrayRules.Max = uint16(tt.max)
-			err := arrayRules.CheckBounds(uint16(len(tt.args)))
+			arrayRules.Min = uint(tt.min)
+			arrayRules.Max = uint(tt.max)
+			err := arrayRules.CheckBounds(uint(len(tt.args)))
 			assert.Equal(t, tt.valid, err == nil)
 		})
 	}

--- a/serializer/serializer_test.go
+++ b/serializer/serializer_test.go
@@ -46,7 +46,7 @@ func TestDeserializer_ReadSliceOfObjects(t *testing.T) {
 	bytesRead, err := serializer.NewDeserializer(data).
 		ReadSliceOfObjects(func(seri serializer.Serializables) {
 			readObjects = seri
-		}, serializer.DeSeriModePerformValidation, serializer.TypeDenotationByte, DummyTypeSelector, nil, func(err error) error { return err }).
+		}, serializer.DeSeriModePerformValidation, serializer.SeriSliceLengthAsUint16, serializer.TypeDenotationByte, DummyTypeSelector, nil, func(err error) error { return err }).
 		ConsumedAll(func(left int, err error) error { return err }).
 		Done()
 
@@ -94,7 +94,7 @@ func TestDeserializer_ReadString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var s string
 			_, err := serializer.NewDeserializer(tt.args.data).
-				ReadString(&s, func(err error) error {
+				ReadString(&s, serializer.SeriSliceLengthAsUint16, func(err error) error {
 					return err
 				}).
 				ConsumedAll(func(left int, err error) error { return err }).


### PR DESCRIPTION
This PR adds the possibility to change the slice length type for SliceOfObjects and String Read/Write serializer functions according to the other serializer functions.

It is the same PR like in the original iota.go, and was ported to hive.go.

https://github.com/iotaledger/iota.go/pull/292