### PR TITLE
Fix inbound request status response

### DIFF
--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -175,8 +175,8 @@ Loop:
 					m.triggerPeeringEvent(true, req.Remote, false)
 					m.dropPeering(p)
 				} else {
-					m.addNeighbor(m.outbound, req)
-					m.triggerPeeringEvent(true, req.Remote, true)
+					added := m.addNeighbor(m.outbound, req)
+					m.triggerPeeringEvent(true, req.Remote, added)
 				}
 			}
 			// call updateOutbound again after the given interval
@@ -325,19 +325,21 @@ func (m *manager) handleInRequest(req peeringRequest) (resp bool) {
 		return
 	}
 
-	m.addNeighbor(m.inbound, toAccept)
-	resp = accept
+	if m.addNeighbor(m.inbound, toAccept) {
+		resp = accept
+	}
 	return
 }
 
-func (m *manager) addNeighbor(nh *Neighborhood, toAdd peer.PeerDistance) {
+func (m *manager) addNeighbor(nh *Neighborhood, toAdd peer.PeerDistance) bool {
 	// drop furthest neighbor if necessary
 	if furthest, _ := nh.getFurthest(); furthest.Remote != nil {
 		if p := nh.RemovePeer(furthest.Remote.ID()); p != nil {
 			m.dropPeering(p)
 		}
 	}
-	nh.Add(toAdd)
+
+	return nh.Add(toAdd)
 }
 
 func (m *manager) updateSalt() {

--- a/autopeering/selection/neighborhood_test.go
+++ b/autopeering/selection/neighborhood_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/iotaledger/hive.go/autopeering/distance"
 	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/autopeering/peer/peertest"
 	"github.com/iotaledger/hive.go/autopeering/salt"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFurthest(t *testing.T) {
@@ -28,23 +29,27 @@ func TestGetFurthest(t *testing.T) {
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
+				size:      4,
+			},
 			expected: peer.PeerDistance{
 				Remote:   nil,
-				Distance: distance.Max},
+				Distance: distance.Max,
+			},
 			index: 1,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				size:      4},
+				size:      4,
+			},
 			expected: d[3],
 			index:    3,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				size:      4},
+				size:      4,
+			},
 			expected: d[4],
 			index:    2,
 		},
@@ -74,21 +79,24 @@ func TestGetPeerIndex(t *testing.T) {
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
+				size:      4,
+			},
 			target: d[0].Remote,
 			index:  0,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				size:      4},
+				size:      4,
+			},
 			target: d[3].Remote,
 			index:  3,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				size:      4},
+				size:      4,
+			},
 			target: d[3].Remote,
 			index:  -1,
 		},
@@ -117,21 +125,24 @@ func TestRemove(t *testing.T) {
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
+				size:      4,
+			},
 			toRemove: d[0].Remote,
 			expected: []peer.PeerDistance{},
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				size:      4},
+				size:      4,
+			},
 			toRemove: d[1].Remote,
 			expected: []peer.PeerDistance{d[0], d[3]},
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				size:      4},
+				size:      4,
+			},
 			toRemove: d[2].Remote,
 			expected: []peer.PeerDistance{d[0], d[1], d[4]},
 		},
@@ -151,37 +162,45 @@ func TestAdd(t *testing.T) {
 	}
 
 	type testCase struct {
-		input    *Neighborhood
-		toAdd    peer.PeerDistance
-		expected []peer.PeerDistance
+		input         *Neighborhood
+		toAdd         peer.PeerDistance
+		expected      []peer.PeerDistance
+		shouldBeAdded bool
 	}
 
 	tests := []testCase{
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
-			toAdd:    d[2],
-			expected: []peer.PeerDistance{d[0], d[2]},
+				size:      4,
+			},
+			toAdd:         d[2],
+			expected:      []peer.PeerDistance{d[0], d[2]},
+			shouldBeAdded: true,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				size:      4},
-			toAdd:    d[2],
-			expected: []peer.PeerDistance{d[0], d[1], d[3], d[2]},
+				size:      4,
+			},
+			toAdd:         d[2],
+			expected:      []peer.PeerDistance{d[0], d[1], d[3], d[2]},
+			shouldBeAdded: true,
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				size:      4},
-			toAdd:    d[3],
-			expected: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4,
+			},
+			toAdd:         d[3],
+			expected:      []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+			shouldBeAdded: false,
 		},
 	}
 
 	for _, test := range tests {
-		test.input.Add(test.toAdd)
+		added := test.input.Add(test.toAdd)
+		assert.Equal(t, test.shouldBeAdded, added)
 		assert.Equal(t, test.expected, test.input.neighbors, "Add")
 	}
 }
@@ -203,7 +222,8 @@ func TestUpdateDistance(t *testing.T) {
 
 	neighborhood := Neighborhood{
 		neighbors: d[1:],
-		size:      4}
+		size:      4,
+	}
 
 	neighborhood.UpdateDistance(d[0].Remote.ID().Bytes(), s.GetBytes())
 
@@ -229,19 +249,22 @@ func TestGetPeers(t *testing.T) {
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{},
-				size:      4},
+				size:      4,
+			},
 			expected: []*peer.Peer{},
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
+				size:      4,
+			},
 			expected: []*peer.Peer{peers[0]},
 		},
 		{
 			input: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[3], d[2]},
-				size:      4},
+				size:      4,
+			},
 			expected: []*peer.Peer{peers[0], peers[1], peers[3], peers[2]},
 		},
 	}

--- a/autopeering/selection/selection_test.go
+++ b/autopeering/selection/selection_test.go
@@ -3,9 +3,10 @@ package selection
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/autopeering/peer/peertest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFilterAddPeers(t *testing.T) {
@@ -129,25 +130,29 @@ func TestSelection(t *testing.T) {
 		{
 			nh: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0]},
-				size:      4},
+				size:      4,
+			},
 			expCandidate: d[1].Remote,
 		},
 		{
 			nh: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				size:      4},
+				size:      4,
+			},
 			expCandidate: d[2].Remote,
 		},
 		{
 			nh: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				size:      4},
+				size:      4,
+			},
 			expCandidate: d[3].Remote,
 		},
 		{
 			nh: &Neighborhood{
 				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				size:      4},
+				size:      4,
+			},
 			expCandidate: nil,
 		},
 	}


### PR DESCRIPTION
The PR fixes the response to autopeering inbound requests if the neighbourhood is already full.