### PR TITLE
Move database package from hornet to hive.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters-settings:
         locale: US
     staticcheck:
         checks: ["all"]
+    nlreturn:
+        block-size: 2
     stylecheck:
         initialisms: ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
 

--- a/core/database/engine.go
+++ b/core/database/engine.go
@@ -1,0 +1,207 @@
+package database
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotaledger/hive.go/core/generics/lo"
+	"github.com/iotaledger/hive.go/core/ioutils"
+)
+
+type Engine string
+
+const (
+	EngineUnknown Engine = "unknown"
+	EngineAuto    Engine = "auto"
+	EngineBadger  Engine = "badger"
+	EngineDebug   Engine = "debug"
+	EngineMapDB   Engine = "mapdb"
+	EnginePebble  Engine = "pebble"
+	EngineRocksDB Engine = "rocksdb"
+)
+
+var (
+	allowedEnginesDefault = []Engine{
+		EngineAuto,
+		EngineBadger,
+		EngineDebug,
+		EngineMapDB,
+		EnginePebble,
+		EngineRocksDB,
+	}
+
+	enginesStorage = map[Engine]struct{}{
+		EngineBadger:  {},
+		EnginePebble:  {},
+		EngineRocksDB: {},
+	}
+)
+
+var (
+	ErrEngineMismatch = errors.New("database engine mismatch")
+)
+
+type databaseInfo struct {
+	Engine string `toml:"databaseEngine"`
+}
+
+// engineFromString parses an engine from a string.
+func engineFromString(engineStr string) Engine {
+	if engineStr == "" {
+		// no engine specified
+		return EngineAuto
+	}
+
+	return Engine(strings.ToLower(engineStr))
+}
+
+// getSupportedEnginesString returns a string containing all supported engines separated by "/".
+func getSupportedEnginesString(supportedEngines []Engine) string {
+	supportedEnginesStr := ""
+	for i, allowedEngine := range supportedEngines {
+		if i != 0 {
+			supportedEnginesStr += "/"
+		}
+		supportedEnginesStr += string(allowedEngine)
+	}
+
+	return supportedEnginesStr
+}
+
+// EngineAllowed checks if the database engine is allowed.
+func EngineAllowed(dbEngine Engine, allowedEngines ...Engine) (Engine, error) {
+
+	tmpAllowedEngines := allowedEnginesDefault
+	if len(allowedEngines) > 0 {
+		tmpAllowedEngines = allowedEngines
+	}
+
+	for _, allowedEngine := range tmpAllowedEngines {
+		if dbEngine == allowedEngine {
+			return dbEngine, nil
+		}
+	}
+
+	return EngineUnknown, fmt.Errorf("unknown database engine: %s, supported engines: %s", dbEngine, getSupportedEnginesString(tmpAllowedEngines))
+}
+
+// EngineFromStringAllowed parses an engine from a string and checks if the database engine is allowed.
+func EngineFromStringAllowed(dbEngineStr string, allowedEngines ...Engine) (Engine, error) {
+	return EngineAllowed(engineFromString(dbEngineStr), allowedEngines...)
+}
+
+// CheckEngine checks if the correct database engine is used.
+// This function stores a so called "database info file" in the database folder or
+// checks if an existing "database info file" contains the correct engine.
+// Otherwise the files in the database folder are not compatible.
+func CheckEngine(dbPath string, createDatabaseIfNotExists bool, dbEngine Engine, allowedEngines ...Engine) (Engine, error) {
+
+	// check if the given target engine is allowed
+	_, err := EngineAllowed(dbEngine, allowedEngines...)
+	if err != nil {
+		return EngineUnknown, err
+	}
+
+	switch dbEngine {
+	case EngineUnknown:
+		return EngineUnknown, errors.New("the database engine must not be EngineUnknown")
+
+	case EngineMapDB:
+		// no need to create or access a "database info file" in case of mapdb (in-memory)
+		return EngineMapDB, nil
+	}
+
+	dbEngineSpecified := dbEngine != EngineAuto
+
+	// check if the database exists and if it should be created
+	dbExists, err := Exists(dbPath)
+	if err != nil {
+		return EngineUnknown, err
+	}
+
+	if !dbExists {
+		if !createDatabaseIfNotExists {
+			return EngineUnknown, fmt.Errorf("database not found (%s)", dbPath)
+		}
+
+		if createDatabaseIfNotExists && !dbEngineSpecified {
+			return EngineUnknown, errors.New("the database engine must be specified if the database should be newly created")
+		}
+	}
+
+	var targetEngine Engine
+
+	// check if the database info file exists and if it should be created
+	dbInfoFilePath := filepath.Join(dbPath, "dbinfo")
+	_, err = os.Stat(dbInfoFilePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return EngineUnknown, fmt.Errorf("unable to check database info file (%s): %w", dbInfoFilePath, err)
+		}
+
+		if !dbEngineSpecified {
+			return EngineUnknown, fmt.Errorf("database info file not found (%s)", dbInfoFilePath)
+		}
+
+		// if the dbInfo file does not exist and the dbEngine is given, create the dbInfo file.
+		if err := storeDatabaseInfoToFile(dbInfoFilePath, dbEngine); err != nil {
+			return EngineUnknown, err
+		}
+
+		targetEngine = dbEngine
+	} else {
+		dbEngineFromInfoFile, err := LoadEngineFromFile(dbInfoFilePath, allowedEngines...)
+		if err != nil {
+			return EngineUnknown, err
+		}
+
+		// if the dbInfo file exists and the dbEngine is given, compare the engines.
+		if dbEngineSpecified && dbEngineFromInfoFile != dbEngine {
+			return dbEngineFromInfoFile, ErrEngineMismatch
+		}
+
+		targetEngine = dbEngineFromInfoFile
+	}
+
+	return targetEngine, nil
+}
+
+// LoadEngineFromFile returns the engine from the "database info file".
+func LoadEngineFromFile(path string, allowedEngines ...Engine) (Engine, error) {
+
+	tmpAllowedEngines := lo.Keys(enginesStorage)
+	if len(allowedEngines) > 0 {
+		// allowed engines were give, filter for storage engines only
+		tmpAllowedEngines = lo.Filter(allowedEngines, func(engine Engine) bool {
+			_, exists := enginesStorage[engine]
+			return exists
+		})
+	}
+
+	var info databaseInfo
+
+	if err := ioutils.ReadTOMLFromFile(path, &info); err != nil {
+		return "", fmt.Errorf("unable to read database info file: %w", err)
+	}
+
+	return EngineFromStringAllowed(info.Engine, tmpAllowedEngines...)
+}
+
+// storeDatabaseInfoToFile stores the used engine in a "database info file".
+func storeDatabaseInfoToFile(filePath string, engine Engine) error {
+	dirPath := filepath.Dir(filePath)
+
+	if err := os.MkdirAll(dirPath, 0700); err != nil {
+		return fmt.Errorf("could not create database dir '%s': %w", dirPath, err)
+	}
+
+	info := &databaseInfo{
+		Engine: string(engine),
+	}
+
+	return ioutils.WriteTOMLToFile(filePath, info, 0660, "# auto-generated\n# !!! do not modify this file !!!")
+}

