### PR TITLE
Adds map/json de/encoding to serix

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20220808190747-1e4c2b60c887
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/emirpasic/gods v1.18.1
+	github.com/ethereum/go-ethereum v1.10.21
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-version v1.6.0
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/iotaledger/grocksdb v1.7.5-0.20220808142449-1dc0b8ac4d7d
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.1
 	github.com/jellydator/ttlcache/v2 v2.11.1

--- a/core/go.mod
+++ b/core/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/iotaledger/grocksdb v1.7.5-0.20220808142449-1dc0b8ac4d7d
-	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.1
+	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.2
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/knadh/koanf v1.4.2
 	github.com/kr/text v0.2.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -214,6 +214,8 @@ github.com/iotaledger/grocksdb v1.7.5-0.20220808142449-1dc0b8ac4d7d h1:KYc/EkMX3
 github.com/iotaledger/grocksdb v1.7.5-0.20220808142449-1dc0b8ac4d7d/go.mod h1:DuNKJ1G/vKugT7WGAoftMTu2aApNNxF4ADFMxLmKS2Y=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.1 h1:0NwAA/6N8/pUm7IQdd6rjmExfdwNZigYFhE31fOuQrU=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.1/go.mod h1:beZKjVT4HPayWfwsmItNNI5E81rS783vGx5ZwRbZQgY=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.2 h1:3eiiw4JazsOgDcyxT5dA4UhFRHO5NCAWyWwOl8aRa94=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.2/go.mod h1:beZKjVT4HPayWfwsmItNNI5E81rS783vGx5ZwRbZQgY=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/core/go.sum
+++ b/core/go.sum
@@ -94,6 +94,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/ethereum/go-ethereum v1.10.21 h1:5lqsEx92ZaZzRyOqBEXux4/UR06m296RGzN3ol3teJY=
+github.com/ethereum/go-ethereum v1.10.21/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
@@ -205,6 +206,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iotaledger/grocksdb v1.7.5-0.20220808142449-1dc0b8ac4d7d h1:KYc/EkMX3CXvsYyUC9EvToUeYc0c74ZwjRg/0Wd27LU=

--- a/core/serix/decode.go
+++ b/core/serix/decode.go
@@ -127,12 +127,13 @@ func (api *API) decodeBasedOnType(ctx context.Context, b []byte, value reflect.V
 		deseri := serializer.NewDeserializer(b)
 		addrValue := value.Addr()
 		addrValue = addrValue.Convert(reflect.TypeOf((*string)(nil)))
+		minLen, maxLen := ts.MinMaxLen()
 		deseri.ReadString(
 			addrValue.Interface().(*string),
 			serializer.SeriLengthPrefixType(lengthPrefixType),
 			func(err error) error {
 				return errors.Wrap(err, "failed to read string value from the deserializer")
-			})
+			}, minLen, maxLen)
 		return deseri.Done()
 
 	case reflect.Bool:
