### PR TITLE
Add BucketStore

### DIFF
--- a/kvstore/bucket/bucket_store.go
+++ b/kvstore/bucket/bucket_store.go
@@ -1,0 +1,689 @@
+package bucketstore
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+var (
+	// ErrNotEnoughBuckets is returned when not enough buckets are available.
+	ErrNotEnoughBuckets = errors.New("not enough buckets")
+	// ErrInvalidBucketIndex is returned when a bucket index does not exist or is invalid.
+	ErrInvalidBucketIndex = errors.New("invalid bucket index")
+)
+
+const (
+	// MinBucketCount is the minimum amount of remaining buckets in the store.
+	MinBucketCount = 2
+)
+
+// BucketCaller is an event caller which gets a bucket passed.
+func BucketCaller(handler interface{}, params ...interface{}) {
+	handler.(func(kvstore.KVStore))(params[0].(kvstore.KVStore))
+}
+
+// BucketConsumerFunc consumes the given index and bucket.
+// A returned boolean flag signals to proceed further iteration.
+type BucketConsumerFunc = func(index int, bucket kvstore.KVStore) bool
+
+// Events are the events issued by the BucketStore.
+type Events struct {
+	// PreBucketCreated is fired before a new bucket is created.
+	PreBucketCreated *events.Event
+	// PreBucketDeleted is fired before a bucket is deleted.
+	PreBucketDeleted *events.Event
+	// BucketCreated is fired when a new bucket is created.
+	BucketCreated *events.Event
+	// BucketDeleted is fired when a bucket is deleted.
+	BucketDeleted *events.Event
+}
+
+// BucketStore is a KVStore implementation that consists of multiple "buckets"
+// of other KVStores.
+//
+// Operations applied to all buckets:
+//    - Get
+//    - Has
+//    - Iterate (in order from latest bucket to oldest bucket)
+//    - IterateKeys (in order from latest bucket to oldest bucket)
+//    - Delete
+//    - DeletePrefix
+//    - Clear
+//    - Close
+//    - Flush
+//
+// Operations applied to the latest bucket:
+//    - Set
+//
+// Important to consider
+//
+// During a Set operation, old versions of existing keys
+// in older buckets are deleted, if WithDeleteKeyInOtherBucketsOnSet
+// is set to true (default).
+//
+// If this option is set to false, there could be multiple versions
+// of the same key.
+//
+// Get always returns the latest version.
+// Iterate and IterateKeys will return the different versions
+// of the keys in order from latest bucket to oldest bucket.
+//
+// Setting this option to true may impact the write performance.
+type BucketStore struct {
+	sync.RWMutex
+
+	// holds the buckets.
+	buckets []kvstore.KVStore
+	// holds the BucketStore options.
+	opts *Options
+	// events of the BucketStore.
+	Events *Events
+	// used to signal that the store was closed already.
+	closed *atomic.Bool
+}
+
+// the default options applied to the BucketStore.
+var defaultOptions = []Option{
+	WithDeleteKeyInOtherBucketsOnSet(true),
+}
+
+// Options define options for the BucketStore.
+type Options struct {
+	// deletes older versions of the key in other buckets on Set or Batched().Set
+	deleteKeyInOtherBucketsOnSet bool
+}
+
+// applies the given Option.
+func (so *Options) apply(opts ...Option) {
+	for _, opt := range opts {
+		opt(so)
+	}
+}
+
+// WithDeleteKeyInOtherBucketsOnSet deletes older versions of the key in other buckets on Set or Batched().Set.
+func WithDeleteKeyInOtherBucketsOnSet(deleteOnSet bool) Option {
+	return func(opts *Options) {
+		opts.deleteKeyInOtherBucketsOnSet = deleteOnSet
+	}
+}
+
+// Option is a function setting a BucketStore option.
+type Option func(opts *Options)
+
+// New creates a new BucketStore.
+func New(buckets []kvstore.KVStore, opts ...Option) (*BucketStore, error) {
+	if len(buckets) < MinBucketCount {
+		return nil, ErrNotEnoughBuckets
+	}
+
+	options := &Options{}
+	options.apply(defaultOptions...)
+	options.apply(opts...)
+
+	return &BucketStore{
+		buckets: buckets,
+		opts:    options,
+		closed:  atomic.NewBool(false),
+
+		Events: &Events{
+			PreBucketCreated: events.NewEvent(BucketCaller),
+			PreBucketDeleted: events.NewEvent(events.VoidCaller),
+			BucketCreated:    events.NewEvent(BucketCaller),
+			BucketDeleted:    events.NewEvent(events.VoidCaller),
+		},
+	}, nil
+}
+
+// Options returns a copy of the options.
+func (bs *BucketStore) Options() Options {
+	return *bs.opts
+}
+
+// bucketForEachWithoutLocking calls the consumer function on every bucket.
+func (bs *BucketStore) bucketForEachWithoutLocking(consumer BucketConsumerFunc) bool {
+
+	for i, bucket := range bs.buckets {
+		if !consumer(i, bucket) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// BucketAdd adds a new bucket to the store (front).
+func (bs *BucketStore) BucketAdd(bucket kvstore.KVStore) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.Events.PreBucketCreated.Trigger(bucket)
+
+	// push front
+	bs.Lock()
+	bs.buckets = append([]kvstore.KVStore{bucket}, bs.buckets...)
+	bs.Unlock()
+
+	bs.Events.BucketCreated.Trigger(bucket)
+
+	return nil
+}
+
+// BucketDeleteLast deletes a bucket from the store (end).
+func (bs *BucketStore) BucketDeleteLast() error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	lenBuckets := len(bs.buckets)
+	bs.RUnlock()
+
+	if lenBuckets <= MinBucketCount {
+		return ErrNotEnoughBuckets
+	}
+
+	bs.Events.PreBucketDeleted.Trigger()
+
+	bs.Lock()
+
+	// check again
+	lenBuckets = len(bs.buckets)
+	if lenBuckets <= MinBucketCount {
+		bs.Unlock()
+		return ErrNotEnoughBuckets
+	}
+
+	lastBucket := bs.buckets[lenBuckets-1]
+	lastBucket.Close()
+	bs.buckets[lenBuckets-1] = nil // avoid memory leak
+
+	// pop
+	bs.buckets = bs.buckets[:lenBuckets-1]
+	bs.Unlock()
+
+	bs.Events.BucketDeleted.Trigger()
+	return nil
+}
+
+func (bs *BucketStore) bucketFirst() kvstore.KVStore {
+	return bs.buckets[0]
+}
+
+// BucketFirst returns the latest bucket (front).
+func (bs *BucketStore) BucketFirst() (kvstore.KVStore, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	return bs.bucketFirst(), nil
+}
+
+func (bs *BucketStore) bucketLast() kvstore.KVStore {
+	return bs.buckets[len(bs.buckets)-1]
+}
+
+// BucketLast returns the oldest bucket (end).
+func (bs *BucketStore) BucketLast() (kvstore.KVStore, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	return bs.bucketLast(), nil
+}
+
+// Bucket returns the bucket at the given index.
+func (bs *BucketStore) Bucket(index int) (kvstore.KVStore, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	if index < 0 || index >= len(bs.buckets) {
+		return nil, ErrInvalidBucketIndex
+	}
+
+	return bs.buckets[index], nil
+}
+
+// BucketCount returns the amount of buckets in the store.
+func (bs *BucketStore) BucketCount() (int, error) {
+	if bs.closed.Load() {
+		return 0, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	return len(bs.buckets), nil
+}
+
+// BucketForEach calls the consumer on every bucket in order from latest to oldest.
+func (bs *BucketStore) BucketForEach(consumer BucketConsumerFunc) (bool, error) {
+	if bs.closed.Load() {
+		return false, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	return bs.bucketForEachWithoutLocking(consumer), nil
+}
+
+///////////////////////
+// KVStore interface //
+///////////////////////
+
+// WithRealm is a factory method for using the same underlying storage with a different realm.
+func (bs *BucketStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	return NewRealm(bs, realm), nil
+}
+
+// Realm returns the configured realm.
+func (bs *BucketStore) Realm() kvstore.Realm {
+	bs.RLock()
+	defer bs.RUnlock()
+
+	return bs.bucketFirst().Realm()
+}
+
+// Iterate iterates over all keys and values with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys and values.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (bs *BucketStore) Iterate(prefix kvstore.KeyPrefix, kvConsumerFunc kvstore.IteratorKeyValueConsumerFunc, direction ...kvstore.IterDirection) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	proceedIteration := true
+
+	kvConsumerFuncWrapped := func(key kvstore.Key, value kvstore.Value) bool {
+		if !kvConsumerFunc(key, value) {
+			proceedIteration = false
+		}
+		return proceedIteration
+	}
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.Iterate(prefix, kvConsumerFuncWrapped, direction...); err != nil {
+			innerErr = err
+			return false
+		}
+		return proceedIteration
+	})
+
+	return innerErr
+}
+
+// IterateKeys iterates over all keys with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (bs *BucketStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc, direction ...kvstore.IterDirection) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	proceedIteration := true
+
+	consumerFuncWrapped := func(key kvstore.Key) bool {
+		if !consumerFunc(key) {
+			proceedIteration = false
+		}
+		return proceedIteration
+	}
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.IterateKeys(prefix, consumerFuncWrapped, direction...); err != nil {
+			innerErr = err
+			return false
+		}
+		return proceedIteration
+	})
+
+	return innerErr
+}
+
+// Clear clears the realm.
+func (bs *BucketStore) Clear() error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.Clear(); err != nil {
+			innerErr = err
+		}
+
+		// clear all buckets, even if one fails.
+		return true
+	})
+
+	return innerErr
+}
+
+// Get gets the given key or nil if it doesn't exist or an error if an error occurred.
+func (bs *BucketStore) Get(key kvstore.Key) (kvstore.Value, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var value kvstore.Value = nil
+	var innerErr error = kvstore.ErrKeyNotFound
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		v, err := bucket.Get(key)
+		if err != nil {
+			if err == kvstore.ErrKeyNotFound {
+				// key not found.
+				// => continue searching for the key in other buckets.
+				return true
+			}
+
+			// an error has occurred.
+			// => stop searching for the key in other buckets.
+			innerErr = err
+			return false
+		}
+
+		// reset the ErrKeyNotFound because we found the key.
+		innerErr = nil
+		value = v
+
+		// key found.
+		// => stop searching for the key in other buckets.
+		return false
+	})
+
+	return value, innerErr
+}
+
+// Set sets the given key and value.
+func (bs *BucketStore) Set(key kvstore.Key, value kvstore.Value) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	if bs.opts.deleteKeyInOtherBucketsOnSet {
+		_ = bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+			// Delete the key in older buckets
+			if index != 0 {
+				_ = bucket.Delete(key)
+			}
+			return true
+		})
+	}
+
+	return bs.bucketFirst().Set(key, value)
+}
+
+// Has checks whether the given key exists.
+func (bs *BucketStore) Has(key kvstore.Key) (bool, error) {
+	if bs.closed.Load() {
+		return false, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var has bool = false
+	var innerErr error = nil
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		found, err := bucket.Has(key)
+		if err != nil {
+			// an error has occurred.
+			// => stop searching for the key in other buckets.
+			innerErr = err
+			return false
+		}
+
+		if found {
+			has = true
+
+			// key found.
+			// => stop searching for the key in other buckets.
+			return false
+		}
+
+		// key not found.
+		// => continue searching for the key in other buckets.
+		return true
+	})
+
+	return has, innerErr
+}
+
+// Delete deletes the entry for the given key.
+func (bs *BucketStore) Delete(key kvstore.Key) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.Delete(key); err != nil {
+			innerErr = err
+		}
+
+		// delete key in all buckets, even if one fails.
+		return true
+	})
+
+	return innerErr
+}
+
+// DeletePrefix deletes all the entries matching the given key prefix.
+func (bs *BucketStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.DeletePrefix(prefix); err != nil {
+			innerErr = err
+		}
+
+		// delete prefix in all buckets, even if one fails.
+		return true
+	})
+
+	return innerErr
+}
+
+// Flush persists all outstanding write operations to disc.
+func (bs *BucketStore) Flush() error {
+	if bs.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.Flush(); err != nil {
+			innerErr = err
+		}
+
+		// flush all buckets, even if one fails.
+		return true
+	})
+
+	return innerErr
+}
+
+// Close closes the database file handles.
+func (bs *BucketStore) Close() error {
+	if bs.closed.Swap(true) {
+		// was already closed
+		return kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	var innerErr error
+
+	bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		if err := bucket.Close(); err != nil {
+			innerErr = err
+		}
+
+		// close all buckets, even if one fails.
+		return true
+	})
+
+	return innerErr
+}
+
+// Batched returns a BatchedMutations interface to execute batched mutations.
+func (bs *BucketStore) Batched() (kvstore.BatchedMutations, error) {
+	if bs.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	bs.RLock()
+	defer bs.RUnlock()
+
+	batchedOthers := make([]kvstore.BatchedMutations, len(bs.buckets)-1)
+
+	var innerErr error
+
+	_ = bs.bucketForEachWithoutLocking(func(index int, bucket kvstore.KVStore) bool {
+		// Initialize a batched mutation for the other buckets,
+		// because we need to delete all keys that are deleted, and also delete
+		// keys that are set if "deleteKeyInOtherBucketsOnSet" is set to true.
+		if index != 0 {
+			batchedMutation, err := bucket.Batched()
+			if err != nil {
+				innerErr = err
+				return false
+			}
+			batchedOthers[index-1] = batchedMutation
+		}
+		return true
+	})
+
+	if innerErr != nil {
+		return nil, innerErr
+	}
+
+	batchedFirst, err := bs.bucketFirst().Batched()
+	if err != nil {
+		return nil, err
+	}
+
+	return &batchedMutations{
+		batchedFirst:                 batchedFirst,
+		batchedOthers:                batchedOthers,
+		deleteKeyInOtherBucketsOnSet: bs.opts.deleteKeyInOtherBucketsOnSet,
+		closed:                       bs.closed,
+	}, nil
+}
+
+// batchedMutations is a wrapper around a kvstore.BatchedMutations.
+type batchedMutations struct {
+	batchedFirst                 kvstore.BatchedMutations
+	batchedOthers                []kvstore.BatchedMutations
+	deleteKeyInOtherBucketsOnSet bool
+	closed                       *atomic.Bool
+}
+
+// Set sets the given key and value.
+func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
+
+	if b.deleteKeyInOtherBucketsOnSet {
+		for _, batched := range b.batchedOthers {
+			if err := batched.Delete(key); err != nil {
+				return err
+			}
+		}
+	}
+
+	return b.batchedFirst.Set(key, value)
+}
+
+// Delete deletes the entry for the given key.
+func (b *batchedMutations) Delete(key kvstore.Key) error {
+	for _, batched := range b.batchedOthers {
+		if err := batched.Delete(key); err != nil {
+			return err
+		}
+	}
+
+	return b.batchedFirst.Delete(key)
+}
+
+// Cancel cancels the batched mutations.
+func (b *batchedMutations) Cancel() {
+	for _, batched := range b.batchedOthers {
+		batched.Cancel()
+	}
+
+	b.batchedFirst.Cancel()
+}
+
+// Commit commits/flushes the mutations.
+func (b *batchedMutations) Commit() error {
+	if b.closed.Load() {
+		return kvstore.ErrStoreClosed
+	}
+
+	for _, batched := range b.batchedOthers {
+		if err := batched.Commit(); err != nil {
+			return err
+		}
+	}
+
+	return b.batchedFirst.Commit()
+}
+
+// code guards
+var _ kvstore.KVStore = &BucketStore{}
+var _ kvstore.BatchedMutations = &batchedMutations{}

