### PR TITLE
Unlock mutexes before firing events

### DIFF
--- a/core/subscriptionmanager/subscription_manager.go
+++ b/core/subscriptionmanager/subscription_manager.go
@@ -168,7 +168,6 @@ func (s *SubscriptionManager[C, T]) Connect(clientID C) {
 		for _, topic := range unsubscribedTopics {
 			s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
 		}
-		// send disconnect notification then delete the subscriber
 		s.events.ClientDisconnected.Trigger(&ClientEvent[C]{ClientID: clientID})
 	}
 
@@ -185,7 +184,6 @@ func (s *SubscriptionManager[C, T]) Disconnect(clientID C) {
 		for _, topic := range unsubscribedTopics {
 			s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
 		}
-		// send disconnect notification then delete the subscriber
 		s.events.ClientDisconnected.Trigger(&ClientEvent[C]{ClientID: clientID})
 	}
 }
@@ -246,7 +244,7 @@ func (s *SubscriptionManager[C, T]) Subscribe(clientID C, topic T) {
 		}
 		// notify the caller to drop the client
 		s.events.DropClient.Trigger(&DropClientEvent[C]{ClientID: clientID, Reason: ErrMaxTopicSubscriptionsPerClientReached})
-		// send disconnect notification then delete the subscriber
+
 		s.events.ClientDisconnected.Trigger(&ClientEvent[C]{ClientID: clientID})
 
 		// do not fire the subscribed events

