### PR TITLE
Add Flush function to BatchedWriter

### DIFF
--- a/kvstore/batch_collector.go
+++ b/kvstore/batch_collector.go
@@ -11,7 +11,7 @@ type BatchCollector struct {
 	batchSize            int
 	writtenValues        []BatchWriteObject
 	writtenValuesCounter int
-	commited             bool
+	committed            bool
 }
 
 // newBatchCollector creates a new BatchCollector that is used to collect objects that should be written.
@@ -22,14 +22,14 @@ func newBatchCollector(batchedMuts BatchedMutations, scheduledCount *atomic.Int3
 		batchSize:            batchSize,
 		writtenValues:        make([]BatchWriteObject, batchSize),
 		writtenValuesCounter: 0,
-		commited:             false,
+		committed:            false,
 	}
 }
 
 // Add adds an object to the batch.
 // It returns true in case the batch size is reached.
 func (br *BatchCollector) Add(objectToPersist BatchWriteObject) (batchSizeReached bool) {
-	if br.commited {
+	if br.committed {
 		panic("mutations were already committed")
 	}
 
@@ -45,10 +45,10 @@ func (br *BatchCollector) Add(objectToPersist BatchWriteObject) (batchSizeReache
 
 // Commit applies the collected mutations.
 func (br *BatchCollector) Commit() error {
-	if br.commited {
+	if br.committed {
 		panic("mutations were already committed")
 	}
-	br.commited = true
+	br.committed = true
 
 	if br.writtenValuesCounter == 0 {
 		// nothing to commit

--- a/kvstore/batch_collector.go
+++ b/kvstore/batch_collector.go
@@ -1,0 +1,68 @@
+package kvstore
+
+import (
+	"go.uber.org/atomic"
+)
+
+// BatchCollector is used to collect objects that should be written.
+type BatchCollector struct {
+	batchedMuts          BatchedMutations
+	scheduledCount       *atomic.Int32
+	batchSize            int
+	writtenValues        []BatchWriteObject
+	writtenValuesCounter int
+	commited             bool
+}
+
+// newBatchCollector creates a new BatchCollector that is used to collect objects that should be written.
+func newBatchCollector(batchedMuts BatchedMutations, scheduledCount *atomic.Int32, batchSize int) *BatchCollector {
+	return &BatchCollector{
+		batchedMuts:          batchedMuts,
+		scheduledCount:       scheduledCount,
+		batchSize:            batchSize,
+		writtenValues:        make([]BatchWriteObject, batchSize),
+		writtenValuesCounter: 0,
+		commited:             false,
+	}
+}
+
+// Add adds an object to the batch.
+// It returns true in case the batch size is reached.
+func (br *BatchCollector) Add(objectToPersist BatchWriteObject) (batchSizeReached bool) {
+	if br.commited {
+		panic("mutations were already committed")
+	}
+
+	objectToPersist.ResetBatchWriteScheduled()
+	br.scheduledCount.Dec()
+
+	objectToPersist.BatchWrite(br.batchedMuts)
+	br.writtenValues[br.writtenValuesCounter] = objectToPersist
+	br.writtenValuesCounter++
+
+	return br.writtenValuesCounter >= br.batchSize
+}
+
+// Commit applies the collected mutations.
+func (br *BatchCollector) Commit() error {
+	if br.commited {
+		panic("mutations were already committed")
+	}
+	br.commited = true
+
+	if br.writtenValuesCounter == 0 {
+		// nothing to commit
+		br.batchedMuts.Cancel()
+		return nil
+	}
+
+	if err := br.batchedMuts.Commit(); err != nil {
+		return err
+	}
+
+	for i := 0; i < br.writtenValuesCounter; i++ {
+		br.writtenValues[i].BatchWriteDone()
+	}
+
+	return nil
+}

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -1092,6 +1092,7 @@ func (objectStorage *ObjectStorage) flush(shutdown bool) {
 		}
 	}
 
+	objectStorage.options.batchedWriterInstance.Flush()
 	objectStorage.cachedObjectsEmpty.Wait()
 }
 


### PR DESCRIPTION
This PR adds the possibility to flush the `BatchedWriter`.

Without that, it took the `ObjectStorage` a whole `BatchWriterTimeout` until the `ObjectStorage` flush was done, since it needed to wait until all objects were persisted by the `BatchedWriter`