### PR TITLE
Use contexts to cancel instead of signal channels

### DIFF
--- a/backoff/options.go
+++ b/backoff/options.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"context"
 	"math/rand"
 	"time"
 )
@@ -65,11 +66,11 @@ func Timeout(timeout time.Time) Option {
 	})
 }
 
-// Cancel configures a backoff policy to stop the given channel is closed.
-func Cancel(done <-chan struct{}) Option {
+// Cancel configures a backoff policy to stop if the given context is done.
+func Cancel(ctx context.Context) Option {
 	return statelessOptionFunc(func(duration time.Duration) time.Duration {
 		select {
-		case <-done:
+		case <-ctx.Done():
 			return Stop
 		default:
 		}

--- a/backoff/options_test.go
+++ b/backoff/options_test.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -106,9 +107,9 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestCancel(t *testing.T) {
-	cancel := make(chan struct{})
+	ctx, ctxCancel := context.WithCancel(context.Background())
 
-	p := ZeroBackOff().With(Cancel(cancel))
+	p := ZeroBackOff().With(Cancel(ctx))
 
 	stopped := make(chan struct{}, 1)
 	go func() {
@@ -124,7 +125,7 @@ func TestCancel(t *testing.T) {
 		assert.FailNow(t, "retry stopped prematurely")
 	default:
 	}
-	close(cancel)
+	ctxCancel()
 	<-stopped
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -301,7 +301,7 @@ func (d *OrderedDaemon) stopWorkers() {
 		for _, name := range d.shutdownOrderWorker {
 			worker := d.workers[name]
 			if !worker.running.IsSet() {
-				// the worker's shutdown channel will be automatically garbage collected
+				worker.ctxCancel()
 				continue
 			}
 			// if the current worker has a lower priority...

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -107,10 +107,11 @@ type OrderedDaemon struct {
 }
 
 type worker struct {
-	handler        WorkerFunc
-	running        *typeutils.AtomicBool
-	shutdownOrder  int
-	shutdownSignal chan struct{}
+	ctx           context.Context
+	ctxCancel     context.CancelFunc
+	handler       WorkerFunc
+	running       *typeutils.AtomicBool
+	shutdownOrder int
 }
 
 // GetRunningBackgroundWorkers gets the running background workers sorted by their priority.
@@ -143,7 +144,7 @@ func (d *OrderedDaemon) runBackgroundWorker(name string, backgroundWorker Worker
 		if d.logger != nil {
 			d.logger.Debugf("Starting Background Worker: %s ...", name)
 		}
-		backgroundWorker(worker.shutdownSignal)
+		backgroundWorker(worker.ctx)
 		worker.running.UnSet()
 		shutdownOrderWaitGroup.Done()
 		if d.logger != nil {
@@ -198,11 +199,14 @@ func (d *OrderedDaemon) BackgroundWorker(name string, handler WorkerFunc, order 
 		d.wgPerSameShutdownOrder[shutdownOrder] = &sync.WaitGroup{}
 	}
 
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
 	d.workers[name] = &worker{
-		handler:        handler,
-		running:        typeutils.NewAtomicBool(),
-		shutdownOrder:  shutdownOrder,
-		shutdownSignal: make(chan struct{}, 1),
+		ctx:           ctx,
+		ctxCancel:     ctxCancel,
+		handler:       handler,
+		running:       typeutils.NewAtomicBool(),
+		shutdownOrder: shutdownOrder,
 	}
 
 	// add to the shutdown sequence and order by order
@@ -309,7 +313,7 @@ func (d *OrderedDaemon) stopWorkers() {
 			if d.logger != nil {
 				d.logger.Debugf("Stopping Background Worker: %s ...", name)
 			}
-			close(worker.shutdownSignal)
+			worker.ctxCancel()
 		}
 		// wait for the last priority to finish
 		d.wgPerSameShutdownOrder[prevPriority].Wait()

--- a/daemon/interfaces.go
+++ b/daemon/interfaces.go
@@ -4,8 +4,8 @@ import (
 	"context"
 )
 
-// WorkerFunc is the function to run a worker accepting its shutdown signal handler channel.
-type WorkerFunc = func(shutdownSignal <-chan struct{})
+// WorkerFunc is the function to run a worker accepting its context.
+type WorkerFunc = func(ctx context.Context)
 
 // Daemon specifies an interface to run background go routines.
 type Daemon interface {

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -158,7 +158,7 @@ func (s *Serializer) writeSliceLength(l int, lenType SeriLengthPrefixType, errPr
 	switch lenType {
 	case SeriLengthPrefixTypeAsByte:
 		if l > math.MaxUint8 {
-			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint8))
+			s.err = errProducer(fmt.Errorf("unable to serialize collection length: length %d is out of range (0-%d)", l, math.MaxUint8))
 			return s
 		}
 		if err := s.buf.WriteByte(byte(l)); err != nil {
@@ -167,7 +167,7 @@ func (s *Serializer) writeSliceLength(l int, lenType SeriLengthPrefixType, errPr
 		}
 	case SeriLengthPrefixTypeAsUint16:
 		if l > math.MaxUint16 {
-			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint16))
+			s.err = errProducer(fmt.Errorf("unable to serialize collection length: length %d is out of range (0-%d)", l, math.MaxUint16))
 			return s
 		}
 		if err := binary.Write(&s.buf, binary.LittleEndian, uint16(l)); err != nil {
@@ -176,7 +176,7 @@ func (s *Serializer) writeSliceLength(l int, lenType SeriLengthPrefixType, errPr
 		}
 	case SeriLengthPrefixTypeAsUint32:
 		if l > math.MaxUint32 {
-			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint32))
+			s.err = errProducer(fmt.Errorf("unable to serialize collection length: length %d is out of range (0-%d)", l, math.MaxUint32))
 			return s
 		}
 		if err := binary.Write(&s.buf, binary.LittleEndian, uint32(l)); err != nil {

--- a/timeutil/sleep.go
+++ b/timeutil/sleep.go
@@ -1,12 +1,13 @@
 package timeutil
 
 import (
+	"context"
 	"time"
 )
 
-func Sleep(interval time.Duration, shutdownSignal <-chan struct{}) bool {
+func Sleep(ctx context.Context, interval time.Duration) bool {
 	select {
-	case <-shutdownSignal:
+	case <-ctx.Done():
 		return false
 
 	case <-time.After(interval):

--- a/timeutil/ticker.go
+++ b/timeutil/ticker.go
@@ -1,33 +1,36 @@
 package timeutil
 
 import (
+	"context"
 	"sync"
 	"time"
 )
 
 // Ticker is task that gets executed repeatedly. It adjusts the intervals or drops ticks to make up for slow executions.
 type Ticker struct {
-	handler                func()
-	interval               time.Duration
-	internalShutdownSignal chan struct{}
-	externalShutdownSignal <-chan struct{}
-	gracefulShutdown       sync.WaitGroup
-	shutdownOnce           sync.Once
+	ctx              context.Context
+	ctxCancel        context.CancelFunc
+	handler          func()
+	interval         time.Duration
+	gracefulShutdown sync.WaitGroup
 }
 
 // NewTicker creates a new Ticker from the given details. The interval must be greater than zero; if not, NewTicker will
 // panic.
-func NewTicker(handler func(), interval time.Duration, optionalExternalShutdownSignal ...<-chan struct{}) (ticker *Ticker) {
-	ticker = &Ticker{
-		handler:                handler,
-		interval:               interval,
-		internalShutdownSignal: make(chan struct{}, 1),
+func NewTicker(handler func(), interval time.Duration, ctx ...context.Context) (ticker *Ticker) {
+
+	innerCtx := context.Background()
+	if len(ctx) > 0 {
+		innerCtx = ctx[0]
 	}
 
-	if len(optionalExternalShutdownSignal) >= 1 && optionalExternalShutdownSignal[0] != nil {
-		ticker.externalShutdownSignal = optionalExternalShutdownSignal[0]
-	} else {
-		ticker.externalShutdownSignal = ticker.internalShutdownSignal
+	tickerCtx, tickerCtxCancel := context.WithCancel(innerCtx)
+
+	ticker = &Ticker{
+		ctx:       tickerCtx,
+		ctxCancel: tickerCtxCancel,
+		handler:   handler,
+		interval:  interval,
 	}
 
 	go ticker.run()
@@ -37,19 +40,12 @@ func NewTicker(handler func(), interval time.Duration, optionalExternalShutdownS
 
 // Shutdown shuts down the Ticker.
 func (t *Ticker) Shutdown() {
-	t.shutdownOnce.Do(func() {
-		close(t.internalShutdownSignal)
-	})
+	t.ctxCancel()
 }
 
 // WaitForShutdown waits until the Ticker was shut down.
 func (t *Ticker) WaitForShutdown() {
-	select {
-	case <-t.externalShutdownSignal:
-		return
-	case <-t.internalShutdownSignal:
-		return
-	}
+	<-t.ctx.Done()
 }
 
 // WaitForGracefulShutdown waits until the Ticker was shut down and the last handler has terminated.
@@ -67,9 +63,7 @@ func (t *Ticker) run() {
 
 	for {
 		select {
-		case <-t.externalShutdownSignal:
-			return
-		case <-t.internalShutdownSignal:
+		case <-t.ctx.Done():
 			return
 		case <-ticker.C:
 			t.handler()

--- a/timeutil/ticker_test.go
+++ b/timeutil/ticker_test.go
@@ -1,6 +1,7 @@
 package timeutil
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,17 +9,17 @@ import (
 	"go.uber.org/atomic"
 )
 
-func TestTicker_ExternalShutdownSignal(t *testing.T) {
+func TestTicker_ExternalContext(t *testing.T) {
 	// use counter to track execution state
 	counter := atomic.NewUint64(0)
 
-	// create "external" shutdown signal
-	shutdownChan := make(chan struct{}, 1)
+	// create "external" context
+	ctx, ctxCancel := context.WithCancel(context.Background())
 	go func() {
 		for {
 			time.Sleep(10 * time.Millisecond)
 			if counter.Load() > 2 {
-				close(shutdownChan)
+				ctxCancel()
 				return
 			}
 		}
@@ -29,7 +30,7 @@ func TestTicker_ExternalShutdownSignal(t *testing.T) {
 		counter.Inc()
 		time.Sleep(1 * time.Second)
 		counter.Inc()
-	}, 100*time.Millisecond, shutdownChan)
+	}, 100*time.Millisecond, ctx)
 
 	// wait for the shutdown signal
 	ticker.WaitForShutdown()

--- a/websockethub/client.go
+++ b/websockethub/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
 	"github.com/iotaledger/hive.go/typeutils"
 )
 
@@ -98,7 +99,7 @@ func (c *Client) checkPong() {
 
 	defer func() {
 		select {
-		case <-c.hub.shutdownSignal:
+		case <-c.hub.ctx.Done():
 		case <-c.ExitSignal:
 			// the Hub closed the channel.
 		default:
@@ -140,7 +141,7 @@ func (c *Client) checkPong() {
 		if c.ReceiveChan != nil {
 			select {
 
-			case <-c.hub.shutdownSignal:
+			case <-c.hub.ctx.Done():
 				return
 
 			case <-c.ExitSignal:
@@ -172,7 +173,7 @@ func (c *Client) writePump() {
 		pingTicker.Stop()
 
 		select {
-		case <-c.hub.shutdownSignal:
+		case <-c.hub.ctx.Done():
 		case <-c.ExitSignal:
 			// the Hub closed the channel.
 		default:
@@ -191,7 +192,7 @@ func (c *Client) writePump() {
 	for {
 		select {
 
-		case <-c.hub.shutdownSignal:
+		case <-c.hub.ctx.Done():
 			return
 
 		case <-c.ExitSignal:
@@ -235,7 +236,7 @@ func (c *Client) Send(msg interface{}, dontDrop ...bool) {
 
 	if len(dontDrop) > 0 && dontDrop[0] {
 		select {
-		case <-c.hub.shutdownSignal:
+		case <-c.hub.ctx.Done():
 		case <-c.ExitSignal:
 		case <-c.sendChanClosed:
 		case c.sendChan <- msg:
@@ -244,7 +245,7 @@ func (c *Client) Send(msg interface{}, dontDrop ...bool) {
 	}
 
 	select {
-	case <-c.hub.shutdownSignal:
+	case <-c.hub.ctx.Done():
 	case <-c.ExitSignal:
 	case <-c.sendChanClosed:
 	case c.sendChan <- msg:


### PR DESCRIPTION
This PR replaces most of the signal channels we used for cancellation or shutdown with contexts.

This is more go-idiomatic.