### PR TITLE
Fix: debug.Enabled needs to be accessed atomically

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -8,17 +8,34 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
 
 var (
-	// Enabled contains a flag that determines if the debug mode is active.
-	Enabled = false
+	enabled      = false
+	enabledMutex sync.RWMutex
 
 	// DeadlockDetectionTimeout contains the duration to wait before assuming a deadlock.
 	DeadlockDetectionTimeout = 5 * time.Second
 )
+
+// GetEnabled returns true if the debug mode is active.
+func GetEnabled() bool {
+	enabledMutex.RLock()
+	defer enabledMutex.RUnlock()
+
+	return enabled
+}
+
+// SetEnable sets if the debug mode is active.
+func SetEnabled(newEnabled bool) {
+	enabledMutex.Lock()
+	defer enabledMutex.Unlock()
+
+	enabled = newEnabled
+}
 
 // FunctionName returns the name of the generic function pointer.
 func FunctionName(functionPointer interface{}) string {

--- a/generics/event/event.go
+++ b/generics/event/event.go
@@ -97,7 +97,7 @@ func (e *Event[T]) Trigger(event T) {
 func (e *Event[T]) triggerEventHandlers(event T) {
 	e.eventHandlers.ForEach(func(closureID uint64, callback func(T)) bool {
 		var closureStackTrace string
-		if debug.Enabled {
+		if debug.GetEnabled() {
 			closureStackTrace = debug.ClosureStackTrace(callback)
 		}
 

--- a/syncutils/starvingmutex.go
+++ b/syncutils/starvingmutex.go
@@ -32,7 +32,7 @@ func (f *StarvingMutex) RLock() {
 	defer f.mutex.Unlock()
 
 	var doneChan chan types.Empty
-	if debug.Enabled {
+	if debug.GetEnabled() {
 		doneChan = make(chan types.Empty, 1)
 
 		go f.detectDeadlock("RLock", debug.CallerStackTrace(), doneChan)
@@ -42,7 +42,7 @@ func (f *StarvingMutex) RLock() {
 		f.readerCond.Wait()
 	}
 
-	if debug.Enabled {
+	if debug.GetEnabled() {
 		close(doneChan)
 	}
 
@@ -75,7 +75,7 @@ func (f *StarvingMutex) Lock() {
 	defer f.mutex.Unlock()
 
 	var doneChan chan types.Empty
-	if debug.Enabled {
+	if debug.GetEnabled() {
 		doneChan = make(chan types.Empty, 1)
 
 		go f.detectDeadlock("Lock", debug.CallerStackTrace(), doneChan)
@@ -85,7 +85,7 @@ func (f *StarvingMutex) Lock() {
 	for !f.canWrite() {
 		f.writerCond.Wait()
 	}
-	if debug.Enabled {
+	if debug.GetEnabled() {
 		close(doneChan)
 	}
 	f.pendingWriters--

--- a/syncutils/starvingmutex_test.go
+++ b/syncutils/starvingmutex_test.go
@@ -35,7 +35,7 @@ func Benchmark(b *testing.B) {
 }
 
 func Test(t *testing.T) {
-	debug.Enabled = true
+	debug.SetEnabled(true)
 	debug.DeadlockDetectionTimeout = 100 * time.Millisecond
 
 	mutex := NewStarvingMutex()

--- a/workerpool/blocking_queued_workerpool.go
+++ b/workerpool/blocking_queued_workerpool.go
@@ -243,7 +243,7 @@ type BlockingQueueWorkerPoolTask struct {
 
 // newBlockingQueueWorkerPoolTask creates a new BlockingQueueWorkerPoolTask.
 func newBlockingQueueWorkerPoolTask(workerPool *BlockingQueuedWorkerPool, workerFunc func(), stackTrace string) *BlockingQueueWorkerPoolTask {
-	if debug.Enabled && stackTrace == "" {
+	if debug.GetEnabled() && stackTrace == "" {
 		stackTrace = debug.ClosureStackTrace(workerFunc)
 	}
 
@@ -257,7 +257,7 @@ func newBlockingQueueWorkerPoolTask(workerPool *BlockingQueuedWorkerPool, worker
 
 // run executes the task.
 func (t *BlockingQueueWorkerPoolTask) run() {
-	if debug.Enabled {
+	if debug.GetEnabled() {
 		go t.detectedHangingTasks()
 	}
 

--- a/workerpool/blocking_queued_workerpool_test.go
+++ b/workerpool/blocking_queued_workerpool_test.go
@@ -125,7 +125,7 @@ func Test_NoFlushVsFlush(t *testing.T) {
 }
 
 func Test_DeadlockDetection(t *testing.T) {
-	debug.Enabled = true
+	debug.SetEnabled(true)
 
 	el := NewBlockingQueuedWorkerPool(QueueSize(1000000), FlushTasksAtShutdown(true), WithAlias("event.Loop"))
 	el.Start()


### PR DESCRIPTION
Introduce getter and setter for the global debug.Enabled flag, preventing race conditions.