### PR TITLE
Fix configuration default values

### DIFF
--- a/core/configuration/configuration.go
+++ b/core/configuration/configuration.go
@@ -261,9 +261,12 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			continue
 		}
 
+		// only use the default value from the tags if the value is the zero value
+		isZeroValue := valueField.IsZero()
+
 		switch defaultValue := valueField.Interface().(type) {
 		case bool:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseBool(tagDefaultValue); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -273,7 +276,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.BoolVarP(valueField.Addr().Interface().(*bool), name, shortHand, defaultValue, usage)
 
 		case time.Duration:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if parsedDuration, err := time.ParseDuration(tagDefaultValue); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -283,7 +286,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.DurationVarP(valueField.Addr().Interface().(*time.Duration), name, shortHand, defaultValue, usage)
 
 		case float32:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseFloat(tagDefaultValue, 32); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -293,7 +296,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Float32VarP(valueField.Addr().Interface().(*float32), name, shortHand, defaultValue, usage)
 
 		case float64:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseFloat(tagDefaultValue, 64); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -303,7 +306,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Float64VarP(valueField.Addr().Interface().(*float64), name, shortHand, defaultValue, usage)
 
 		case int:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseInt(tagDefaultValue, 10, 64); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -313,7 +316,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.IntVarP(valueField.Addr().Interface().(*int), name, shortHand, defaultValue, usage)
 
 		case int8:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseInt(tagDefaultValue, 10, 8); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -323,7 +326,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Int8VarP(valueField.Addr().Interface().(*int8), name, shortHand, defaultValue, usage)
 
 		case int16:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseInt(tagDefaultValue, 10, 16); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -333,7 +336,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Int16VarP(valueField.Addr().Interface().(*int16), name, shortHand, defaultValue, usage)
 
 		case int32:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseInt(tagDefaultValue, 10, 32); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -343,7 +346,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Int32VarP(valueField.Addr().Interface().(*int32), name, shortHand, defaultValue, usage)
 
 		case int64:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseInt(tagDefaultValue, 10, 64); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -353,13 +356,13 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Int64VarP(valueField.Addr().Interface().(*int64), name, shortHand, defaultValue, usage)
 
 		case string:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				defaultValue = tagDefaultValue
 			}
 			flagset.StringVarP(valueField.Addr().Interface().(*string), name, shortHand, defaultValue, usage)
 
 		case uint:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseUint(tagDefaultValue, 10, 64); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -369,7 +372,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.UintVarP(valueField.Addr().Interface().(*uint), name, shortHand, defaultValue, usage)
 
 		case uint8:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseUint(tagDefaultValue, 10, 8); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -379,7 +382,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Uint8VarP(valueField.Addr().Interface().(*uint8), name, shortHand, defaultValue, usage)
 
 		case uint16:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseUint(tagDefaultValue, 10, 16); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -389,7 +392,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Uint16VarP(valueField.Addr().Interface().(*uint16), name, shortHand, defaultValue, usage)
 
 		case uint32:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseUint(tagDefaultValue, 10, 32); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -399,7 +402,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Uint32VarP(valueField.Addr().Interface().(*uint32), name, shortHand, defaultValue, usage)
 
 		case uint64:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if value, err := strconv.ParseUint(tagDefaultValue, 10, 64); err != nil {
 					panic(fmt.Sprintf("could not parse default value of '%s', error: %s", name, err))
 				} else {
@@ -409,7 +412,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.Uint64VarP(valueField.Addr().Interface().(*uint64), name, shortHand, defaultValue, usage)
 
 		case []string:
-			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists {
+			if tagDefaultValue, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				if len(tagDefaultValue) == 0 {
 					defaultValue = []string{}
 				} else {
@@ -419,7 +422,7 @@ func (c *Configuration) BindParameters(flagset *flag.FlagSet, namespace string, 
 			flagset.StringSliceVarP(valueField.Addr().Interface().(*[]string), name, shortHand, defaultValue, usage)
 
 		case map[string]string:
-			if _, exists := typeField.Tag.Lookup("default"); exists {
+			if _, exists := typeField.Tag.Lookup("default"); exists && isZeroValue {
 				panic(fmt.Sprintf("passing default value of '%s' via tag not allowed", name))
 			}
 			flagset.StringToStringVarP(valueField.Addr().Interface().(*map[string]string), name, shortHand, defaultValue, usage)


### PR DESCRIPTION
This PR changes the behavior of the reflection based configuration.

Before the default value was always overwritten by the default value set in the tag.
Now it first checks if the actual value is zero, before it applies the default value from the tag.

This way we can overwrite default values.

Example:

```go

type ParametersPlugin struct {
	Enabled bool `default:"true" usage:"whether the  plugin is enabled"`
}

var ParamsPlugin = &ParametersPlugin{
	Enabled: false,
}

var params = &app.ComponentParams{
	Params: map[string]any{
		"plugin": ParamsPlugin,
	},
	Masked: nil,
}
```

Before `Enabled` was `true`, not it would be `false`.