### PR TITLE
Use MkDirAll to create subdirectories

### DIFF
--- a/core/ioutils/ioutils.go
+++ b/core/ioutils/ioutils.go
@@ -34,7 +34,7 @@ func CreateDirectory(dir string, perm os.FileMode) error {
 	}
 
 	if !exists {
-		return os.Mkdir(dir, perm)
+		return os.MkdirAll(dir, perm)
 	}
 
 	return nil


### PR DESCRIPTION
# Description of change

This PR changes the ioutil to use `MkDirAll` instead of `MkDir` so that subfolders are also created.
