### PR TITLE
Use root logger in app instead of global logger

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -45,7 +45,8 @@ type App struct {
 	pluginsMap              map[string]*Plugin
 	plugins                 []*Plugin
 	container               *dig.Container
-	log                     *logger.Logger
+	loggerRoot              *logger.Logger
+	logger                  *logger.Logger
 	appFlagSet              *flag.FlagSet
 	appConfig               *configuration.Configuration
 	appParams               *ParametersApp
@@ -73,7 +74,8 @@ func New(name string, version string, optionalOptions ...Option) *App {
 		pluginsMap:              make(map[string]*Plugin),
 		plugins:                 make([]*Plugin, 0),
 		container:               dig.New(dig.DeferAcyclicVerification()),
-		log:                     nil,
+		loggerRoot:              nil,
+		logger:                  nil,
 		appFlagSet:              nil,
 		appConfig:               nil,
 		configs:                 nil,
@@ -118,6 +120,9 @@ func (a *App) init() {
 
 	a.appParams = &ParametersApp{}
 	a.appConfig.BindParameters(a.appFlagSet, "app", a.appParams)
+
+	loggerParams := &logger.Config{}
+	a.appConfig.BindParameters(a.appFlagSet, "logger", loggerParams)
 
 	// provide the app params in the container
 	if err := a.container.Provide(func() *ParametersApp {
@@ -293,13 +298,15 @@ Command line flags:
 	// enable version check
 	a.options.versionCheckEnabled = a.appParams.CheckForUpdates
 
-	// initialize the global logger
-	if err := logger.InitGlobalLogger(a.appConfig); err != nil {
+	// initialize the root logger
+	log, err := logger.NewRootLogger(*loggerParams)
+	if err != nil {
 		panic(err)
 	}
+	a.loggerRoot = log
 
 	// initialize logger after init phase because components could modify it
-	a.log = logger.NewLogger("App")
+	a.logger = log.Named("App")
 }
 
 // printAppInfo prints app name and version info.
@@ -766,76 +773,85 @@ func (a *App) ForEachPlugin(f PluginForEachFunc) {
 // Logger
 //
 
+// NewLogger returns a new named child of the app's root logger.
+func (a *App) NewLogger(name string) *logger.Logger {
+	if a.loggerRoot == nil {
+		panic("app root logger not initialized")
+	}
+
+	return a.loggerRoot.Named(name)
+}
+
 // LogDebug uses fmt.Sprint to construct and log a message.
 func (a *App) LogDebug(args ...interface{}) {
-	a.log.Debug(args...)
+	a.logger.Debug(args...)
 }
 
 // LogDebugf uses fmt.Sprintf to log a templated message.
 func (a *App) LogDebugf(template string, args ...interface{}) {
-	a.log.Debugf(template, args...)
+	a.logger.Debugf(template, args...)
 }
 
 // LogError uses fmt.Sprint to construct and log a message.
 func (a *App) LogError(args ...interface{}) {
-	a.log.Error(args...)
+	a.logger.Error(args...)
 }
 
 // LogErrorAndExit uses fmt.Sprint to construct and log a message, then calls os.Exit.
 func (a *App) LogErrorAndExit(args ...interface{}) {
-	a.log.Error(args...)
-	a.log.Error("Exiting...")
+	a.logger.Error(args...)
+	a.logger.Error("Exiting...")
 	os.Exit(1)
 }
 
 // LogErrorf uses fmt.Sprintf to log a templated message.
 func (a *App) LogErrorf(template string, args ...interface{}) {
-	a.log.Errorf(template, args...)
+	a.logger.Errorf(template, args...)
 }
 
 // LogErrorfAndExit uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func (a *App) LogErrorfAndExit(template string, args ...interface{}) {
-	a.log.Errorf(template, args...)
-	a.log.Error("Exiting...")
+	a.logger.Errorf(template, args...)
+	a.logger.Error("Exiting...")
 	os.Exit(1)
 }
 
 // LogFatalAndExit uses fmt.Sprint to construct and log a message, then calls os.Exit.
 func (a *App) LogFatalAndExit(args ...interface{}) {
-	a.log.Fatal(args...)
+	a.logger.Fatal(args...)
 }
 
 // LogFatalfAndExit uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func (a *App) LogFatalfAndExit(template string, args ...interface{}) {
-	a.log.Fatalf(template, args...)
+	a.logger.Fatalf(template, args...)
 }
 
 // LogInfo uses fmt.Sprint to construct and log a message.
 func (a *App) LogInfo(args ...interface{}) {
-	a.log.Info(args...)
+	a.logger.Info(args...)
 }
 
 // LogInfof uses fmt.Sprintf to log a templated message.
 func (a *App) LogInfof(template string, args ...interface{}) {
-	a.log.Infof(template, args...)
+	a.logger.Infof(template, args...)
 }
 
 // LogWarn uses fmt.Sprint to construct and log a message.
 func (a *App) LogWarn(args ...interface{}) {
-	a.log.Warn(args...)
+	a.logger.Warn(args...)
 }
 
 // LogWarnf uses fmt.Sprintf to log a templated message.
 func (a *App) LogWarnf(template string, args ...interface{}) {
-	a.log.Warnf(template, args...)
+	a.logger.Warnf(template, args...)
 }
 
 // LogPanic uses fmt.Sprint to construct and log a message, then panics.
 func (a *App) LogPanic(args ...interface{}) {
-	a.log.Panic(args...)
+	a.logger.Panic(args...)
 }
 
 // LogPanicf uses fmt.Sprintf to log a templated message, then panics.
 func (a *App) LogPanicf(template string, args ...interface{}) {
-	a.log.Panicf(template, args...)
+	a.logger.Panicf(template, args...)
 }

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -171,7 +171,7 @@ func (a *App) init() {
 	//
 
 	collectParameters := func(component *Component) {
-		component.App = a
+		component.app = a
 
 		if component.Params == nil {
 			return
@@ -299,14 +299,14 @@ Command line flags:
 	a.options.versionCheckEnabled = a.appParams.CheckForUpdates
 
 	// initialize the root logger
-	log, err := logger.NewRootLogger(*loggerParams)
+	loggerRoot, err := logger.NewRootLogger(*loggerParams)
 	if err != nil {
 		panic(err)
 	}
-	a.loggerRoot = log
+	a.loggerRoot = loggerRoot
 
 	// initialize logger after init phase because components could modify it
-	a.logger = log.Named("App")
+	a.logger = loggerRoot.Named("App")
 }
 
 // printAppInfo prints app name and version info.

--- a/core/app/component.go
+++ b/core/app/component.go
@@ -43,17 +43,17 @@ type Component struct {
 	Run Callback
 
 	// The logger instance used in this component.
-	log     *logger.Logger
-	logOnce sync.Once
+	logger     *logger.Logger
+	loggerOnce sync.Once
 }
 
 // Logger instantiates and returns a logger with the name of the component.
 func (c *Component) Logger() *logger.Logger {
-	c.logOnce.Do(func() {
-		c.log = logger.NewLogger(c.Name)
+	c.loggerOnce.Do(func() {
+		c.logger = c.App.NewLogger(c.Name)
 	})
 
-	return c.log
+	return c.logger
 }
 
 func (c *Component) Daemon() daemon.Daemon {

--- a/core/app/component.go
+++ b/core/app/component.go
@@ -22,7 +22,7 @@ type ComponentParams struct {
 // Component is something which extends the App's capabilities.
 type Component struct {
 	// A reference to the App instance.
-	App *App
+	app *App
 	// The name of the component.
 	Name string
 	// The config parameters for this component.
@@ -47,17 +47,21 @@ type Component struct {
 	loggerOnce sync.Once
 }
 
+func (c *Component) App() *App {
+	return c.app
+}
+
 // Logger instantiates and returns a logger with the name of the component.
 func (c *Component) Logger() *logger.Logger {
 	c.loggerOnce.Do(func() {
-		c.logger = c.App.NewLogger(c.Name)
+		c.logger = c.App().NewLogger(c.Name)
 	})
 
 	return c.logger
 }
 
 func (c *Component) Daemon() daemon.Daemon {
-	return c.App.Daemon()
+	return c.App().Daemon()
 }
 
 func (c *Component) Identifier() string {

--- a/core/daemon/daemon.go
+++ b/core/daemon/daemon.go
@@ -34,9 +34,9 @@ func BackgroundWorker(name string, handler WorkerFunc, priority ...int) error {
 	return defaultDaemon.BackgroundWorker(name, handler, priority...)
 }
 
-// DebugEnabled allows to configure the daemon to issue log messages for debugging purposes.
-func DebugEnabled(enabled bool) {
-	defaultDaemon.DebugEnabled(enabled)
+// DebugLogger allows to pass a logger to the daemon to issue log messages for debugging purposes.
+func DebugLogger(logger *logger.Logger) {
+	defaultDaemon.DebugLogger(logger)
 }
 
 // Start starts the default daemon instance.
@@ -244,13 +244,9 @@ func (d *OrderedDaemon) BackgroundWorker(name string, handler WorkerFunc, order 
 	return nil
 }
 
-// DebugEnabled allows to configure the daemon to issue log messages for debugging purposes.
-func (d *OrderedDaemon) DebugEnabled(enabled bool) {
-	if enabled {
-		defaultDaemon.logger = logger.NewLogger("Daemon")
-	} else {
-		defaultDaemon.logger = nil
-	}
+// DebugLogger allows to pass a logger to the daemon to issue log messages for debugging purposes.
+func (d *OrderedDaemon) DebugLogger(logger *logger.Logger) {
+	defaultDaemon.logger = logger
 }
 
 // Start starts the daemon.

--- a/core/daemon/interfaces.go
+++ b/core/daemon/interfaces.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+
+	"github.com/iotaledger/hive.go/core/logger"
 )
 
 // WorkerFunc is the function to run a worker accepting its context.
@@ -17,8 +19,8 @@ type Daemon interface {
 	// background worker is shut down (higher = earlier).
 	BackgroundWorker(name string, handler WorkerFunc, order ...int) error
 
-	// DebugEnabled allows to configure the daemon to issue log messages for debugging purposes.
-	DebugEnabled(enabled bool)
+	// DebugLogger allows to pass a logger to the daemon to issue log messages for debugging purposes.
+	DebugLogger(logger *logger.Logger)
 
 	// Start starts the daemon.
 	Start()

--- a/core/logger/config.go
+++ b/core/logger/config.go
@@ -16,24 +16,24 @@ const (
 type Config struct {
 	// Level is the minimum enabled logging level.
 	// The default is "info".
-	Level string `json:"level"`
+	Level string `default:"info" usage:"the minimum enabled logging level" json:"level"`
 	// DisableCaller stops annotating logs with the calling function's file name and line number.
 	// By default, logs are not annotated.
-	DisableCaller bool `json:"disableCaller"`
+	DisableCaller bool `default:"true" usage:"stops annotating logs with the calling function's file name and line number" json:"disableCaller"`
 	// DisableStacktrace disables automatic stacktrace capturing.
-	DisableStacktrace bool `json:"disableStacktrace"`
+	DisableStacktrace bool `default:"false" usage:"disables automatic stacktrace capturing" json:"disableStacktrace"`
 	// StacktraceLevel is the level stacktraces are captured and above.
 	// The default is "panic".
-	StacktraceLevel string `json:"stacktraceLevel"`
+	StacktraceLevel string `default:"panic" usage:"the level stacktraces are captured and above" json:"stacktraceLevel"`
 	// Encoding sets the logger's encoding. Valid values are "json" and "console".
 	// The default is "console".
-	Encoding string `json:"encoding"`
+	Encoding string `default:"console" usage:"the logger's encoding (options: \"json\", \"console\")" json:"encoding"`
 	// OutputPaths is a list of URLs, file paths or stdout/stderr to write logging output to.
 	// The default is ["stdout"].
-	OutputPaths []string `json:"outputPaths"`
+	OutputPaths []string `default:"stdout" usage:"a list of URLs, file paths or stdout/stderr to write logging output to" json:"outputPaths"`
 	// DisableEvents prevents log messages from being raced as events.
 	// By default, the corresponding events are not triggered.
-	DisableEvents bool `json:"disableEvents"`
+	DisableEvents bool `default:"true" usage:"prevents log messages from being raced as events" json:"disableEvents"`
 }
 
 var defaultCfg = Config{


### PR DESCRIPTION
The way the global logger is initialized now doesn't fit to the reflection based config parameters we use in the app module.

This PR removes the global logger from the app module, and initializes a root logger with parameters that are parsed with the reflection based logic.