### PR TITLE
Add UnblockNeighbor to autopeering

### DIFF
--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -162,10 +162,17 @@ func (m *manager) requestPeering(p *peer.Peer, s *salt.Salt) bool {
 	return status
 }
 
-func (m *manager) blockNeighbor(id identity.ID) {
-	if err := m.blocklist.Set(id.EncodeBase58(), nil); err != nil {
-		m.log.Warnw("Failed to set neighbor to blocklist cache", "err", err)
+func (m *manager) blockNeighbor(id identity.ID, ttl ...time.Duration) {
+	if len(ttl) > 0 {
+		if err := m.blocklist.SetWithTTL(id.EncodeBase58(), nil, ttl[0]); err != nil {
+			m.log.Warnw("Failed to set neighbor to blocklist cache", "err", err)
+		}
+	} else {
+		if err := m.blocklist.Set(id.EncodeBase58(), nil); err != nil {
+			m.log.Warnw("Failed to set neighbor to blocklist cache", "err", err)
+		}
 	}
+
 	m.removeNeighbor(id)
 }
 

--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -169,6 +169,18 @@ func (m *manager) blockNeighbor(id identity.ID) {
 	m.removeNeighbor(id)
 }
 
+func (m *manager) unblockNeighbor(id identity.ID) {
+	if err := m.blocklist.Remove(id.EncodeBase58()); err != nil && err != ttlcache.ErrNotFound {
+		m.log.Warnw("Failed to remove neighbor from blocklist cache", "err", err)
+	}
+
+	// we need to remove the neighbor from the skiplist as well,
+	// because they are added to the skiplist at first connection attempt if they were blocked.
+	if err := m.skiplist.Remove(id.EncodeBase58()); err != nil && err != ttlcache.ErrNotFound {
+		m.log.Warnw("Failed to remove neighbor from skiplist cache", "err", err)
+	}
+}
+
 func (m *manager) removeNeighbor(id identity.ID) {
 	m.dropChan <- id
 }

--- a/autopeering/selection/manager.go
+++ b/autopeering/selection/manager.go
@@ -327,7 +327,7 @@ func (m *manager) getOutboundPeeringCandidate() (candidate peer.PeerDistance) {
 	// Filter out blocklisted peers.
 	allowedPeers := make([]*peer.Peer, 0, len(knownPeers))
 	for _, p := range knownPeers {
-		if !m.isInBlocklist(p) {
+		if !m.isInBlocklist(p.ID()) {
 			allowedPeers = append(allowedPeers, p)
 		}
 	}
@@ -345,7 +345,7 @@ func (m *manager) getOutboundPeeringCandidate() (candidate peer.PeerDistance) {
 	// filter out previous rejections
 	filteredList := make([]peer.PeerDistance, 0, len(distList))
 	for _, dist := range distList {
-		if !m.isInSkiplist(dist.Remote) {
+		if !m.isInSkiplist(dist.Remote.ID()) {
 			filteredList = append(filteredList, dist)
 		}
 	}
@@ -367,7 +367,7 @@ func (m *manager) handleInRequest(req peeringRequest) (resp bool) {
 	resp = reject
 	defer func() { req.back <- resp }() // assure that a response is always issued
 
-	if m.isInBlocklist(req.peer) {
+	if m.isInBlocklist(req.peer.ID()) {
 		return
 	}
 
@@ -514,22 +514,22 @@ func (m *manager) triggerPeeringEvent(isOut bool, p *peer.Peer, status bool) {
 	}
 }
 
-func (m *manager) isInBlocklist(p *peer.Peer) bool {
-	if _, err := m.blocklist.Get(p.ID().EncodeBase58()); err != nil {
+func (m *manager) isInBlocklist(id identity.ID) bool {
+	if _, err := m.blocklist.Get(id.EncodeBase58()); err != nil {
 		if !errors.Is(err, ttlcache.ErrNotFound) {
 			m.log.Warnw("Failed to retrieve record for peer from blocklist cache",
-				"peerId", p.ID())
+				"peerId", id)
 		}
 		return false
 	}
 	return true
 }
 
-func (m *manager) isInSkiplist(p *peer.Peer) bool {
-	if _, err := m.skiplist.Get(p.ID().EncodeBase58()); err != nil {
+func (m *manager) isInSkiplist(id identity.ID) bool {
+	if _, err := m.skiplist.Get(id.EncodeBase58()); err != nil {
 		if !errors.Is(err, ttlcache.ErrNotFound) {
 			m.log.Warnw("Failed to retrieve record for peer from skiplist cache",
-				"peerId", p.ID())
+				"peerId", id)
 		}
 		return false
 	}

--- a/autopeering/selection/manager_test.go
+++ b/autopeering/selection/manager_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/autopeering/peer/peertest"
 	"github.com/iotaledger/hive.go/autopeering/salt"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -82,7 +83,8 @@ func TestBlocklistNeighbor(t *testing.T) {
 		blocklistedMgr.updateOutbound(resultCh)
 		result := <-resultCh
 		assert.Nil(t, result.Remote)
-		assert.True(t, blocklistedMgr.isInSkiplist(blocklistingMgr.net.local().Peer))
+		assert.True(t, blocklistingMgr.isInBlocklist(blocklistedMgr.getID()))
+		assert.True(t, blocklistedMgr.isInSkiplist(blocklistingMgr.getID()))
 		got := blocklistedMgr.getOutboundPeeringCandidate()
 		assert.Nil(t, got.Remote)
 	})

--- a/autopeering/selection/manager_test.go
+++ b/autopeering/selection/manager_test.go
@@ -88,6 +88,19 @@ func TestBlocklistNeighbor(t *testing.T) {
 		got := blocklistedMgr.getOutboundPeeringCandidate()
 		assert.Nil(t, got.Remote)
 	})
+	t.Run("Blocklisted manager connects to Blocklisting neighbor after unblocking", func(t *testing.T) {
+		blocklistingMgr.unblockNeighbor(blocklistedMgr.getID())
+		blocklistedMgr.cleanSkiplist()
+		resultCh := make(chan peer.PeerDistance, 1)
+		blocklistedMgr.updateOutbound(resultCh)
+		result := <-resultCh
+		assert.NotNil(t, result.Remote)
+		assert.False(t, blocklistingMgr.isInBlocklist(blocklistingMgr.getID()))
+		assert.False(t, blocklistingMgr.isInSkiplist(blocklistingMgr.getID()))
+		assert.False(t, blocklistedMgr.isInSkiplist(blocklistingMgr.getID()))
+		got := blocklistedMgr.getOutboundPeeringCandidate()
+		assert.NotNil(t, got.Remote)
+	})
 }
 
 func TestEvents(t *testing.T) {

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -128,6 +128,11 @@ func (p *Protocol) BlockNeighbor(id identity.ID) {
 	p.mgr.blockNeighbor(id)
 }
 
+// UnblockNeighbor removes the neighbor from the blocklist to allow future peering.
+func (p *Protocol) UnblockNeighbor(id identity.ID) {
+	p.mgr.unblockNeighbor(id)
+}
+
 // HandleMessage responds to incoming neighbor selection messages.
 func (p *Protocol) HandleMessage(s *server.Server, fromAddr *net.UDPAddr, from *identity.Identity, data []byte) (bool, error) {
 	if !p.running.IsSet() {

--- a/autopeering/selection/protocol.go
+++ b/autopeering/selection/protocol.go
@@ -124,8 +124,8 @@ func (p *Protocol) RemoveNeighbor(id identity.ID) {
 
 // BlockNeighbor does everything the RemoveNeighbor() does,
 // but it also adds the neighbor to the blocklist for certain amount of time to prevent future peering.
-func (p *Protocol) BlockNeighbor(id identity.ID) {
-	p.mgr.blockNeighbor(id)
+func (p *Protocol) BlockNeighbor(id identity.ID, ttl ...time.Duration) {
+	p.mgr.blockNeighbor(id, ttl...)
 }
 
 // UnblockNeighbor removes the neighbor from the blocklist to allow future peering.


### PR DESCRIPTION
This PR adds the possibility to unblock neighbors in the autopeering after they were blocked.