--- a/kvstore/bucket/bucket_store_realm.go
+++ b/kvstore/bucket/bucket_store_realm.go
@@ -1,0 +1,149 @@
+package bucketstore
+
+import (
+	"github.com/iotaledger/hive.go/byteutils"
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+// Realm is a KVStore implementation
+// that uses an underlying BucketStore with a prefix.
+type Realm struct {
+	bucketStore *BucketStore
+	realm       kvstore.Realm
+}
+
+// NewRealm creates a new Realm.
+func NewRealm(bucketStore *BucketStore, realm kvstore.Realm) *Realm {
+	return &Realm{
+		bucketStore: bucketStore,
+		realm:       realm,
+	}
+}
+
+// buildKeyPrefix builds a key using the realm and the given prefix.
+func (bsr *Realm) buildKeyPrefix(prefix kvstore.KeyPrefix) kvstore.KeyPrefix {
+	return byteutils.ConcatBytes(bsr.realm, prefix)
+}
+
+///////////////////////
+// KVStore interface //
+///////////////////////
+
+// WithRealm is a factory method for using the same underlying storage with a different realm.
+func (bsr *Realm) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
+	if bsr.bucketStore.closed.Load() {
+		return nil, kvstore.ErrStoreClosed
+	}
+
+	return NewRealm(bsr.bucketStore, bsr.buildKeyPrefix(realm)), nil
+}
+
+// Realm returns the configured realm.
+func (bsr *Realm) Realm() kvstore.Realm {
+	return bsr.realm
+}
+
+// Iterate iterates over all keys and values with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys and values.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (bsr *Realm) Iterate(prefix kvstore.KeyPrefix, kvConsumerFunc kvstore.IteratorKeyValueConsumerFunc, direction ...kvstore.IterDirection) error {
+
+	kvConsumerFuncWrapped := func(key kvstore.Key, value kvstore.Value) bool {
+		return kvConsumerFunc(key[len(bsr.realm):], value)
+	}
+
+	return bsr.bucketStore.Iterate(bsr.buildKeyPrefix(prefix), kvConsumerFuncWrapped, direction...)
+}
+
+// IterateKeys iterates over all keys with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (bsr *Realm) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc, direction ...kvstore.IterDirection) error {
+
+	consumerFuncWrapped := func(key kvstore.Key) bool {
+		return consumerFunc(key[len(bsr.realm):])
+	}
+
+	return bsr.bucketStore.IterateKeys(bsr.buildKeyPrefix(prefix), consumerFuncWrapped, direction...)
+}
+
+// Clear clears the realm.
+func (bsr *Realm) Clear() error {
+	return bsr.bucketStore.DeletePrefix(bsr.realm)
+}
+
+// Get gets the given key or nil if it doesn't exist or an error if an error occurred.
+func (bsr *Realm) Get(key kvstore.Key) (kvstore.Value, error) {
+	return bsr.bucketStore.Get(bsr.buildKeyPrefix(key))
+}
+
+// Set sets the given key and value.
+func (bsr *Realm) Set(key kvstore.Key, value kvstore.Value) error {
+	return bsr.bucketStore.Set(bsr.buildKeyPrefix(key), value)
+}
+
+// Has checks whether the given key exists.
+func (bsr *Realm) Has(key kvstore.Key) (bool, error) {
+	return bsr.bucketStore.Has(bsr.buildKeyPrefix(key))
+}
+
+// Delete deletes the entry for the given key.
+func (bsr *Realm) Delete(key kvstore.Key) error {
+	return bsr.bucketStore.Delete(bsr.buildKeyPrefix(key))
+}
+
+// DeletePrefix deletes all the entries matching the given key prefix.
+func (bsr *Realm) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	return bsr.bucketStore.DeletePrefix(bsr.buildKeyPrefix(prefix))
+}
+
+// Flush persists all outstanding write operations to disc.
+func (bsr *Realm) Flush() error {
+	return bsr.bucketStore.Flush()
+}
+
+// Close closes the database file handles.
+func (bsr *Realm) Close() error {
+	return bsr.bucketStore.Close()
+}
+
+// Batched returns a BatchedMutations interface to execute batched mutations.
+func (bsr *Realm) Batched() (kvstore.BatchedMutations, error) {
+	batchedMutation, err := bsr.bucketStore.Batched()
+	if err != nil {
+		return nil, err
+	}
+
+	return &batchedMutationsWithRealm{
+		batched: batchedMutation,
+		realm:   bsr.realm,
+	}, nil
+}
+
+// batchedMutationsWithRealm is a wrapper around a kvstore.BatchedMutations with realm.
+type batchedMutationsWithRealm struct {
+	batched kvstore.BatchedMutations
+	realm   kvstore.Realm
+}
+
+// Set sets the given key and value.
+func (b *batchedMutationsWithRealm) Set(key kvstore.Key, value kvstore.Value) error {
+	return b.batched.Set(byteutils.ConcatBytes(b.realm, key), value)
+}
+
+// Delete deletes the entry for the given key.
+func (b *batchedMutationsWithRealm) Delete(key kvstore.Key) error {
+	return b.batched.Delete(byteutils.ConcatBytes(b.realm, key))
+}
+
+// Cancel cancels the batched mutations.
+func (b *batchedMutationsWithRealm) Cancel() {
+	b.batched.Cancel()
+}
+
+// Commit commits/flushes the mutations.
+func (b *batchedMutationsWithRealm) Commit() error {
+	return b.batched.Commit()
+}
+
+// code guards
+var _ kvstore.KVStore = &Realm{}
+var _ kvstore.BatchedMutations = &batchedMutationsWithRealm{}