--- a/core/database/utils.go
+++ b/core/database/utils.go
@@ -1,0 +1,28 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/iotaledger/hive.go/core/ioutils"
+)
+
+// Exists checks if the database folder exists and is not empty.
+func Exists(dbPath string) (bool, error) {
+
+	dirExists, err := ioutils.PathExists(dbPath)
+	if err != nil {
+		return false, fmt.Errorf("unable to check database path (%s): %w", dbPath, err)
+	}
+	if !dirExists {
+		return false, nil
+	}
+
+	// directory exists, but maybe database doesn't exist.
+	// check if the directory is empty (needed for example in docker environments)
+	dirEmpty, err := ioutils.DirectoryEmpty(dbPath)
+	if err != nil {
+		return false, fmt.Errorf("unable to check database path (%s): %w", dbPath, err)
+	}
+
+	return !dirEmpty, nil
+}

--- a/core/subscriptionmanager/subscription_manager.go
+++ b/core/subscriptionmanager/subscription_manager.go
@@ -100,7 +100,7 @@ func WithMaxTopicSubscriptionsPerClient[C ClientID, T Topic](maxTopicSubscriptio
 	}
 }
 
-// WithShrinkingThresholdCount defines the count of
+// WithCleanupThresholdCount defines the count of
 // deletions that triggers shrinking of the map.
 func WithCleanupThresholdCount[C ClientID, T Topic](cleanupThresholdCount int) options.Option[SubscriptionManager[C, T]] {
 	return func(s *SubscriptionManager[C, T]) {
@@ -108,7 +108,7 @@ func WithCleanupThresholdCount[C ClientID, T Topic](cleanupThresholdCount int) o
 	}
 }
 
-// WithShrinkingThresholdRatio defines the ratio between the amount
+// WithCleanupThresholdRatio defines the ratio between the amount
 // of deleted keys and the current map's size before shrinking is triggered.
 func WithCleanupThresholdRatio[C ClientID, T Topic](cleanupThresholdRatio float32) options.Option[SubscriptionManager[C, T]] {
 	return func(s *SubscriptionManager[C, T]) {


### PR DESCRIPTION
This PR moves parts of the database package from hornet to hive.go.

It contains functions that can be used to check if the database folder matches the used database engine.