@@ -149,7 +150,7 @@ func (api *API) decodeBasedOnType(ctx context.Context, b []byte, value reflect.V
 		reflect.Float32, reflect.Float64:
 		deseri := serializer.NewDeserializer(b)
 		addrValue := value.Addr()
-		_, addrTypeToConvert := getNumberTypeToConvert(valueType.Kind())
+		_, _, addrTypeToConvert := getNumberTypeToConvert(valueType.Kind())
 		addrValue = addrValue.Convert(addrTypeToConvert)
 		deseri.ReadNum(addrValue.Interface(), func(err error) error {
 			return errors.Wrap(err, "failed to read number value from the serializer")
@@ -288,12 +289,13 @@ func (api *API) decodeSlice(ctx context.Context, b []byte, value reflect.Value,
 		deseri := serializer.NewDeserializer(b)
 		addrValue := value.Addr()
 		addrValue = addrValue.Convert(reflect.TypeOf((*[]byte)(nil)))
+		minLen, maxLen := ts.MinMaxLen()
 		deseri.ReadVariableByteSlice(
 			addrValue.Interface().(*[]byte),
 			serializer.SeriLengthPrefixType(lengthPrefixType),
 			func(err error) error {
 				return errors.Wrap(err, "failed to read bytes from the deserializer")
-			})
+			}, minLen, maxLen)
 		return deseri.Done()
 	}
 	deserializeItem := func(b []byte) (bytesRead int, err error) {

--- a/core/serix/map_decode.go
+++ b/core/serix/map_decode.go
@@ -26,7 +26,10 @@ func (api *API) mapDecodeBasedOnType(ctx context.Context, mapVal any, value refl
 	switch value.Kind() {
 	case reflect.Ptr:
 		if valueType == bigIntPtrType {
-			bigIntHexStr := mapVal.(string)
+			bigIntHexStr, ok := mapVal.(string)
+			if !ok {
+				return fmt.Errorf("non string value in map when decoding a big.Int, got %T instead", mapVal)
+			}
 			bigInt, err := DecodeUint256(bigIntHexStr)
 			if err != nil {
 				return errors.Wrap(err, "failed to read big.Int from map")

--- a/core/serix/map_decode.go
+++ b/core/serix/map_decode.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pkg/errors"
 )
@@ -94,6 +95,13 @@ func (api *API) mapDecodeBasedOnType(ctx context.Context, mapVal any, value refl
 	case reflect.Interface:
 		return api.mapDecodeInterface(ctx, mapVal, value, valueType, ts, opts)
 	case reflect.String:
+		str, ok := mapVal.(string)
+		if !ok {
+			return fmt.Errorf("non string value for string field")
+		}
+		if !utf8.ValidString(str) {
+			return ErrNonUTF8String
+		}
 		addrValue := value.Addr().Convert(reflect.TypeOf((*string)(nil)))
 		addrValue.Elem().Set(reflect.ValueOf(mapVal))
 		return nil

--- a/core/serix/map_decode.go
+++ b/core/serix/map_decode.go
@@ -2,8 +2,10 @@ package serix
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -226,7 +228,12 @@ func (api *API) mapDecodeInterface(
 func (api *API) mapDecodeStruct(ctx context.Context, mapVal any, value reflect.Value,
 	valueType reflect.Type, ts TypeSettings, opts *options) error {
 	if valueType == timeType {
-		// TODO
+		strVal := mapVal.(string)
+		parsedTime, err := time.Parse(time.RFC3339Nano, strVal)
+		if err != nil {
+			return fmt.Errorf("unable to parse time %s map value: %w", strVal, err)
+		}
+		value.Set(reflect.ValueOf(parsedTime))
 		return nil
 	}
 

--- a/core/serix/map_decode.go
+++ b/core/serix/map_decode.go
@@ -1,0 +1,367 @@
+package serix
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+func (api *API) mapDecode(ctx context.Context, mapVal any, value reflect.Value, ts TypeSettings, opts *options) error {
+	valueType := value.Type()
+	if opts.validation {
+		// TODO: add map validator?
+	}
+
+	if err := api.mapDecodeBasedOnType(ctx, mapVal, value, valueType, ts, opts); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if opts.validation {
+		// TODO: add post map validator?
+	}
+
+	return nil
+}
+
+func (api *API) mapDecodeBasedOnType(ctx context.Context, mapVal any, value reflect.Value,
+	valueType reflect.Type, ts TypeSettings, opts *options) error {
+	globalTS, _ := api.getTypeSettings(valueType)
+	ts = ts.merge(globalTS)
+	switch value.Kind() {
+	case reflect.Ptr:
+		if valueType == bigIntPtrType {
+			bigIntHexStr := mapVal.(string)
+			bigInt, err := DecodeUint256(bigIntHexStr)
+			if err != nil {
+				return errors.Wrap(err, "failed to read big.Int from map")
+			}
+			value.Addr().Elem().Set(reflect.ValueOf(bigInt))
+			return nil
+		}
+
+		elemType := valueType.Elem()
+		if elemType.Kind() == reflect.Struct {
+			if value.IsNil() {
+				value.Set(reflect.New(elemType))
+			}
+			elemValue := value.Elem()
+			return api.mapDecodeStruct(ctx, mapVal, elemValue, elemType, ts, opts)
+		}
+
+		if elemType.Kind() == reflect.Array {
+			if value.IsNil() {
+				value.Set(reflect.New(elemType))
+			}
+			sliceValue := sliceFromArray(value.Elem())
+			sliceValueType := sliceValue.Type()
+			if sliceValueType.AssignableTo(bytesType) {
+				innerTs, ok := api.getTypeSettings(valueType)
+				if !ok {
+					return errors.Errorf("missing type settings for interface %s", valueType)
+				}
+
+				mapKey := mapSliceArrayDefaultKey
+				if innerTs.mapKey != nil {
+					mapKey = *innerTs.mapKey
+				}
+
+				fieldValStr := mapVal.(map[string]any)[mapKey].(string)
+				byteSlice, err := DecodeHex(fieldValStr)
+				if err != nil {
+					return errors.Wrap(err, "failed to read byte slice from map")
+				}
+				copy(sliceValue.Bytes(), byteSlice)
+				fillArrayFromSlice(value.Elem(), sliceValue)
+				return nil
+			}
+			return api.mapDecodeSlice(ctx, mapVal, sliceValue, sliceValueType, ts, opts)
+		}
+
+	case reflect.Struct:
+		return api.mapDecodeStruct(ctx, mapVal, value, valueType, ts, opts)
+	case reflect.Slice:
+		return api.mapDecodeSlice(ctx, mapVal, value, valueType, ts, opts)
+	case reflect.Map:
+		return api.mapDecodeMap(ctx, mapVal, value, valueType, ts, opts)
+	case reflect.Array:
+		sliceValue := sliceFromArray(value)
+		sliceValueType := sliceValue.Type()
+		if sliceValueType.AssignableTo(bytesType) {
+			byteSlice, err := DecodeHex(mapVal.(string))
+			if err != nil {
+				return errors.Wrap(err, "failed to read byte slice from map")
+			}
+			copy(sliceValue.Bytes(), byteSlice)
+			fillArrayFromSlice(value, sliceValue)
+			return nil
+		}
+		return api.mapDecodeSlice(ctx, mapVal, sliceValue, sliceValueType, ts, opts)
+	case reflect.Interface:
+		return api.mapDecodeInterface(ctx, mapVal, value, valueType, ts, opts)
+	case reflect.String:
+		addrValue := value.Addr().Convert(reflect.TypeOf((*string)(nil)))
+		addrValue.Elem().Set(reflect.ValueOf(mapVal))
+		return nil
+	case reflect.Bool:
+		addrValue := value.Addr().Convert(reflect.TypeOf((*bool)(nil)))
+		addrValue.Elem().Set(reflect.ValueOf(mapVal))
+		return nil
+	case reflect.Int8, reflect.Int16, reflect.Int32:
+		return api.mapDecodeNum(value, valueType, float64NumParser(mapVal.(float64), value.Kind(), true))
+	case reflect.Int64:
+		return api.mapDecodeNum(value, valueType, strNumParser(mapVal.(string), 64, true))
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return api.mapDecodeNum(value, valueType, float64NumParser(mapVal.(float64), value.Kind(), false))
+	case reflect.Uint64:
+		return api.mapDecodeNum(value, valueType, strNumParser(mapVal.(string), 64, false))
+	case reflect.Float32:
+		return api.mapDecodeFloat(value, valueType, mapVal, 32)
+	case reflect.Float64:
+		return api.mapDecodeFloat(value, valueType, mapVal, 64)
+	default:
+	}
+	return errors.Errorf("can't map decode: unsupported type %s", valueType)
+}
+
+// num parse func returns a num or an error.
+type numParseFunc func() (any, error)
+
+func float64NumParser(v float64, ty reflect.Kind, signed bool) numParseFunc {
+	return func() (any, error) {
+		if signed {
+			switch ty {
+			case reflect.Int8:
+				return int8(v), nil
+			case reflect.Int16:
+				return int16(v), nil
+			case reflect.Int32:
+				return int32(v), nil
+			default:
+				return nil, errors.Errorf("can not map decode kind %s to signed integer", ty)
+			}
+		}
+		switch ty {
+		case reflect.Uint8:
+			return uint8(v), nil
+		case reflect.Uint16:
+			return uint16(v), nil
+		case reflect.Uint32:
+			return uint32(v), nil
+		default:
+			return nil, errors.Errorf("can not map decode kind %s to unsigned integer", ty)
+		}
+	}
+}
+
+func strNumParser(str string, bitSize int, signed bool) numParseFunc {
+	return func() (any, error) {
+		if signed {
+			return strconv.ParseInt(str, 10, bitSize)
+		}
+		return strconv.ParseUint(str, 10, bitSize)
+	}
+}
+
+func (api *API) mapDecodeNum(value reflect.Value, valueType reflect.Type, parser numParseFunc) error {
+	addrValue := value.Addr()
+	_, _, addrTypeToConvert := getNumberTypeToConvert(valueType.Kind())
+	addrValue = addrValue.Convert(addrTypeToConvert)
+
+	num, err := parser()
+	if err != nil {
+		return err
+	}
+
+	addrValue.Elem().Set(reflect.ValueOf(num))
+	return nil
+}
+
+func (api *API) mapDecodeFloat(value reflect.Value, valueType reflect.Type, mapVal any, bitSize int) error {
+	addrValue := value.Addr()
+	bitSize, _, addrTypeToConvert := getNumberTypeToConvert(valueType.Kind())
+	addrValue = addrValue.Convert(addrTypeToConvert)
+
+	f, err := strconv.ParseFloat(mapVal.(string), bitSize)
+	if err != nil {
+		return err
+	}
+	addrValue.Elem().SetFloat(f)
+	return nil
+}
+
+func (api *API) mapDecodeInterface(
+	ctx context.Context, mapVal any, value reflect.Value, valueType reflect.Type, ts TypeSettings, opts *options,
+) error {
+	iObjects := api.getInterfaceObjects(valueType)
+	if iObjects == nil {
+		return errors.Errorf("interface %s hasn't been registered", valueType)
+	}
+
+	m, ok := mapVal.(map[string]any)
+	if !ok {
+		return errors.Errorf("non map[string]any in struct map decode, got %T instead", mapVal)
+	}
+
+	objectCodeAny, has := m[mapTypeKeyName]
+	if !has {
+		return errors.Errorf("no object type defined in map for interface %s", valueType)
+	}
+	objectCode := uint32(objectCodeAny.(float64))
+
+	objectType := iObjects.fromCodeToType[objectCode]
+	if objectType == nil {
+		return errors.Errorf("no object type with code %d was found for interface %s", objectCode, valueType)
+	}
+
+	objectValue := reflect.New(objectType).Elem()
+	if err := api.mapDecode(ctx, m, objectValue, ts, opts); err != nil {
+		return errors.WithStack(err)
+	}
+	value.Set(objectValue)
+	return nil
+}
+
+func (api *API) mapDecodeStruct(ctx context.Context, mapVal any, value reflect.Value,
+	valueType reflect.Type, ts TypeSettings, opts *options) error {
+	if valueType == timeType {
+		// TODO
+		return nil
+	}
+
+	m, ok := mapVal.(map[string]any)
+	if !ok {
+		return errors.Errorf("non map[string]any in struct map decode, got %T instead", mapVal)
+	}
+
+	if objectType := ts.ObjectType(); objectType != nil {
+		_, objectCode, err := getTypeDenotationAndCode(objectType)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		mapObjectCode, has := m[mapTypeKeyName]
+		if !has {
+			return errors.Wrap(err, "missing type key in struct")
+		}
+		if uint32(mapObjectCode.(float64)) != objectCode {
+			return errors.Errorf("map type key (%d) not equal registered object code (%d)", mapObjectCode, objectCode)
+		}
+	}
+
+	if err := api.mapDecodeStructFields(ctx, m, value, valueType, opts); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (api *API) mapDecodeStructFields(
+	ctx context.Context, m map[string]any, structVal reflect.Value, valueType reflect.Type, opts *options,
+) error {
+	structFields, err := parseStructType(valueType)
+	if err != nil {
+		return errors.Wrapf(err, "can't parse struct type %s", valueType)
+	}
+	if len(structFields) == 0 {
+		return nil
+	}
+
+	for _, sField := range structFields {
+		fieldValue := structVal.Field(sField.index)
+		if sField.isEmbeddedStruct && !sField.settings.nest {
+			fieldType := sField.fType
+			if fieldType.Kind() == reflect.Ptr {
+				// TODO: how can an embedded struct be of kind pointer?
+				if fieldValue.IsNil() {
+					if sField.isUnexported {
+						return errors.Errorf(
+							"embedded field %s is a nil pointer, can't initialize because it's unexported",
+							sField.name,
+						)
+					}
+					fieldValue.Set(reflect.New(fieldType.Elem()))
+				}
+				fieldValue = fieldValue.Elem()
+				fieldType = fieldType.Elem()
+			}
+			if err := api.mapDecodeStructFields(ctx, m, fieldValue, fieldType, opts); err != nil {
+				return errors.Wrapf(err, "can't deserialize embedded struct %s", sField.name)
+			}
+			continue
+		}
+
+		key := mapStringKey(sField.name)
+		if sField.settings.ts.mapKey != nil {
+			key = sField.settings.ts.MustMapKey()
+		}
+
+		mapVal, has := m[key]
+		if !has {
+			if sField.settings.isOptional || sField.settings.omitEmpty {
+				continue
+			}
+			return errors.Wrapf(err, "missing map entry for field %s", sField.name)
+		}
+
+		if err := api.mapDecode(ctx, mapVal, fieldValue, sField.settings.ts, opts); err != nil {
+			return errors.Wrapf(err, "failed to deserialize struct field %s", sField.name)
+		}
+	}
+	return nil
+}
+
+func (api *API) mapDecodeSlice(ctx context.Context, mapVal any, value reflect.Value,
+	valueType reflect.Type, ts TypeSettings, opts *options) error {
+	if valueType.AssignableTo(bytesType) {
+		fieldValStr := mapVal.(string)
+		byteSlice, err := DecodeHex(fieldValStr)
+		if err != nil {
+			return errors.Wrap(err, "failed to read byte slice from map")
+		}
+
+		addrValue := value.Addr().Convert(reflect.TypeOf((*[]byte)(nil)))
+		addrValue.Elem().SetBytes(byteSlice)
+		return nil
+	}
+
+	refVal := reflect.ValueOf(mapVal)
+	for i := 0; i < refVal.Len(); i++ {
+		elemValue := reflect.New(valueType.Elem()).Elem()
+		if err := api.mapDecode(ctx, refVal.Index(i).Interface(), elemValue, TypeSettings{}, opts); err != nil {
+			return errors.WithStack(err)
+		}
+		value.Set(reflect.Append(value, elemValue))
+	}
+
+	return nil
+}
+
+func (api *API) mapDecodeMap(ctx context.Context, mapVal any, value reflect.Value,
+	valueType reflect.Type, ts TypeSettings, opts *options) error {
+	m, ok := mapVal.(map[string]any)
+	if !ok {
+		return errors.Errorf("non map[string]any in struct map decode, got %T instead", mapVal)
+	}
+
+	if value.IsNil() {
+		value.Set(reflect.MakeMap(valueType))
+	}
+
+	for k, v := range m {
+		key := reflect.New(valueType.Key()).Elem()
+		val := reflect.New(valueType.Elem()).Elem()
+
+		if err := api.mapDecode(ctx, k, key, TypeSettings{}, opts); err != nil {
+			return errors.Wrapf(err, "failed to map decode map key of type %s", key.Type())
+		}
+
+		if err := api.mapDecode(ctx, v, val, TypeSettings{}, opts); err != nil {
+			return errors.Wrapf(err, "failed to map decode map element of type %s", val.Type())
+		}
+
+		value.SetMapIndex(key, val)
+	}
+
+	return nil
+}

--- a/core/serix/map_decode.go
+++ b/core/serix/map_decode.go
@@ -11,17 +11,8 @@ import (
 )
 
 func (api *API) mapDecode(ctx context.Context, mapVal any, value reflect.Value, ts TypeSettings, opts *options) error {
-	valueType := value.Type()
-	if opts.validation {
-		// TODO: add map validator?
-	}
-
-	if err := api.mapDecodeBasedOnType(ctx, mapVal, value, valueType, ts, opts); err != nil {
+	if err := api.mapDecodeBasedOnType(ctx, mapVal, value, value.Type(), ts, opts); err != nil {
 		return errors.WithStack(err)
-	}
-
-	if opts.validation {
-		// TODO: add post map validator?
 	}
 
 	return nil
@@ -279,7 +270,6 @@ func (api *API) mapDecodeStructFields(
 		if sField.isEmbeddedStruct && !sField.settings.nest {
 			fieldType := sField.fType
 			if fieldType.Kind() == reflect.Ptr {
-				// TODO: how can an embedded struct be of kind pointer?
 				if fieldValue.IsNil() {
 					if sField.isUnexported {
 						return errors.Errorf(

--- a/core/serix/map_encode.go
+++ b/core/serix/map_encode.go
@@ -1,0 +1,248 @@
+package serix
+
+import (
+	"context"
+	"github.com/iancoleman/orderedmap"
+	"github.com/pkg/errors"
+	"math/big"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+const (
+	// the map key under which the object code is written.
+	mapTypeKeyName = "type"
+	// key used when no map key is defined for types which are slice/arrays of bytes.
+	mapSliceArrayDefaultKey = "data"
+)
+
+func (api *API) mapEncode(ctx context.Context, value reflect.Value, ts TypeSettings, opts *options) (any, error) {
+	valueI := value.Interface()
+	valueType := value.Type()
+	if opts.validation {
+		if err := api.callSyntacticValidator(ctx, value, valueType); err != nil {
+			return nil, errors.Wrap(err, "pre-serialization validation failed")
+		}
+	}
+
+	ele, err := api.mapEncodeBasedOnType(ctx, value, valueI, valueType, ts, opts)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return ele, nil
+}
+
+func (api *API) mapEncodeBasedOnType(
+	ctx context.Context, value reflect.Value, valueI interface{}, valueType reflect.Type, ts TypeSettings, opts *options,
+) (any, error) {
+	globalTS, _ := api.getTypeSettings(valueType)
+	ts = ts.merge(globalTS)
+	switch value.Kind() {
+	case reflect.Ptr:
+		if valueBigInt, ok := valueI.(*big.Int); ok {
+			return EncodeUint256(valueBigInt), nil
+		}
+
+		elemValue := reflect.Indirect(value)
+		if !elemValue.IsValid() {
+			return nil, errors.Errorf("unexpected nil pointer for type %T", valueI)
+		}
+		if elemValue.Kind() == reflect.Struct {
+			return api.mapEncodeStruct(ctx, elemValue, elemValue.Interface(), elemValue.Type(), ts, opts)
+		}
+		if elemValue.Kind() == reflect.Array {
+			sliceValue := sliceFromArray(elemValue)
+			sliceValueType := sliceValue.Type()
+
+			ts, _ = api.getTypeSettings(valueType)
+			return api.mapEncodeSlice(ctx, sliceValue, sliceValueType, ts, opts)
+		}
+
+	case reflect.Struct:
+		return api.mapEncodeStruct(ctx, value, valueI, valueType, ts, opts)
+	case reflect.Slice:
+		return api.mapEncodeSlice(ctx, value, valueType, ts, opts)
+	case reflect.Map:
+		return api.mapEncodeMap(ctx, value, valueType, ts, opts)
+	case reflect.Array:
+		sliceValue := sliceFromArray(value)
+		sliceValueType := sliceValue.Type()
+		return api.mapEncodeSlice(ctx, sliceValue, sliceValueType, ts, opts)
+	case reflect.Interface:
+		return api.mapEncodeInterface(ctx, value, valueType, ts, opts)
+	case reflect.String:
+		return value.String(), nil
+	case reflect.Bool:
+		return value.Bool(), nil
+	case reflect.Int8, reflect.Int16, reflect.Int32:
+		return value.Int(), nil
+	case reflect.Int64:
+		return strconv.FormatInt(value.Int(), 10), nil
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return value.Uint(), nil
+	case reflect.Uint64:
+		return strconv.FormatUint(value.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(value.Float(), 'E', -1, 64), nil
+	default:
+	}
+	return nil, errors.Errorf("can't encode: unsupported type %T", valueI)
+}
+
+func (api *API) mapEncodeInterface(
+	ctx context.Context, value reflect.Value, valueType reflect.Type, ts TypeSettings, opts *options,
+) (any, error) {
+	elemValue := value.Elem()
+	if !elemValue.IsValid() {
+		return nil, errors.Errorf("can't serialize interface %s it must have underlying value", valueType)
+	}
+
+	registry := api.getInterfaceObjects(valueType)
+	if registry == nil {
+		return nil, errors.Errorf("interface %s isn't registered", valueType)
+	}
+
+	elemType := elemValue.Type()
+	if _, exists := registry.fromTypeToCode[elemType]; !exists {
+		return nil, errors.Errorf("underlying type %s hasn't been registered for interface type %s",
+			elemType, valueType)
+	}
+
+	elemTypeSettings, _ := api.getTypeSettings(elemType)
+
+	ele, err := api.mapEncode(ctx, elemValue, elemTypeSettings, opts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to encode interface element %s", elemType)
+	}
+	return ele, nil
+}
+
+func (api *API) mapEncodeStruct(
+	ctx context.Context, value reflect.Value, valueI interface{}, valueType reflect.Type, ts TypeSettings, opts *options,
+) (any, error) {
+	if valueTime, ok := valueI.(time.Time); ok {
+		return valueTime.String(), nil
+	}
+
+	obj := orderedmap.New()
+	if ts.ObjectType() != nil {
+		obj.Set(mapTypeKeyName, ts.ObjectType())
+	}
+	if err := api.mapEncodeStructFields(ctx, obj, value, valueType, opts); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return obj, nil
+}
+
+func (api *API) mapEncodeStructFields(
+	ctx context.Context, obj *orderedmap.OrderedMap, value reflect.Value, valueType reflect.Type, opts *options,
+) error {
+	structFields, err := parseStructType(valueType)
+	if err != nil {
+		return errors.Wrapf(err, "can't parse struct type %s", valueType)
+	}
+
+	for _, sField := range structFields {
+		fieldValue := value.Field(sField.index)
+		if sField.isEmbeddedStruct && !sField.settings.nest {
+			fieldType := sField.fType
+			if fieldValue.Kind() == reflect.Ptr {
+				if fieldValue.IsNil() {
+					continue
+				}
+				fieldValue = fieldValue.Elem()
+				fieldType = fieldType.Elem()
+			}
+			if err := api.mapEncodeStructFields(ctx, obj, fieldValue, fieldType, opts); err != nil {
+				return errors.Wrapf(err, "can't serialize embedded struct %s", sField.name)
+			}
+			continue
+		}
+
+		if sField.settings.omitEmpty && fieldValue.IsZero() {
+			continue
+		}
+
+		var eleOut any
+		if sField.settings.isOptional {
+			if fieldValue.IsNil() {
+				continue
+			}
+		}
+
+		eleOut, err = api.mapEncode(ctx, fieldValue, sField.settings.ts, opts)
+		if err != nil {
+			return errors.Wrapf(err, "failed to serialize optional struct field %s", sField.name)
+		}
+
+		switch {
+		case sField.settings.ts.mapKey != nil:
+			obj.Set(*sField.settings.ts.mapKey, eleOut)
+		default:
+			obj.Set(mapStringKey(sField.name), eleOut)
+		}
+	}
+	return nil
+}
+
+func (api *API) mapEncodeSlice(ctx context.Context, value reflect.Value, valueType reflect.Type,
+	ts TypeSettings, opts *options) (any, error) {
+
+	if ts.ObjectType() != nil {
+		m := orderedmap.New()
+		m.Set(mapTypeKeyName, ts.ObjectType())
+		mapKey := mapSliceArrayDefaultKey
+		if ts.mapKey != nil {
+			mapKey = *ts.mapKey
+		}
+		m.Set(mapKey, EncodeHex(value.Bytes()))
+		return m, nil
+	}
+
+	if valueType.AssignableTo(bytesType) {
+		return EncodeHex(value.Bytes()), nil
+	}
+
+	sliceLen := value.Len()
+	data := make([]any, sliceLen)
+	for i := 0; i < sliceLen; i++ {
+		elemValue := value.Index(i)
+		elem, err := api.mapEncode(ctx, elemValue, TypeSettings{}, opts)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to encode element with index %d of slice %s", i, valueType)
+		}
+		data[i] = elem
+	}
+	return data, nil
+}
+
+func (api *API) mapEncodeMap(ctx context.Context, value reflect.Value, valueType reflect.Type,
+	ts TypeSettings, opts *options) (*orderedmap.OrderedMap, error) {
+	m := orderedmap.New()
+	iter := value.MapRange()
+	for i := 0; iter.Next(); i++ {
+		key := iter.Key()
+		elem := iter.Value()
+		k, v, err := api.mapEncodeMapKVPair(ctx, key, elem, opts)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		m.Set(k, v)
+	}
+
+	return m, nil
+}
+
+func (api *API) mapEncodeMapKVPair(ctx context.Context, key, val reflect.Value, opts *options) (string, any, error) {
+	k, err := api.mapEncode(ctx, key, TypeSettings{}, opts)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "failed to encode map key of type %s", key.Type())
+	}
+	v, err := api.mapEncode(ctx, val, TypeSettings{}, opts)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "failed to encode map element of type %s", val.Type())
+	}
+	return k.(string), v, nil
+}

--- a/core/serix/map_encode.go
+++ b/core/serix/map_encode.go
@@ -2,12 +2,13 @@ package serix
 
 import (
 	"context"
-	"github.com/iancoleman/orderedmap"
-	"github.com/pkg/errors"
 	"math/big"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/iancoleman/orderedmap"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -123,7 +124,7 @@ func (api *API) mapEncodeStruct(
 	ctx context.Context, value reflect.Value, valueI interface{}, valueType reflect.Type, ts TypeSettings, opts *options,
 ) (any, error) {
 	if valueTime, ok := valueI.(time.Time); ok {
-		return valueTime.String(), nil
+		return valueTime.Format(time.RFC3339Nano), nil
 	}
 
 	obj := orderedmap.New()

--- a/core/serix/map_encode_test.go
+++ b/core/serix/map_encode_test.go
@@ -1,0 +1,352 @@
+package serix_test
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/iancoleman/orderedmap"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/core/serix"
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestMapEncodeDecode(t *testing.T) {
+	type paras struct {
+		api *serix.API
+		in  any
+	}
+
+	type test struct {
+		name     string
+		paras    paras
+		expected string
+	}
+
+	tests := []test{
+		{
+			name: "basic types",
+			paras: func() paras {
+				type example struct {
+					Uint64    uint64  `serix:"0,mapKey=uint64"`
+					Uint32    uint32  `serix:"1,mapKey=uint32"`
+					Uint16    uint16  `serix:"2,mapKey=uint16"`
+					Uint8     uint8   `serix:"3,mapKey=uint8"`
+					Int64     int64   `serix:"4,mapKey=int64"`
+					Int32     int32   `serix:"5,mapKey=int32"`
+					Int16     int16   `serix:"6,mapKey=int16"`
+					Int8      int8    `serix:"7,mapKey=int8"`
+					ZeroInt32 int32   `serix:"8,mapKey=zeroInt32,omitempty"`
+					Float32   float32 `serix:"9,mapKey=float32"`
+					Float64   float64 `serix:"10,mapKey=float64"`
+					String    string  `serix:"11,mapKey=string"`
+					Bool      bool    `serix:"12,mapKey=bool"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(42))))
+
+				return paras{
+					api: api,
+					in: &example{
+						Uint64:    64,
+						Uint32:    32,
+						Uint16:    16,
+						Uint8:     8,
+						Int64:     -64,
+						Int32:     -32,
+						Int16:     -16,
+						Int8:      -8,
+						ZeroInt32: 0,
+						Float32:   0.33,
+						Float64:   0.44,
+						String:    "abcd",
+						Bool:      true,
+					},
+				}
+			}(),
+			expected: `{
+				"type": 42,
+				"uint64": "64",
+				"uint32": 32,
+				"uint16": 16,
+				"uint8": 8,
+				"int64": "-64",
+				"int32": -32,
+				"int16": -16,
+				"int8": -8,
+				"float32": "3.3000001311302185E-01",
+				"float64": "4.4E-01",
+				"string": "abcd",
+				"bool": true
+			}`,
+		},
+		{
+			name: "big int",
+			paras: func() paras {
+				type example struct {
+					BigInt *big.Int `serix:"0,mapKey=bigInt"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(66))))
+
+				return paras{
+					api: api,
+					in: &example{
+						BigInt: big.NewInt(1337),
+					},
+				}
+			}(),
+			expected: `{
+				"type": 66,
+ 				"bigInt": "0x539"
+			}`,
+		},
+		{
+			name: "map",
+			paras: func() paras {
+				type example struct {
+					Map map[string]string `serix:"0,mapKey=map"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(99))))
+
+				return paras{
+					api: api,
+					in: &example{
+						Map: map[string]string{
+							"alice": "123",
+						},
+					},
+				}
+			}(),
+			expected: `{
+				"type": 99,
+ 				"map": {
+					"alice": "123"
+				}
+			}`,
+		},
+		{
+			name: "byte slices/arrays",
+			paras: func() paras {
+
+				type example struct {
+					ByteSlice         []byte    `serix:"0,mapKey=byteSlice"`
+					Array             [5]byte   `serix:"1,mapKey=array"`
+					SliceOfByteSlices [][]byte  `serix:"3,mapKey=sliceOfByteSlices"`
+					SliceOfByteArrays [][3]byte `serix:"4,mapKey=sliceOfByteArrays"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(5))))
+
+				return paras{
+					api: api,
+					in: &example{
+						ByteSlice: []byte{1, 2, 3, 4, 5},
+						Array:     [5]byte{5, 4, 3, 2, 1},
+						SliceOfByteSlices: [][]byte{
+							{1, 2, 3},
+							{3, 2, 1},
+						},
+						SliceOfByteArrays: [][3]byte{
+							{5, 6, 7},
+							{7, 6, 5},
+						},
+					},
+				}
+			}(),
+			expected: `{
+				"type": 5,
+ 				"byteSlice": "0x0102030405",
+				"array": "0x0504030201",
+				"sliceOfByteSlices": [
+					"0x010203",
+					"0x030201"
+				],
+				"sliceOfByteArrays": [
+					"0x050607",
+					"0x070605"
+				]
+			}`,
+		},
+		{
+			name: "inner struct",
+			paras: func() paras {
+				type (
+					inner struct {
+						String string `serix:"0,mapKey=string"`
+					}
+
+					example struct {
+						inner `serix:"0"`
+					}
+				)
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(22))))
+
+				return paras{
+					api: api,
+					in: &example{
+						inner{String: "abcd"},
+					},
+				}
+			}(),
+			expected: `{
+				"type": 22,
+ 				"string": "abcd"
+			}`,
+		},
+		{
+			name: "interface & direct pointer",
+			paras: func() paras {
+				type (
+					InterfaceType      interface{}
+					InterfaceTypeImpl1 [4]byte
+					OtherObj           [2]byte
+
+					example struct {
+						Interface InterfaceType `serix:"0,mapKey=interface"`
+						Other     *OtherObj     `serix:"1,mapKey=other"`
+					}
+				)
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(33))))
+				must(api.RegisterTypeSettings(InterfaceTypeImpl1{},
+					serix.TypeSettings{}.WithObjectType(uint8(5)).WithMapKey("customInnerKey")),
+				)
+				must(api.RegisterInterfaceObjects((*InterfaceType)(nil), (*InterfaceTypeImpl1)(nil)))
+				must(api.RegisterTypeSettings(OtherObj{},
+					serix.TypeSettings{}.WithObjectType(uint8(2)).WithMapKey("otherObjKey")),
+				)
+
+				return paras{
+					api: api,
+					in: &example{
+						Interface: &InterfaceTypeImpl1{1, 2, 3, 4},
+						Other:     &OtherObj{1, 2},
+					},
+				}
+			}(),
+			expected: `{
+				"type": 33,
+ 				"interface": {
+					"type": 5,
+					"customInnerKey": "0x01020304"
+				},
+				"other": {
+					"type": 2,
+					"otherObjKey": "0x0102"
+				}
+			}`,
+		},
+		{
+			name: "slice of interface",
+			paras: func() paras {
+				type (
+					Interface interface{}
+					Impl1     struct {
+						String string `serix:"0,mapKey=string"`
+					}
+					Impl2 struct {
+						Uint16 uint16 `serix:"0,mapKey=uint16"`
+					}
+
+					example struct {
+						Slice []Interface `serix:"0,mapKey=slice"`
+					}
+				)
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(11))))
+				must(api.RegisterTypeSettings(Impl1{}, serix.TypeSettings{}.WithObjectType(uint8(0))))
+				must(api.RegisterTypeSettings(Impl2{}, serix.TypeSettings{}.WithObjectType(uint8(1))))
+				must(api.RegisterInterfaceObjects((*Interface)(nil), (*Impl1)(nil), (*Impl2)(nil)))
+
+				return paras{
+					api: api,
+					in: &example{
+						Slice: []Interface{
+							&Impl1{String: "impl1"},
+							&Impl2{Uint16: 1337},
+						},
+					},
+				}
+			}(),
+			expected: `{
+				"type": 11,
+ 				"slice": [
+					{
+						"type": 0,
+						"string": "impl1"
+					},
+					{
+						"type": 1,
+						"uint16": 1337
+					}
+				]
+			}`,
+		},
+		{
+			name: "no map key",
+			paras: func() paras {
+				type example struct {
+					CaptainHook string `serix:"0"`
+					LiquidSoul  int64  `serix:"1"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(23))))
+
+				return paras{
+					api: api,
+					in: &example{
+						CaptainHook: "jump",
+						LiquidSoul:  30,
+					},
+				}
+			}(),
+			expected: `{
+				"type": 23,
+ 				"captainHook": "jump",
+				"liquidSoul": "30"
+			}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// encode input to a map
+			out, err := test.paras.api.MapEncode(context.Background(), test.paras.in, serix.WithValidation())
+			require.NoError(t, err)
+			jsonOut, err := json.MarshalIndent(out, "", "\t")
+			require.NoError(t, err)
+
+			// re-arrange expected json output to conform to same indentation
+			aux := orderedmap.New()
+			require.NoError(t, json.Unmarshal([]byte(test.expected), aux))
+			expectedJson, err := json.MarshalIndent(aux, "", "\t")
+			require.NoError(t, err)
+			require.EqualValues(t, string(expectedJson), string(jsonOut))
+
+			mapTarget := map[string]any{}
+			require.NoError(t, json.Unmarshal(expectedJson, &mapTarget))
+
+			dest := reflect.New(reflect.TypeOf(test.paras.in).Elem()).Interface()
+			require.NoError(t, test.paras.api.MapDecode(context.Background(), mapTarget, dest))
+			require.EqualValues(t, test.paras.in, dest)
+		})
+	}
+}

--- a/core/serix/map_encode_test.go
+++ b/core/serix/map_encode_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/iancoleman/orderedmap"
 	"github.com/stretchr/testify/require"
@@ -323,6 +324,31 @@ func TestMapEncodeDecode(t *testing.T) {
 				"type": 23,
  				"captainHook": "jump",
 				"liquidSoul": "30"
+			}`,
+		},
+		{
+			name: "time",
+			paras: func() paras {
+				type example struct {
+					CreationDate time.Time `serix:"0"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(23))))
+
+				exampleTime, err := time.Parse(time.RFC3339Nano, "2022-08-12T12:51:18.120072+02:00")
+				require.NoError(t, err)
+
+				return paras{
+					api: api,
+					in: &example{
+						CreationDate: exampleTime,
+					},
+				}
+			}(),
+			expected: `{
+				"type": 23,
+ 				"creationDate": "2022-08-12T12:51:18.120072+02:00"
 			}`,
 		},
 	}

