### PR TITLE
Add error returns to KVStore interface and remove Shutdown()

### DIFF
--- a/autopeering/peer/peerdb.go
+++ b/autopeering/peer/peerdb.go
@@ -114,12 +114,14 @@ func (db *DB) expirer() {
 // expireNodes iterates over the database and deletes all nodes that have not
 // been seen (i.e. received a pong from) for some time.
 func (db *DB) expireNodes() error {
-	var (
-		threshold   = time.Now().Add(-peerExpiration).Unix()
-		latestPong  = make(map[identity.ID]int64)
-		batchedMuts = db.store.Batched()
-	)
-	err := db.store.Iterate(kvstore.KeyPrefix(dbNodePrefix), func(key kvstore.Key, value kvstore.Value) bool {
+	threshold := time.Now().Add(-peerExpiration).Unix()
+	latestPong := make(map[identity.ID]int64)
+	batchedMuts, err := db.store.Batched()
+	if err != nil {
+		return err
+	}
+
+	err = db.store.Iterate(kvstore.KeyPrefix(dbNodePrefix), func(key kvstore.Key, value kvstore.Value) bool {
 		var id identity.ID
 		copy(id[:], key[len(dbNodePrefix):])
 

--- a/kvstore/badger/badger.go
+++ b/kvstore/badger/badger.go
@@ -1,8 +1,9 @@
 package badger
 
 import (
-	"errors"
 	"sync"
+
+	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/badger/v2"
 	"go.uber.org/atomic"

--- a/kvstore/batch_writer.go
+++ b/kvstore/batch_writer.go
@@ -168,7 +168,11 @@ func (bw *BatchedWriter) runBatchWriter() {
 
 	for bw.running.Load() || bw.scheduledCount.Load() != 0 {
 
-		batchCollector := newBatchCollector(bw.store.Batched(), bw.scheduledCount, bw.opts.batchSize)
+		batchedMutation, err := bw.store.Batched()
+		if err != nil {
+			panic(err)
+		}
+		batchCollector := newBatchCollector(batchedMutation, bw.scheduledCount, bw.opts.batchSize)
 		batchWriterTimeoutChan := time.After(bw.opts.batchTimeout)
 		shouldFlush := false
 
@@ -215,8 +219,13 @@ func (bw *BatchedWriter) runBatchWriter() {
 						if err := batchCollector.Commit(); err != nil {
 							panic(err)
 						}
+
 						// create a new collector to batch the remaining elements
-						batchCollector = newBatchCollector(bw.store.Batched(), bw.scheduledCount, bw.opts.batchSize)
+						batchedMutation, err := bw.store.Batched()
+						if err != nil {
+							panic(err)
+						}
+						batchCollector = newBatchCollector(batchedMutation, bw.scheduledCount, bw.opts.batchSize)
 					}
 
 				// no elements left

--- a/kvstore/bolt/bolt.go
+++ b/kvstore/bolt/bolt.go
@@ -2,8 +2,9 @@ package bolt
 
 import (
 	"bytes"
-	"errors"
 	"sync"
+
+	"github.com/pkg/errors"
 
 	"go.etcd.io/bbolt"
 	"go.uber.org/atomic"

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -8,6 +8,7 @@ import (
 var (
 	// ErrKeyNotFound is returned when an op. doesn't find the given key.
 	ErrKeyNotFound = errors.New("key not found")
+	ErrStoreClosed = errors.New("trying to access closed kvstore")
 
 	EmptyPrefix = KeyPrefix{}
 )

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -1,8 +1,9 @@
 package kvstore
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -8,6 +8,7 @@ import (
 var (
 	// ErrKeyNotFound is returned when an op. doesn't find the given key.
 	ErrKeyNotFound = errors.New("key not found")
+	// ErrStoreClosed is returned when an op accesses the kvstore but it was already closed.
 	ErrStoreClosed = errors.New("trying to access closed kvstore")
 
 	EmptyPrefix = KeyPrefix{}

--- a/kvstore/mapdb/mapdb.go
+++ b/kvstore/mapdb/mapdb.go
@@ -6,6 +6,8 @@ package mapdb
 import (
 	"sync"
 
+	"go.uber.org/atomic"
+
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/types"
@@ -14,21 +16,28 @@ import (
 // mapDB is a simple implementation of KVStore using a map.
 type mapDB struct {
 	sync.RWMutex
-	m     *syncedKVMap
-	realm []byte
+	m      *syncedKVMap
+	closed *atomic.Bool
+	realm  []byte
 }
 
 // NewMapDB creates a kvstore.KVStore implementation purely based on a go map.
 func NewMapDB() kvstore.KVStore {
 	return &mapDB{
-		m: &syncedKVMap{m: make(map[string][]byte)},
+		m:      &syncedKVMap{m: make(map[string][]byte)},
+		closed: atomic.NewBool(false),
 	}
 }
 
 func (s *mapDB) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
+	if s.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
 	return &mapDB{
-		m:     s.m, // use the same underlying map
-		realm: realm,
+		m:      s.m, // use the same underlying map
+		closed: s.closed,
+		realm:  realm,
 	}, nil
 }
 
@@ -39,6 +48,10 @@ func (s *mapDB) Realm() kvstore.Realm {
 // Iterate iterates over all keys and values with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys and values.
 // Optionally the direction for the iteration can be passed (default: IterDirectionForward).
 func (s *mapDB) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc, iterDirection ...kvstore.IterDirection) error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.m.iterate(s.realm, prefix, consumerFunc, iterDirection...)
 	return nil
 }
@@ -46,11 +59,19 @@ func (s *mapDB) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorK
 // IterateKeys iterates over all keys with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys.
 // Optionally the direction for the iteration can be passed (default: IterDirectionForward).
 func (s *mapDB) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc, iterDirection ...kvstore.IterDirection) error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.m.iterateKeys(s.realm, prefix, consumerFunc, iterDirection...)
 	return nil
 }
 
 func (s *mapDB) Clear() error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -59,6 +80,10 @@ func (s *mapDB) Clear() error {
 }
 
 func (s *mapDB) Get(key kvstore.Key) (kvstore.Value, error) {
+	if s.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
 	s.RLock()
 	defer s.RUnlock()
 
@@ -70,6 +95,10 @@ func (s *mapDB) Get(key kvstore.Key) (kvstore.Value, error) {
 }
 
 func (s *mapDB) Set(key kvstore.Key, value kvstore.Value) error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -82,6 +111,10 @@ func (s *mapDB) set(key kvstore.Key, value kvstore.Value) error {
 }
 
 func (s *mapDB) Has(key kvstore.Key) (bool, error) {
+	if s.closed.Load() {
+		return false, kvstore.ErrStoreClosed
+	}
+
 	s.RLock()
 	defer s.RUnlock()
 
@@ -90,6 +123,10 @@ func (s *mapDB) Has(key kvstore.Key) (bool, error) {
 }
 
 func (s *mapDB) Delete(key kvstore.Key) error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -102,6 +139,10 @@ func (s *mapDB) delete(key kvstore.Key) error {
 }
 
 func (s *mapDB) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -110,14 +151,27 @@ func (s *mapDB) DeletePrefix(prefix kvstore.KeyPrefix) error {
 }
 
 func (s *mapDB) Flush() error {
+	if s.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
 	return nil
 }
 
 func (s *mapDB) Close() error {
+	if s.closed.Swap(true) {
+		// was already closed
+		return kvstore.ErrStoreClosed
+	}
+
 	return nil
 }
 
 func (s *mapDB) Batched() (kvstore.BatchedMutations, error) {
+	if s.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
 	return &batchedMutations{
 		kvStore:          s,
 		setOperations:    make(map[string]kvstore.Value),

--- a/kvstore/mapdb/mapdb.go
+++ b/kvstore/mapdb/mapdb.go
@@ -25,19 +25,15 @@ func NewMapDB() kvstore.KVStore {
 	}
 }
 
-func (s *mapDB) WithRealm(realm kvstore.Realm) kvstore.KVStore {
+func (s *mapDB) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 	return &mapDB{
 		m:     s.m, // use the same underlying map
 		realm: realm,
-	}
+	}, nil
 }
 
 func (s *mapDB) Realm() kvstore.Realm {
 	return byteutils.ConcatBytes(s.realm)
-}
-
-// Shutdown marks the store as shutdown.
-func (s *mapDB) Shutdown() {
 }
 
 // Iterate iterates over all keys and values with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys and values.
@@ -113,20 +109,20 @@ func (s *mapDB) DeletePrefix(prefix kvstore.KeyPrefix) error {
 	return nil
 }
 
-func (s *mapDB) Batched() kvstore.BatchedMutations {
-	return &batchedMutations{
-		kvStore:          s,
-		setOperations:    make(map[string]kvstore.Value),
-		deleteOperations: make(map[string]types.Empty),
-	}
-}
-
 func (s *mapDB) Flush() error {
 	return nil
 }
 
 func (s *mapDB) Close() error {
 	return nil
+}
+
+func (s *mapDB) Batched() (kvstore.BatchedMutations, error) {
+	return &batchedMutations{
+		kvStore:          s,
+		setOperations:    make(map[string]kvstore.Value),
+		deleteOperations: make(map[string]types.Empty),
+	}, nil
 }
 
 type kvtuple struct {
@@ -199,3 +195,6 @@ func (b *batchedMutations) Commit() error {
 
 	return nil
 }
+
+var _ kvstore.KVStore = &mapDB{}
+var _ kvstore.BatchedMutations = &batchedMutations{}

--- a/kvstore/mapdb/mapdb_test.go
+++ b/kvstore/mapdb/mapdb_test.go
@@ -97,18 +97,22 @@ func TestMapDB_IterateDirection(t *testing.T) {
 func TestMapDB_Realm(t *testing.T) {
 	store := NewMapDB()
 	realm := kvstore.Realm("realm")
-	realmStore := store.WithRealm(realm)
-
-	key := []byte("key")
-	err := realmStore.Set(key, []byte("value"))
+	realmStore, err := store.WithRealm(realm)
 	require.NoError(t, err)
 
-	tmpStore := store.WithRealm(kvstore.Realm("tmp"))
+	key := []byte("key")
+	err = realmStore.Set(key, []byte("value"))
+	require.NoError(t, err)
+
+	tmpStore, err := store.WithRealm(kvstore.Realm("tmp"))
+	require.NoError(t, err)
+
 	key2 := []byte("key2")
 	err = tmpStore.Set(key2, []byte("value"))
 	require.NoError(t, err)
 
-	realmStore2 := store.WithRealm(realm)
+	realmStore2, err := store.WithRealm(realm)
+	require.NoError(t, err)
 
 	has, err := realmStore2.Has(key)
 	assert.NoError(t, err)

--- a/kvstore/rocksdb/rocksdb.go
+++ b/kvstore/rocksdb/rocksdb.go
@@ -4,10 +4,12 @@
 package rocksdb
 
 import (
-	"errors"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/linxGnu/grocksdb"
+	"go.uber.org/atomic"
 
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/kvstore"
@@ -38,7 +40,7 @@ func (s *rocksDBStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 		instance: s.instance,
 		closed:   s.closed,
 		dbPrefix: realm,
-	}
+	}, nil
 }
 
 func (s *rocksDBStore) Realm() []byte {
@@ -315,5 +317,5 @@ func (b *batchedMutations) Commit() error {
 	return b.store.db.Write(b.store.wo, writeBatch)
 }
 
-var _ kvstore.KVStore = &rocksDB{}
+var _ kvstore.KVStore = &rocksDBStore{}
 var _ kvstore.BatchedMutations = &batchedMutations{}

--- a/kvstore/test/kvstore_test.go
+++ b/kvstore/test/kvstore_test.go
@@ -813,7 +813,13 @@ func TestStoreClosed(t *testing.T) {
 		store, err := testStore(t, dbImplementation, prefix)
 		require.NoError(t, err, "used db: %s", dbImplementation)
 
+		batchedMutation, err := store.Batched()
+		require.NoError(t, err, "used db: %s", dbImplementation)
+
 		require.NoError(t, store.Close(), "used db: %s", dbImplementation)
+
+		err = batchedMutation.Commit()
+		require.ErrorIs(t, err, kvstore.ErrStoreClosed, "used db: %s", dbImplementation)
 
 		_, err = store.WithRealm(kvstore.EmptyPrefix)
 		require.ErrorIs(t, err, kvstore.ErrStoreClosed, "used db: %s", dbImplementation)

--- a/kvstore/test/kvstore_test.go
+++ b/kvstore/test/kvstore_test.go
@@ -31,7 +31,7 @@ var (
 	}
 )
 
-func testStore(t require.TestingT, dbImplementation string, realm []byte) kvstore.KVStore {
+func testStore(t require.TestingT, dbImplementation string, realm []byte) (kvstore.KVStore, error) {
 	switch dbImplementation {
 
 	case "badger":
@@ -94,7 +94,8 @@ func TestSetAndGet(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
 		for _, entry := range testEntries {
 			err := store.Set(entry.Key, entry.Value)
@@ -117,7 +118,8 @@ func TestSetAndGetEmptyValue(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
 		expectedValue := []byte{}
 
@@ -142,7 +144,8 @@ func TestDelete(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
 		for _, entry := range testEntries {
 			err := store.Set(entry.Key, entry.Value)
@@ -172,11 +175,15 @@ func TestRealm(t *testing.T) {
 
 	prefix := kvstore.EmptyPrefix
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
 		realm := kvstore.Realm("realm")
-		realmStore := store.WithRealm(realm)
-		tmpStore := store.WithRealm(kvstore.Realm("tmp"))
+		realmStore, err := store.WithRealm(realm)
+		require.NoError(t, err)
+
+		tmpStore, err := store.WithRealm(kvstore.Realm("tmp"))
+		require.NoError(t, err)
 
 		for _, entry := range testEntries {
 			err := realmStore.Set(entry.Key, entry.Value)
@@ -190,7 +197,8 @@ func TestRealm(t *testing.T) {
 		}
 		require.Equal(t, len(testEntries), countKeys(t, tmpStore), "used db: %s", dbImplementation)
 
-		realmStore2 := store.WithRealm(realm)
+		realmStore2, err := store.WithRealm(realm)
+		require.NoError(t, err)
 
 		for _, entry := range testEntries {
 			has, err := realmStore2.Has(entry.Key)
@@ -203,7 +211,7 @@ func TestRealm(t *testing.T) {
 		}
 
 		// when clearing "realm" the keys in "tmp" should still be there
-		err := realmStore.Clear()
+		err = realmStore.Clear()
 		require.NoError(t, err, "used db: %s", dbImplementation)
 
 		require.Equal(t, 0, countKeys(t, realmStore), "used db: %s", dbImplementation)
@@ -221,7 +229,9 @@ func TestClear(t *testing.T) {
 
 	prefix := kvstore.EmptyPrefix
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
+
 		require.EqualValues(t, 0, countKeys(t, store), "used db: %s", dbImplementation)
 
 		for _, entry := range testEntries {
@@ -231,7 +241,7 @@ func TestClear(t *testing.T) {
 		require.Equal(t, len(testEntries), countKeys(t, store), "used db: %s", dbImplementation)
 
 		// check that Clear removes all the keys
-		err := store.Clear()
+		err = store.Clear()
 		require.NoError(t, err, "used db: %s", dbImplementation)
 		require.EqualValues(t, 0, countKeys(t, store), "used db: %s", dbImplementation)
 	}
@@ -241,10 +251,10 @@ func TestIterate(t *testing.T) {
 
 	prefix := kvstore.EmptyPrefix
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 100
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 100
 
 		insertedValues := make(map[string]string)
 
@@ -276,10 +286,10 @@ func TestIterateDirection(t *testing.T) {
 
 	for _, dbImplementation := range dbImplementations {
 
-		store := testStore(t, dbImplementation, prefix)
-		count := 9
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 9
 
 		insertedValues := make(map[string]string)
 
@@ -383,10 +393,10 @@ func TestIterateDirectionKeyOnly(t *testing.T) {
 
 	for _, dbImplementation := range dbImplementations {
 
-		store := testStore(t, dbImplementation, prefix)
-		count := 9
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 9
 
 		insertedValues := make(map[string]string)
 
@@ -480,10 +490,10 @@ func TestIteratePrefix(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 100
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 100
 
 		insertedValues := make(map[string]string)
 
@@ -521,10 +531,10 @@ func TestIteratePrefixKeyOnly(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 100
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 100
 
 		insertedValues := make(map[string]string)
 
@@ -560,10 +570,10 @@ func TestDeletePrefix(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 1000
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 1000
 
 		insertedValues := make(map[string]string)
 
@@ -605,10 +615,10 @@ func TestDeletePrefixIsEmpty(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 100
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 100
 
 		for i := 0; i < count; i++ {
 			str := strconv.FormatInt(int64(i), 10)
@@ -634,10 +644,10 @@ func TestSetAndOverwrite(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
-		count := 100
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		var err error
+		count := 100
 
 		for i := 0; i < count; i++ {
 			str := strconv.FormatInt(int64(i), 10)
@@ -658,7 +668,8 @@ func TestSetAndOverwrite(t *testing.T) {
 		// Check that we checked the correct amount of entries
 		require.Equal(t, count, verifyCount, "used db: %s", dbImplementation)
 
-		batch := store.Batched()
+		batch, err := store.Batched()
+		require.NoError(t, err)
 
 		// Batch edit all to value 1
 		for i := 0; i < count; i++ {
@@ -689,15 +700,17 @@ func TestBatchedWithSetAndDelete(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		err := store.Set([]byte("testKey1"), []byte{42})
+		err = store.Set([]byte("testKey1"), []byte{42})
 		require.NoError(t, err, "used db: %s", dbImplementation)
 
 		err = store.Set([]byte("testKey2"), []byte{13})
 		require.NoError(t, err, "used db: %s", dbImplementation)
 
-		batch := store.Batched()
+		batch, err := store.Batched()
+		require.NoError(t, err)
 
 		err = batch.Set([]byte("testKey1"), []byte{84})
 		require.NoError(t, err, "used db: %s", dbImplementation)
@@ -729,11 +742,13 @@ func TestBatchedWithDuplicateKeys(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
 
-		batch := store.Batched()
+		batch, err := store.Batched()
+		require.NoError(t, err)
 
-		err := batch.Set([]byte("testKey1"), []byte{84})
+		err = batch.Set([]byte("testKey1"), []byte{84})
 		require.NoError(t, err, "used db: %s", dbImplementation)
 
 		err = batch.Set([]byte("testKey1"), []byte{69})
@@ -758,12 +773,13 @@ func TestBatchedWithLotsOfKeys(t *testing.T) {
 
 	prefix := []byte("testPrefix")
 	for _, dbImplementation := range dbImplementations {
-		store := testStore(t, dbImplementation, prefix)
+		store, err := testStore(t, dbImplementation, prefix)
+		require.NoError(t, err)
+
 		count := 100_000
 
-		var err error
-
-		batch := store.Batched()
+		batch, err := store.Batched()
+		require.NoError(t, err)
 
 		for i := 0; i < count; i++ {
 			testKey := make([]byte, 49)

--- a/objectstorage/factory.go
+++ b/objectstorage/factory.go
@@ -21,5 +21,10 @@ func NewFactory(store kvstore.KVStore, packagePrefix byte) *Factory {
 // New creates a new ObjectStorage with the given parameters. It combines the store specific prefix with the package
 // prefix, to create a unique realm for the KVStore of the ObjectStorage.
 func (factory *Factory) New(storagePrefix byte, objectFactory StorableObjectFactory, optionalOptions ...Option) *ObjectStorage {
-	return New(factory.store.WithRealm([]byte{factory.packagePrefix, storagePrefix}), objectFactory, optionalOptions...)
+	storeWithRealm, err := factory.store.WithRealm([]byte{factory.packagePrefix, storagePrefix})
+	if err != nil {
+		panic(err)
+	}
+
+	return New(storeWithRealm, objectFactory, optionalOptions...)
 }

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -1021,22 +1021,28 @@ func (objectStorage *ObjectStorage) DeleteEntryFromStore(key []byte) {
 }
 
 // DeleteEntriesFromStore deletes entries from the persistence layer.
-func (objectStorage *ObjectStorage) DeleteEntriesFromStore(keys [][]byte) {
+func (objectStorage *ObjectStorage) DeleteEntriesFromStore(keys [][]byte) error {
 	if !objectStorage.options.persistenceEnabled {
-		return
+		return nil
 	}
 
-	batchedMuts := objectStorage.options.store.Batched()
+	batchedMuts, err := objectStorage.options.store.Batched()
+	if err != nil {
+		return err
+	}
+
 	for i := 0; i < len(keys); i++ {
 		if err := batchedMuts.Delete(keys[i]); err != nil {
 			batchedMuts.Cancel()
-			panic(err)
+			return err
 		}
 	}
 
 	if err := batchedMuts.Commit(); err != nil {
-		panic(err)
+		return err
 	}
+
+	return nil
 }
 
 func (objectStorage *ObjectStorage) ObjectExistsInStore(key []byte) bool {

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -5,7 +5,6 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
-
 	"go.uber.org/atomic"
 
 	"github.com/iotaledger/hive.go/events"

--- a/objectstorage/object_storage.go
+++ b/objectstorage/object_storage.go
@@ -1,9 +1,10 @@
 package objectstorage
 
 import (
-	"errors"
 	"sync"
 	"unsafe"
+
+	"github.com/pkg/errors"
 
 	"go.uber.org/atomic"
 

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/objectstorage/test/objectstorage_test.go
+++ b/objectstorage/test/objectstorage_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -10,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/testutil/badgerdb.go
+++ b/testutil/badgerdb.go
@@ -37,5 +37,10 @@ func BadgerDB(t *testing.T) (kvstore.KVStore, error) {
 	counter := databaseCounter[t.Name()]
 	databaseCounterMutex.Unlock()
 
-	return badger.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter))), nil
+	storeWithRealm, err := badger.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter)))
+	if err != nil {
+		return nil, err
+	}
+
+	return storeWithRealm, nil
 }

--- a/testutil/pebbledb.go
+++ b/testutil/pebbledb.go
@@ -66,5 +66,10 @@ func PebbleDB(t *testing.T) (kvstore.KVStore, error) {
 	counter := databaseCounter[t.Name()]
 	databaseCounterMutex.Unlock()
 
-	return pebble.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter))), nil
+	storeWithRealm, err := pebble.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter)))
+	if err != nil {
+		return nil, err
+	}
+
+	return storeWithRealm, nil
 }

--- a/testutil/rocksdb.go
+++ b/testutil/rocksdb.go
@@ -32,5 +32,10 @@ func RocksDB(t *testing.T) (kvstore.KVStore, error) {
 	counter := databaseCounter[t.Name()]
 	databaseCounterMutex.Unlock()
 
-	return rocksdb.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter))), nil
+	storeWithRealm, err := rocksdb.New(db).WithRealm([]byte(t.Name() + strconv.Itoa(counter)))
+	if err != nil {
+		return nil, err
+	}
+
+	return storeWithRealm, nil
 }


### PR DESCRIPTION
This PR modifies the KVStore interface.

The unused Shutdown method was removed.
All interface functions also return an error parameter now.

A check for an already closed KVStore was added to every implementation as well as a test case for that.