--- a/core/subscriptionmanager/subscription_manager.go
+++ b/core/subscriptionmanager/subscription_manager.go
@@ -142,68 +142,120 @@ func (s *SubscriptionManager[C, T]) Events() *Events[C, T] {
 }
 
 func (s *SubscriptionManager[C, T]) Connect(clientID C) {
-	s.Lock()
-	defer s.Unlock()
 
-	// in case the client already exists, we cleanup old subscriptions.
-	s.cleanupClientWithoutLocking(clientID)
+	var removedTopics, unsubscribedTopics []T
 
-	// create a new map for the client
-	s.subscribers.Set(clientID, shrinkingmap.New[T, int](
-		shrinkingmap.WithShrinkingThresholdRatio(s.cleanupThresholdRatio),
-		shrinkingmap.WithShrinkingThresholdCount(s.cleanupThresholdCount),
-	))
+	// inline function used to release the lock before firing the event
+	func() {
+		s.Lock()
+		defer s.Unlock()
+
+		// in case the client already exists, we cleanup old subscriptions.
+		removedTopics, unsubscribedTopics = s.cleanupClientWithoutLocking(clientID)
+
+		// create a new map for the client
+		s.subscribers.Set(clientID, shrinkingmap.New[T, int](
+			shrinkingmap.WithShrinkingThresholdRatio(s.cleanupThresholdRatio),
+			shrinkingmap.WithShrinkingThresholdCount(s.cleanupThresholdCount),
+		))
+	}()
+
+	for _, topic := range removedTopics {
+		s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
+	}
+	for _, topic := range unsubscribedTopics {
+		s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
+	}
 
 	s.events.ClientConnected.Trigger(&ClientEvent[C]{ClientID: clientID})
 }
 
 func (s *SubscriptionManager[C, T]) Disconnect(clientID C) {
-	s.Lock()
-	defer s.Unlock()
 
-	// cleanup the client
-	s.cleanupClientWithoutLocking(clientID)
+	var removedTopics, unsubscribedTopics []T
+
+	// inline function used to release the lock before firing the event
+	func() {
+		s.Lock()
+		defer s.Unlock()
+
+		// cleanup the client
+		removedTopics, unsubscribedTopics = s.cleanupClientWithoutLocking(clientID)
+	}()
+
+	for _, topic := range removedTopics {
+		s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
+	}
+	for _, topic := range unsubscribedTopics {
+		s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
+	}
 
 	// send disconnect notification then delete the subscriber
 	s.events.ClientDisconnected.Trigger(&ClientEvent[C]{ClientID: clientID})
 }
 
 func (s *SubscriptionManager[C, T]) Subscribe(clientID C, topic T) {
-	s.Lock()
-	defer s.Unlock()
 
-	// check if the client is connected
-	subscribedTopics, has := s.subscribers.Get(clientID)
-	if !has {
+	clientDropped := false
+	topicAdded := false
+
+	var removedTopics, unsubscribedTopics []T
+
+	// inline function used to release the lock before firing the event
+	func() {
+		s.Lock()
+		defer s.Unlock()
+
+		// check if the client is connected
+		subscribedTopics, has := s.subscribers.Get(clientID)
+		if !has {
+			return
+		}
+
+		count, has := subscribedTopics.Get(topic)
+		if has {
+			subscribedTopics.Set(topic, count+1)
+		} else {
+			// add a new topic
+			subscribedTopics.Set(topic, 1)
+
+			// check if the client has reached the max number of subscriptions
+			if s.maxTopicSubscriptionsPerClient != 0 && subscribedTopics.Size() >= s.maxTopicSubscriptionsPerClient {
+				// cleanup the client
+				removedTopics, unsubscribedTopics = s.cleanupClientWithoutLocking(clientID)
+				clientDropped = true
+
+				return
+			}
+		}
+
+		// global topics map
+		count, has = s.topics.Get(topic)
+		if has {
+			s.topics.Set(topic, count+1)
+		} else {
+			// add a new topic
+			s.topics.Set(topic, 1)
+			topicAdded = true
+		}
+	}()
+
+	for _, topic := range removedTopics {
+		s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
+	}
+	for _, topic := range unsubscribedTopics {
+		s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
+	}
+
+	if clientDropped {
+		// drop the client
+		s.events.DropClient.Trigger(&DropClientEvent[C]{ClientID: clientID, Reason: ErrMaxTopicSubscriptionsPerClientReached})
+
+		// do not fire the subscribed events
 		return
 	}
 
-	count, has := subscribedTopics.Get(topic)
-	if has {
-		subscribedTopics.Set(topic, count+1)
-	} else {
-		// add a new topic
-		subscribedTopics.Set(topic, 1)
-
-		// check if the client has reached the max number of subscriptions
-		if s.maxTopicSubscriptionsPerClient != 0 && subscribedTopics.Size() >= s.maxTopicSubscriptionsPerClient {
-			// cleanup the client
-			s.cleanupClientWithoutLocking(clientID)
-			// drop the client
-			s.events.DropClient.Trigger(&DropClientEvent[C]{ClientID: clientID, Reason: ErrMaxTopicSubscriptionsPerClientReached})
-
-			// do not fire the subscribed events
-			return
-		}
-	}
-
-	// global topics map
-	count, has = s.topics.Get(topic)
-	if has {
-		s.topics.Set(topic, count+1)
-	} else {
-		// add a new topic
-		s.topics.Set(topic, 1)
+	if topicAdded {
 		s.events.TopicAdded.Trigger(&TopicEvent[T]{Topic: topic})
 	}
 
@@ -211,35 +263,53 @@ func (s *SubscriptionManager[C, T]) Subscribe(clientID C, topic T) {
 }
 
 func (s *SubscriptionManager[C, T]) Unsubscribe(clientID C, topic T) {
-	s.Lock()
-	defer s.Unlock()
 
-	// check if the client is connected
-	subscribedTopics, has := s.subscribers.Get(clientID)
-	if !has {
+	topicRemoved := false
+	topicUnsubscribed := false
+
+	// inline function used to release the lock before firing the event
+	func() {
+		s.Lock()
+		defer s.Unlock()
+
+		// check if the client is connected
+		subscribedTopics, has := s.subscribers.Get(clientID)
+		if !has {
+			return
+		}
+
+		topicUnsubscribed = true
+
+		count, has := subscribedTopics.Get(topic)
+		if has {
+			if count <= 1 {
+				// delete the topic
+				subscribedTopics.Delete(topic)
+			} else {
+				subscribedTopics.Set(topic, count-1)
+			}
+		}
+
+		// global topics map
+		count, has = s.topics.Get(topic)
+		if has {
+			if count <= 1 {
+				// delete the topic
+				s.topics.Delete(topic)
+				topicRemoved = true
+			} else {
+				s.topics.Set(topic, count-1)
+			}
+		}
+	}()
+
+	if !topicUnsubscribed {
+		// do not fire the unsubscribed events
 		return
 	}
 
-	count, has := subscribedTopics.Get(topic)
-	if has {
-		if count <= 1 {
-			// delete the topic
-			subscribedTopics.Delete(topic)
-		} else {
-			subscribedTopics.Set(topic, count-1)
-		}
-	}
-
-	// global topics map
-	count, has = s.topics.Get(topic)
-	if has {
-		if count <= 1 {
-			// delete the topic
-			s.topics.Delete(topic)
-			s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
-		} else {
-			s.topics.Set(topic, count-1)
-		}
+	if topicRemoved {
+		s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
 	}
 
 	s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
@@ -288,12 +358,15 @@ func (s *SubscriptionManager[C, T]) TopicsSizeAll() int {
 }
 
 // cleanupClientWithoutLocking removes all subscriptions and the client itself.
-func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) {
+func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) ([]T, []T) {
+
+	removedTopics := make([]T, 0)
+	unsubscribedTopics := make([]T, 0)
 
 	// check if the client exists
 	subscribedTopics, has := s.subscribers.Get(clientID)
 	if !has {
-		return
+		return removedTopics, unsubscribedTopics
 	}
 
 	// loop over all topics and delete them
@@ -305,7 +378,7 @@ func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) {
 			if topicsCount-count <= 1 {
 				// delete the topic
 				s.topics.Delete(topic)
-				s.events.TopicRemoved.Trigger(&TopicEvent[T]{Topic: topic})
+				removedTopics = append(removedTopics, topic)
 			} else {
 				s.topics.Set(topic, topicsCount-count)
 			}
@@ -313,7 +386,7 @@ func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) {
 
 		// call the topic unsubscribe as many times as it was subscribed
 		for i := 0; i < count; i++ {
-			s.events.TopicUnsubscribed.Trigger(&ClientTopicEvent[C, T]{ClientID: clientID, Topic: topic})
+			unsubscribedTopics = append(unsubscribedTopics, topic)
 		}
 
 		// delete the topic
@@ -324,4 +397,6 @@ func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) {
 
 	// delete the client
 	s.subscribers.Delete(clientID)
+
+	return removedTopics, unsubscribedTopics
 }

--- a/core/subscriptionmanager/subscription_manager.go
+++ b/core/subscriptionmanager/subscription_manager.go
@@ -378,7 +378,7 @@ func (s *SubscriptionManager[C, T]) cleanupClientWithoutLocking(clientID C) (boo
 		// global topics map
 		topicsCount, has := s.topics.Get(topic)
 		if has {
-			if topicsCount-count <= 1 {
+			if topicsCount-count <= 0 {
 				// delete the topic
 				s.topics.Delete(topic)
 				removedTopics = append(removedTopics, topic)


### PR DESCRIPTION
Its better to fire the events without holding the lock of the subscription manager.