--- a/kvstore/bucket/bucket_store_test.go
+++ b/kvstore/bucket/bucket_store_test.go
@@ -1,0 +1,772 @@
+package bucketstore
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+)
+
+var (
+	testKeyPrefix = kvstore.KeyPrefix("testKey")
+)
+
+var testEntries1 = []*struct {
+	kvstore.Key
+	kvstore.Value
+}{
+	{Key: []byte(fmt.Sprintf("%s_a", testKeyPrefix)), Value: []byte("testValue_A_1")},
+	{Key: []byte(fmt.Sprintf("%s_b", testKeyPrefix)), Value: []byte("testValue_B_1")},
+	{Key: []byte(fmt.Sprintf("%s_c", testKeyPrefix)), Value: []byte("testValue_C_1")},
+	{Key: []byte(fmt.Sprintf("%s_d", testKeyPrefix)), Value: []byte("testValue_D_1")},
+}
+
+var testEntries2 = []*struct {
+	kvstore.Key
+	kvstore.Value
+}{
+	{Key: []byte(fmt.Sprintf("%s_a", testKeyPrefix)), Value: []byte("testValue_A_2")},
+	{Key: []byte(fmt.Sprintf("%s_b", testKeyPrefix)), Value: []byte("testValue_B_2")},
+	{Key: []byte(fmt.Sprintf("%s_c", testKeyPrefix)), Value: []byte("testValue_C_2")},
+	{Key: []byte(fmt.Sprintf("%s_d", testKeyPrefix)), Value: []byte("testValue_D_2")},
+}
+
+func getTestStore() kvstore.KVStore {
+	return mapdb.NewMapDB()
+}
+
+func getComparableTestStore(index int) kvstore.KVStore {
+	store := getTestStore()
+
+	// needed for interface comparison (without that it would be equal)
+	store.Set([]byte("index"), []byte{byte(index)})
+
+	return store
+}
+
+func TestBucketStoreNew(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1})
+	require.Nil(t, bucketStore)
+	require.ErrorIs(t, ErrNotEnoughBuckets, err)
+
+	bucketStore, err = New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+}
+
+func TestBucketStoreAdd(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+	testBucket4 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+}
+
+func TestBucketStoreDelete(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 3
+
+	require.ErrorIs(t, ErrNotEnoughBuckets, bucketStore.BucketDeleteLast()) // 2
+}
+
+func TestBucketStoreClose(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	bucketStore.Close()
+
+	err = bucketStore.BucketAdd(testBucket1)
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	err = bucketStore.BucketDeleteLast() // 3
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	_, err = bucketStore.BucketFirst()
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	_, err = bucketStore.BucketLast()
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	_, err = bucketStore.Bucket(0)
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	_, err = bucketStore.BucketCount()
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+
+	_, err = bucketStore.BucketForEach(func(index int, bucket kvstore.KVStore) bool { return true })
+	require.ErrorIs(t, err, kvstore.ErrStoreClosed)
+}
+
+func TestBucketStoreCount(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+	testBucket4 := getTestStore()
+	testBucket5 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	count, err := bucketStore.BucketCount()
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+	count, err = bucketStore.BucketCount()
+	require.NoError(t, err)
+	require.Equal(t, 4, count)
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket5))
+	count, err = bucketStore.BucketCount()
+	require.NoError(t, err)
+	require.Equal(t, 5, count)
+
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 3
+	count, err = bucketStore.BucketCount()
+	require.NoError(t, err)
+	require.Equal(t, 4, count)
+}
+
+func TestBucketStoreIndexing(t *testing.T) {
+	testBucket1 := getComparableTestStore(1)
+	testBucket2 := getComparableTestStore(2)
+	testBucket3 := getComparableTestStore(3)
+	testBucket4 := getComparableTestStore(4)
+	testBucket5 := getComparableTestStore(5)
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	// 1 is the latest
+	bucketFirst, err := bucketStore.BucketFirst()
+	require.NotNil(t, bucketFirst)
+	require.NoError(t, err)
+	require.Equal(t, testBucket1, bucketFirst)
+
+	// 3 is the oldest
+	bucketLast, err := bucketStore.BucketLast()
+	require.NotNil(t, bucketLast)
+	require.NoError(t, err)
+	require.Equal(t, testBucket3, bucketLast)
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+
+	// 4 is the latest now
+	bucketFirst, err = bucketStore.BucketFirst()
+	require.NotNil(t, bucketFirst)
+	require.NoError(t, err)
+	require.Equal(t, testBucket4, bucketFirst)
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket5))
+
+	// 5 is the latest now
+	bucketFirst, err = bucketStore.BucketFirst()
+	require.NotNil(t, bucketFirst)
+	require.NoError(t, err)
+	require.Equal(t, testBucket5, bucketFirst)
+
+	bucket2, err := bucketStore.Bucket(3)
+	require.NotNil(t, bucket2)
+	require.NoError(t, err)
+	require.Equal(t, testBucket2, bucket2)
+	require.NotEqual(t, testBucket3, bucket2)
+}
+
+func TestBucketStoreForEach(t *testing.T) {
+	testBucket1 := getComparableTestStore(1)
+	testBucket2 := getComparableTestStore(2)
+	testBucket3 := getComparableTestStore(3)
+	testBucket4 := getComparableTestStore(4)
+	testBucket5 := getComparableTestStore(5)
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2, testBucket3})
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+	require.NoError(t, bucketStore.BucketAdd(testBucket5))
+
+	buckets := make(map[int]kvstore.KVStore)
+	buckets[0] = testBucket5
+	buckets[1] = testBucket4
+	buckets[2] = testBucket1
+	buckets[3] = testBucket2
+	buckets[4] = testBucket3
+
+	_, err = bucketStore.BucketForEach(func(index int, bucket kvstore.KVStore) bool {
+		require.Equal(t, buckets[index], bucket)
+		delete(buckets, index)
+		return true
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(buckets))
+}
+
+// KVStore interface
+// normal kvstore usage is already tested in kvstore_test.go
+// here we have to test the bucket use cases (add/delete bucket, old version of keys in older buckets, pruning etc...)
+
+func TestBucketStoreGet(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+	testBucket4 := getTestStore()
+	testBucket5 := getTestStore()
+	testBucket6 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(false))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	// add the entries to the first two buckets
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add buckets
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+
+	// set new values for existing keys
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if values match the new version
+	for _, testEntry := range testEntries2 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	// add buckets and delete the old ones
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 2
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 1
+	require.NoError(t, bucketStore.BucketAdd(testBucket5))
+	require.NoError(t, bucketStore.BucketAdd(testBucket6))
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 3
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 4
+
+	// check if keys are removed
+	for _, testEntry := range testEntries1 {
+		value, err := bucketStore.Get(testEntry.Key)
+		require.Equal(t, kvstore.ErrKeyNotFound, err)
+		require.Nil(t, value)
+	}
+}
+
+func TestBucketStoreDeleteKey(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(false))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	// add the entries to the first two buckets
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add bucket
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+
+	// set new values for existing keys
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if values match the new version
+	for _, testEntry := range testEntries2 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	// delete keys
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Delete(testEntry.Key))
+	}
+
+	// check if keys are deleted in all buckets
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.Equal(t, kvstore.ErrKeyNotFound, err2)
+		require.Nil(t, value)
+	}
+}
+
+func TestBucketStoreDeletePrefix(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(false))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	// add the entries to the first two buckets
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add bucket
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+
+	// set new values for existing keys
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+	}
+
+	// check if values match the new version
+	for _, testEntry := range testEntries2 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	// delete prefix
+	require.NoError(t, bucketStore.DeletePrefix(testKeyPrefix))
+
+	// check if keys are deleted in all buckets
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.Equal(t, kvstore.ErrKeyNotFound, err2)
+		require.Nil(t, value)
+	}
+}
+
+func TestBucketStoreIterateWithOldVersions(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+	testBucket4 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(false))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	insertedValues := make(map[string]kvstore.Value)
+
+	// add the entries to the first two buckets
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add buckets
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+
+	// set new values for existing keys
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	unknownValues := make(map[string]kvstore.Value)
+
+	// there will be old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+		if !found {
+			unknownValues[string(key)] = value
+			return true
+		}
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+
+	// the unknownValues should match the old versions of the keys
+	for _, testEntry := range testEntries1 {
+		value, found := unknownValues[string(testEntry.Key)]
+		require.True(t, found)
+
+		// check if values match the old version
+		require.Equal(t, testEntry.Value, value)
+		delete(unknownValues, string(testEntry.Key))
+	}
+
+	// check if we found all old values
+	require.Equal(t, 0, len(unknownValues))
+
+	// delete the old buckets to remove the old key versions
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 2
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 1
+
+	// reinit the expected results
+	insertedValues = make(map[string]kvstore.Value)
+	for _, testEntry := range testEntries2 {
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	// there should be no old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+
+		// check if no old versions of keys exist
+		require.True(t, found)
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+}
+
+func TestBucketStoreIterateWithoutOldVersions(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(true))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	insertedValues := make(map[string]kvstore.Value)
+
+	// add the entries to the first two buckets
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add bucket
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+
+	// set new values for existing keys
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, bucketStore.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	// there should be no old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+
+		// check if no old versions of keys exist
+		require.True(t, found)
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+}
+
+func TestBucketStoreBatchedWithOldVersions(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+	testBucket4 := getTestStore()
+	testBucket5 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(false))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	insertedValues := make(map[string]kvstore.Value)
+
+	// add the entries to the first two buckets
+	batchedMutation, err := bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, batchedMutation.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add buckets
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+	require.NoError(t, bucketStore.BucketAdd(testBucket4))
+
+	// set new values for existing keys
+	batchedMutation, err = bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, batchedMutation.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	unknownValues := make(map[string]kvstore.Value)
+
+	// there will be old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+		if !found {
+			unknownValues[string(key)] = value
+			return true
+		}
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+
+	// the unknownValues should match the old versions of the keys
+	for _, testEntry := range testEntries1 {
+		value, found := unknownValues[string(testEntry.Key)]
+		require.True(t, found)
+
+		// check if values match the old version
+		require.Equal(t, testEntry.Value, value)
+		delete(unknownValues, string(testEntry.Key))
+	}
+
+	// check if we found all old values
+	require.Equal(t, 0, len(unknownValues))
+
+	// delete the old buckets to remove the old key versions
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 2
+	require.NoError(t, bucketStore.BucketDeleteLast()) // 1
+
+	// reinit the expected results
+	insertedValues = make(map[string]kvstore.Value)
+	for _, testEntry := range testEntries2 {
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+
+	// there should be no old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+
+		// check if no old versions of keys exist
+		require.True(t, found)
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+
+	// add bucket
+	require.NoError(t, bucketStore.BucketAdd(testBucket5))
+
+	// delete the keys
+	batchedMutation, err = bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, batchedMutation.Delete(testEntry.Key))
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	// there should be no keys
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		require.Fail(t, "no keys expected")
+		return true
+	}))
+}
+
+func TestBucketStoreBatchedWithoutOldVersions(t *testing.T) {
+	testBucket1 := getTestStore()
+	testBucket2 := getTestStore()
+	testBucket3 := getTestStore()
+
+	bucketStore, err := New([]kvstore.KVStore{testBucket1, testBucket2}, WithDeleteKeyInOtherBucketsOnSet(true))
+	require.NotNil(t, bucketStore)
+	require.NoError(t, err)
+
+	defer bucketStore.Close()
+
+	insertedValues := make(map[string]kvstore.Value)
+
+	// add the entries to the first two buckets
+	batchedMutation, err := bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries1 {
+		require.NoError(t, batchedMutation.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	// check if they exist
+	for _, testEntry := range testEntries1 {
+		value, err2 := bucketStore.Get(testEntry.Key)
+		require.NoError(t, err2)
+		require.Equal(t, testEntry.Value, value)
+	}
+
+	value, err := bucketStore.Get([]byte("invalid"))
+	require.Equal(t, kvstore.ErrKeyNotFound, err)
+	require.Nil(t, value)
+
+	// add bucket
+	require.NoError(t, bucketStore.BucketAdd(testBucket3))
+
+	// set new values for existing keys
+	batchedMutation, err = bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, batchedMutation.Set(testEntry.Key, testEntry.Value))
+		insertedValues[string(testEntry.Key)] = testEntry.Value
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	// there should be no old versions of the same keys in old buckets
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		valueExpected, found := insertedValues[string(key)]
+
+		// check if no old versions of keys exist
+		require.True(t, found)
+
+		// check if values match the latest version
+		require.Equal(t, valueExpected, value)
+		delete(insertedValues, string(key))
+		return true
+	}))
+
+	// check if we found all inserted values
+	require.Equal(t, 0, len(insertedValues))
+
+	// delete the keys
+	batchedMutation, err = bucketStore.Batched()
+	require.NoError(t, err)
+	for _, testEntry := range testEntries2 {
+		require.NoError(t, batchedMutation.Delete(testEntry.Key))
+	}
+	require.NoError(t, batchedMutation.Commit())
+
+	// there should be no keys
+	require.NoError(t, bucketStore.Iterate(testKeyPrefix, func(key, value kvstore.Value) bool {
+		require.Fail(t, "no keys expected")
+		return true
+	}))
+}

