### PR TITLE
Adds minLen/maxLen serix tags

### DIFF
--- a/serix/serix.go
+++ b/serix/serix.go
@@ -15,7 +15,6 @@ package serix
 
 import (
 	"context"
-	"github.com/iancoleman/orderedmap"
 	"math/big"
 	"reflect"
 	"sort"
@@ -23,6 +22,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/iancoleman/orderedmap"
 
 	"github.com/pkg/errors"
 
@@ -690,6 +691,8 @@ type tagSettings struct {
 	isOptional bool
 	nest       bool
 	omitEmpty  bool
+	minLen     uint64
+	maxLen     uint64
 	ts         TypeSettings
 }
 

--- a/serix/serix_test.go
+++ b/serix/serix_test.go
@@ -389,12 +389,6 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-func must(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
 func TestMinMax(t *testing.T) {
 	type paras struct {
 		api         *serix.API

--- a/serix/serix_test.go
+++ b/serix/serix_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"math/big"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/serializer"
 	"github.com/iotaledger/hive.go/serix"
@@ -386,6 +387,12 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}()
 	os.Exit(exitCode)
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
 }
 
 func TestMinMax(t *testing.T) {


### PR DESCRIPTION
Allows the definition of min/max length for string and byte slice types using `minLen=x` and `maxLen=y` serix struct tag K/Vs.