--- a/core/serix/numbers.go
+++ b/core/serix/numbers.go
@@ -1,0 +1,48 @@
+package serix
+
+import (
+	"math/big"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// EncodeHex encodes the bytes string to a hex string. It always adds the 0x prefix if bytes are not empty.
+func EncodeHex(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return hexutil.Encode(b)
+}
+
+// DecodeHex decodes the given hex string to bytes. It expects the 0x prefix.
+func DecodeHex(s string) ([]byte, error) {
+	b, err := hexutil.Decode(s)
+	if err != nil {
+		if err == hexutil.ErrEmptyString {
+			return []byte{}, nil
+		}
+		return nil, err
+	}
+	return b, nil
+}
+
+// EncodeUint256 encodes the uint256 to a little-endian encoded hex string.
+func EncodeUint256(n *big.Int) string {
+	return hexutil.EncodeBig(n)
+}
+
+// DecodeUint256 decodes the little-endian hex encoded string to an uint256.
+func DecodeUint256(s string) (*big.Int, error) {
+	return hexutil.DecodeBig(s)
+}
+
+// EncodeUint64 encodes the uint64 to a base 10 string.
+func EncodeUint64(n uint64) string {
+	return strconv.FormatUint(n, 10)
+}
+
+// DecodeUint64 decodes the base 10 string to an uint64.
+func DecodeUint64(s string) (uint64, error) {
+	return strconv.ParseUint(s, 10, 64)
+}

--- a/core/serix/serix.go
+++ b/core/serix/serix.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iancoleman/orderedmap"
 	"github.com/pkg/errors"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
@@ -151,6 +152,9 @@ type TypeSettings struct {
 	lengthPrefixType *LengthPrefixType
 	objectType       interface{}
 	lexicalOrdering  *bool
+	mapKey           *string
+	minLen           *uint64
+	maxLen           *uint64
 	arrayRules       *ArrayRules
 }
 
@@ -166,6 +170,69 @@ func (ts TypeSettings) LengthPrefixType() (LengthPrefixType, bool) {
 		return 0, false
 	}
 	return *ts.lengthPrefixType, true
+}
+
+// WithMapKey specifies the name for the map key.
+func (ts TypeSettings) WithMapKey(name string) TypeSettings {
+	ts.mapKey = &name
+	return ts
+}
+
+// MapKey returns the map key name.
+func (ts TypeSettings) MapKey() (string, bool) {
+	if ts.mapKey == nil {
+		return "", false
+	}
+	return *ts.mapKey, true
+}
+
+// MustMapKey must return a map key name.
+func (ts TypeSettings) MustMapKey() string {
+	if ts.mapKey == nil {
+		panic("no map key set")
+	}
+	return *ts.mapKey
+}
+
+// WithMinLen specifies the min length for the object.
+func (ts TypeSettings) WithMinLen(l uint64) TypeSettings {
+	ts.minLen = &l
+	return ts
+}
+
+// MinLen returns min length for the object.
+func (ts TypeSettings) MinLen() (uint64, bool) {
+	if ts.minLen == nil {
+		return 0, false
+	}
+	return *ts.minLen, true
+}
+
+// WithMaxLen specifies the max length for the object.
+func (ts TypeSettings) WithMaxLen(l uint64) TypeSettings {
+	ts.maxLen = &l
+	return ts
+}
+
+// MaxLen returns max length for the object.
+func (ts TypeSettings) MaxLen() (uint64, bool) {
+	if ts.maxLen == nil {
+		return 0, false
+	}
+	return *ts.maxLen, true
+}
+
+// MinMaxLen returns min/max lengths for the object.
+// Returns 0 for either value if they are not set.
+func (ts TypeSettings) MinMaxLen() (int, int) {
+	var min, max int
+	if ts.minLen != nil {
+		min = int(*ts.minLen)
+	}
+	if ts.maxLen != nil {
+		max = int(*ts.maxLen)
+	}
+	return min, max
 }
 
 // WithObjectType specifies the object type. It can be either uint8 or uint32 number.