--- a/kvstore/test/config.go
+++ b/kvstore/test/config.go
@@ -4,5 +4,5 @@
 package test
 
 var (
-	dbImplementations = []string{"badger", "mapDB", "pebble"}
+	dbImplementations = []string{"badger", "mapDB", "pebble", "bucket"}
 )

--- a/kvstore/test/kvstore_test.go
+++ b/kvstore/test/kvstore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/kvstore/badger"
+	bucket_store "github.com/iotaledger/hive.go/kvstore/bucket"
 	"github.com/iotaledger/hive.go/kvstore/debug"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/kvstore/pebble"
@@ -56,6 +57,13 @@ func testStore(t require.TestingT, dbImplementation string, realm []byte) (kvsto
 		db, err := rocksdb.CreateDB(dir)
 		require.NoError(t, err, "used db: %s", dbImplementation)
 		return rocksdb.New(db).WithRealm(realm)
+
+	case "bucket":
+		bucket, err := bucket_store.New([]kvstore.KVStore{mapdb.NewMapDB(), mapdb.NewMapDB(), mapdb.NewMapDB()}, bucket_store.WithDeleteKeyInOtherBucketsOnSet(true))
+		if err != nil {
+			panic(err)
+		}
+		return bucket.WithRealm(realm)
 
 	case "debug":
 		return debug.New(mapdb.NewMapDB(), func(command debug.Command, parameters ...[]byte) {


### PR DESCRIPTION
This PR adds a new `KVStore` implementation that consists of `KVStore` buckets.

New buckets can be added and the oldest bucket can be removed.

## Use cases
The `BucketStore` can be used to implement efficient pruning of the tangle database.

## Internal logic of the BucketStore:

### Operations applied to all buckets:
- `Get`
- `Has`
- `Iterate` (in order from latest bucket to oldest bucket)
- `IterateKeys` (in order from latest bucket to oldest bucket)
- `Delete`
- `DeletePrefix`
- `Clear`
- `Close`
- `Flush`

### Operations applied to the latest bucket:
- `Set`

## Important to consider
During a `Set` operation, old versions of existing keys in older buckets are deleted, if `WithDeleteKeyInOtherBucketsOnSet` is set to `true` (default). If this option is set to `false`, there could be multiple versions of the same key. `Get` always returns the latest version. `Iterate` and `IterateKeys` will return the different versions of the keys in order from latest bucket to oldest bucket. Setting this option to `true` may impact the write performance. 