@@ -231,6 +298,9 @@ func (ts TypeSettings) merge(other TypeSettings) TypeSettings {
 	if ts.arrayRules == nil {
 		ts.arrayRules = other.arrayRules
 	}
+	if ts.mapKey == nil {
+		ts.mapKey = other.mapKey
+	}
 	return ts
 }
 
@@ -261,6 +331,22 @@ func (api *API) Encode(ctx context.Context, obj interface{}, opts ...Option) ([]
 	return api.encode(ctx, value, opt.ts, opt)
 }
 
+func (api *API) MapEncode(ctx context.Context, obj interface{}, opts ...Option) (*orderedmap.OrderedMap, error) {
+	value := reflect.ValueOf(obj)
+	if !value.IsValid() {
+		return nil, errors.New("invalid value for destination")
+	}
+	opt := &options{}
+	for _, o := range opts {
+		o(opt)
+	}
+	m, err := api.mapEncode(ctx, value, opt.ts, opt)
+	if err != nil {
+		return nil, err
+	}
+	return m.(*orderedmap.OrderedMap), nil
+}
+
 // Decode deserializes bytes b into the provided object obj.
 // obj must be a non-nil pointer for serix to deserialize into it.
 // serix traverses the object recursively and deserializes everything based on its type.
@@ -286,6 +372,33 @@ func (api *API) Decode(ctx context.Context, b []byte, obj interface{}, opts ...O
 		o(opt)
 	}
 	return api.decode(ctx, b, value, opt.ts, opt)
+}
+
+func (api *API) MapDecode(ctx context.Context, m map[string]any, obj interface{}, opts ...Option) error {
+	value := reflect.ValueOf(obj)
+	if err := checkDecodeDestination(obj, value); err != nil {
+		return err
+	}
+	opt := &options{}
+	for _, o := range opts {
+		o(opt)
+	}
+	return api.mapDecode(ctx, m, value, opt.ts, opt)
+}
+
+func checkDecodeDestination(obj any, value reflect.Value) error {
+	if !value.IsValid() {
+		return errors.New("invalid value for destination")
+	}
+	if value.Kind() != reflect.Ptr {
+		return errors.Errorf(
+			"can't decode, the destination object must be a pointer, got: %T(%s)", obj, value.Kind(),
+		)
+	}
+	if value.IsNil() {
+		return errors.Errorf("can't decode, the destination object %T must be a non-nil pointer", obj)
+	}
+	return nil
 }
 
 // RegisterValidators registers validator functions that serix will call during the Encode and Decode processes.
@@ -595,6 +708,7 @@ type tagSettings struct {
 	position   int
 	isOptional bool
 	nest       bool
+	omitEmpty  bool
 	ts         TypeSettings
 }
 
@@ -680,6 +794,31 @@ func parseStructTag(tag string) (tagSettings, error) {
 			settings.isOptional = true
 		case "nest":
 			settings.nest = true
+		case "omitempty":
+			settings.omitEmpty = true
+		case "mapKey":
+			if len(keyValue) != 2 {
+				return tagSettings{}, errors.Errorf("incorrect mapKey tag format: %s", currentPart)
+			}
+			settings.ts = settings.ts.WithMapKey(keyValue[1])
+		case "minLen":
+			if len(keyValue) != 2 {
+				return tagSettings{}, errors.Errorf("incorrect minLen tag format: %s", currentPart)
+			}
+			minLen, err := strconv.ParseUint(keyValue[1], 10, 64)
+			if err != nil {
+				return tagSettings{}, errors.Wrapf(err, "failed to parse minLen %s", currentPart)
+			}
+			settings.ts = settings.ts.WithMinLen(minLen)
+		case "maxLen":
+			if len(keyValue) != 2 {
+				return tagSettings{}, errors.Errorf("incorrect maxLen tag format: %s", currentPart)
+			}
+			maxLen, err := strconv.ParseUint(keyValue[1], 10, 64)
+			if err != nil {
+				return tagSettings{}, errors.Wrapf(err, "failed to parse maxLen %s", currentPart)
+			}
+			settings.ts = settings.ts.WithMaxLen(maxLen)
 		case "lengthPrefixType":
 			if len(keyValue) != 2 {
 				return tagSettings{}, errors.Errorf("incorrect lengthPrefixType tag format: %s", currentPart)
@@ -736,31 +875,46 @@ func deRefPointer(t reflect.Type) reflect.Type {
 	return t
 }
 
-func getNumberTypeToConvert(kind reflect.Kind) (reflect.Type, reflect.Type) {
+func getNumberTypeToConvert(kind reflect.Kind) (int, reflect.Type, reflect.Type) {
 	var numberType reflect.Type
+	var bitSize int
 	switch kind {
 	case reflect.Int8:
 		numberType = reflect.TypeOf(int8(0))
+		bitSize = 8
 	case reflect.Int16:
 		numberType = reflect.TypeOf(int16(0))
+		bitSize = 16
 	case reflect.Int32:
 		numberType = reflect.TypeOf(int32(0))
+		bitSize = 32
 	case reflect.Int64:
 		numberType = reflect.TypeOf(int64(0))
+		bitSize = 64
 	case reflect.Uint8:
 		numberType = reflect.TypeOf(uint8(0))
+		bitSize = 8
 	case reflect.Uint16:
 		numberType = reflect.TypeOf(uint16(0))
+		bitSize = 16
 	case reflect.Uint32:
 		numberType = reflect.TypeOf(uint32(0))
+		bitSize = 32
 	case reflect.Uint64:
 		numberType = reflect.TypeOf(uint64(0))
+		bitSize = 64
 	case reflect.Float32:
 		numberType = reflect.TypeOf(float32(0))
+		bitSize = 32
 	case reflect.Float64:
 		numberType = reflect.TypeOf(float64(0))
+		bitSize = 64
 	default:
-		return nil, nil
+		return -1, nil, nil
 	}
-	return numberType, reflect.PointerTo(numberType)
+	return bitSize, numberType, reflect.PointerTo(numberType)
+}
+
+func mapStringKey(str string) string {
+	return strings.ToLower(str[:1]) + str[1:]
 }

--- a/core/serix/serix_test.go
+++ b/core/serix/serix_test.go
@@ -7,8 +7,11 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/core/serix"
 	"github.com/iotaledger/hive.go/serializer/v2"
@@ -404,4 +407,109 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}()
 	os.Exit(exitCode)
+}
+
+func TestMinMax(t *testing.T) {
+	type paras struct {
+		api         *serix.API
+		encodeInput any
+		decodeInput []byte
+	}
+
+	type test struct {
+		name  string
+		paras paras
+		error bool
+	}
+	tests := []test{
+		{
+			name: "ok - string in bounds",
+			paras: func() paras {
+				type example struct {
+					Str string `serix:"0,minLen=5,maxLen=10,lengthPrefixType=uint8"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(0))))
+				return paras{
+					api:         api,
+					encodeInput: &example{Str: "abcde"},
+					decodeInput: []byte{0, 5, 97, 98, 99, 100, 101},
+				}
+			}(),
+			error: false,
+		},
+		{
+			name: "err - string out of bounds",
+			paras: func() paras {
+				type example struct {
+					Str string `serix:"0,minLen=5,maxLen=10,lengthPrefixType=uint8"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(0))))
+				return paras{
+					api:         api,
+					encodeInput: &example{Str: "abc"},
+					decodeInput: []byte{0, 3, 97, 98, 99},
+				}
+			}(),
+			error: true,
+		},
+		{
+			name: "ok - slice in bounds",
+			paras: func() paras {
+				type example struct {
+					Slice []byte `serix:"0,minLen=0,maxLen=10,lengthPrefixType=uint8"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(0))))
+				return paras{
+					api:         api,
+					encodeInput: &example{Slice: []byte{1, 2, 3, 4, 5}},
+					decodeInput: []byte{0, 5, 1, 2, 3, 4, 5},
+				}
+			}(),
+			error: false,
+		},
+		{
+			name: "err - slice out of bounds",
+			paras: func() paras {
+				type example struct {
+					Slice []byte `serix:"0,minLen=0,maxLen=3,lengthPrefixType=uint8"`
+				}
+
+				api := serix.NewAPI()
+				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(0))))
+				return paras{
+					api:         api,
+					encodeInput: &example{Slice: []byte{1, 2, 3, 4}},
+					decodeInput: []byte{0, 4, 1, 2, 3, 4},
+				}
+			}(),
+			error: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("encode", func(t *testing.T) {
+				_, err := test.paras.api.Encode(context.Background(), test.paras.encodeInput, serix.WithValidation())
+				if test.error {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			})
+			t.Run("decode", func(t *testing.T) {
+				dest := reflect.New(reflect.TypeOf(test.paras.encodeInput).Elem()).Interface()
+				_, err := test.paras.api.Decode(context.Background(), test.paras.decodeInput, dest, serix.WithValidation())
+				if test.error {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			})
+		})
+	}
 }


### PR DESCRIPTION
Adds functions to de/encode objects to their map representation which can further be used for JSON de/encoding.

In order for the code to figure out which type is being decoded, during encoding, a `"type": <object code>` k/v is defined with the type's object type number.

Furthermore:
- Custom map keys can be defined via the `mapKey` serix field tag, otherwise the field name is used with having the first letter lower cased.
- Using `omitempty` a given value is omitted if it is its zero value.
- Slice/Array types which implement interfaces can declare their `mapKey` naming within `RegisterTypeSetting`. This allows for example for an array to implement an interface (such as say `Address`) but then having its map representation include a custom key to represent the array value (which is something we do in our HTTP API).
- All integer numbers (exkl. 64 bit) are encoded as such but 64 bit nums are encoded as strings due to 53bit limits in json.
- Floats are encoded as strings.
- `time.Time` is encoded as a RFC3339/ISO8601 string.
- Byte slices and arrays are encoded as hex strings.
- `*big.Int` are encoded as hex strings using geth's encoding.