### PR TITLE
Add a kvstore wrapper that flushes changes immediately

### DIFF
--- a/core/kvstore/flushkv/flushkv.go
+++ b/core/kvstore/flushkv/flushkv.go
@@ -1,0 +1,133 @@
+package flushkv
+
+import (
+	"github.com/iotaledger/hive.go/core/kvstore"
+)
+
+// flushKVStore is a wrapper to any KVStore that flushes changes immediately.
+type flushKVStore struct {
+	store kvstore.KVStore
+}
+
+// New creates a kvstore.KVStore implementation that flushes changes immediately.
+func New(store kvstore.KVStore) kvstore.KVStore {
+	return &flushKVStore{
+		store: store,
+	}
+}
+
+func (s *flushKVStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
+	store, err := s.store.WithRealm(realm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flushKVStore{
+		store: store,
+	}, nil
+}
+
+func (s *flushKVStore) WithExtendedRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
+	return s.store.WithExtendedRealm(realm)
+}
+
+func (s *flushKVStore) Realm() kvstore.Realm {
+	return s.store.Realm()
+}
+
+// Iterate iterates over all keys and values with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys and values.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (s *flushKVStore) Iterate(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyValueConsumerFunc, iterDirection ...kvstore.IterDirection) error {
+	return s.store.Iterate(prefix, consumerFunc, iterDirection...)
+}
+
+// IterateKeys iterates over all keys with the provided prefix. You can pass kvstore.EmptyPrefix to iterate over all keys.
+// Optionally the direction for the iteration can be passed (default: IterDirectionForward).
+func (s *flushKVStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstore.IteratorKeyConsumerFunc, iterDirection ...kvstore.IterDirection) error {
+	return s.store.IterateKeys(prefix, consumerFunc, iterDirection...)
+}
+
+func (s *flushKVStore) Clear() error {
+	return s.store.Clear()
+}
+
+func (s *flushKVStore) Get(key kvstore.Key) (kvstore.Value, error) {
+	return s.store.Get(key)
+}
+
+func (s *flushKVStore) Set(key kvstore.Key, value kvstore.Value) error {
+	if err := s.store.Set(key, value); err != nil {
+		return err
+	}
+
+	return s.store.Flush()
+}
+
+func (s *flushKVStore) Has(key kvstore.Key) (bool, error) {
+	return s.store.Has(key)
+}
+
+func (s *flushKVStore) Delete(key kvstore.Key) error {
+	if err := s.store.Delete(key); err != nil {
+		return err
+	}
+
+	return s.store.Flush()
+}
+
+func (s *flushKVStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
+	if err := s.store.DeletePrefix(prefix); err != nil {
+		return err
+	}
+
+	return s.store.Flush()
+}
+
+func (s *flushKVStore) Flush() error {
+	return s.store.Flush()
+}
+
+func (s *flushKVStore) Close() error {
+	return s.store.Close()
+}
+
+func (s *flushKVStore) Batched() (kvstore.BatchedMutations, error) {
+	batched, err := s.store.Batched()
+	if err != nil {
+		return nil, err
+	}
+
+	return &batchedMutations{
+		store:   s.store,
+		batched: batched,
+	}, nil
+}
+
+// batchedMutations is a wrapper around a WriteBatch of a flushKVStore.
+type batchedMutations struct {
+	store   kvstore.KVStore
+	batched kvstore.BatchedMutations
+}
+
+func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
+	return b.batched.Set(key, value)
+}
+
+func (b *batchedMutations) Delete(key kvstore.Key) error {
+	return b.batched.Delete(key)
+}
+
+func (b *batchedMutations) Cancel() {
+	b.batched.Cancel()
+}
+
+func (b *batchedMutations) Commit() error {
+	if err := b.batched.Commit(); err != nil {
+		return err
+	}
+
+	return b.store.Flush()
+}
+
+var _ kvstore.KVStore = &flushKVStore{}
+var _ kvstore.BatchedMutations = &batchedMutations{}

--- a/core/kvstore/flushkv/flushkv.go
+++ b/core/kvstore/flushkv/flushkv.go
@@ -17,6 +17,7 @@ func New(store kvstore.KVStore) kvstore.KVStore {
 	}
 }
 
+// WithRealm is a factory method for using the same underlying storage with a different realm.
 func (s *flushKVStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 	store, err := s.store.WithRealm(realm)
 	if err != nil {
@@ -28,10 +29,12 @@ func (s *flushKVStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 	}, nil
 }
 
+// WithExtendedRealm is a factory method for using the same underlying storage with an realm appended to existing one.
 func (s *flushKVStore) WithExtendedRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 	return s.WithRealm(byteutils.ConcatBytes(s.Realm(), realm))
 }
 
+// Realm returns the configured realm.
 func (s *flushKVStore) Realm() kvstore.Realm {
 	return s.store.Realm()
 }
@@ -48,6 +51,7 @@ func (s *flushKVStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstor
 	return s.store.IterateKeys(prefix, consumerFunc, iterDirection...)
 }
 
+// Clear clears the realm.
 func (s *flushKVStore) Clear() error {
 	if err := s.store.Clear(); err != nil {
 		return err
@@ -56,10 +60,12 @@ func (s *flushKVStore) Clear() error {
 	return s.store.Flush()
 }
 
+// Get gets the given key or nil if it doesn't exist or an error if an error occurred.
 func (s *flushKVStore) Get(key kvstore.Key) (kvstore.Value, error) {
 	return s.store.Get(key)
 }
 
+// Set sets the given key and value.
 func (s *flushKVStore) Set(key kvstore.Key, value kvstore.Value) error {
 	if err := s.store.Set(key, value); err != nil {
 		return err
@@ -68,10 +74,12 @@ func (s *flushKVStore) Set(key kvstore.Key, value kvstore.Value) error {
 	return s.store.Flush()
 }
 
+// Has checks whether the given key exists.
 func (s *flushKVStore) Has(key kvstore.Key) (bool, error) {
 	return s.store.Has(key)
 }
 
+// Delete deletes the entry for the given key.
 func (s *flushKVStore) Delete(key kvstore.Key) error {
 	if err := s.store.Delete(key); err != nil {
 		return err
@@ -80,6 +88,7 @@ func (s *flushKVStore) Delete(key kvstore.Key) error {
 	return s.store.Flush()
 }
 
+// DeletePrefix deletes all the entries matching the given key prefix.
 func (s *flushKVStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
 	if err := s.store.DeletePrefix(prefix); err != nil {
 		return err
@@ -88,14 +97,17 @@ func (s *flushKVStore) DeletePrefix(prefix kvstore.KeyPrefix) error {
 	return s.store.Flush()
 }
 
+// Flush persists all outstanding write operations to disc.
 func (s *flushKVStore) Flush() error {
 	return s.store.Flush()
 }
 
+// Close closes the database file handles.
 func (s *flushKVStore) Close() error {
 	return s.store.Close()
 }
 
+// Batched returns a BatchedMutations interface to execute batched mutations.
 func (s *flushKVStore) Batched() (kvstore.BatchedMutations, error) {
 	batched, err := s.store.Batched()
 	if err != nil {
@@ -114,18 +126,22 @@ type batchedMutations struct {
 	batched kvstore.BatchedMutations
 }
 
+// Set sets the given key and value.
 func (b *batchedMutations) Set(key kvstore.Key, value kvstore.Value) error {
 	return b.batched.Set(key, value)
 }
 
+// Delete deletes the entry for the given key.
 func (b *batchedMutations) Delete(key kvstore.Key) error {
 	return b.batched.Delete(key)
 }
 
+// Cancel cancels the batched mutations.
 func (b *batchedMutations) Cancel() {
 	b.batched.Cancel()
 }
 
+// Commit commits/flushes the mutations.
 func (b *batchedMutations) Commit() error {
 	if err := b.batched.Commit(); err != nil {
 		return err
@@ -134,5 +150,6 @@ func (b *batchedMutations) Commit() error {
 	return b.store.Flush()
 }
 
+// code guards
 var _ kvstore.KVStore = &flushKVStore{}
 var _ kvstore.BatchedMutations = &batchedMutations{}

--- a/core/kvstore/flushkv/flushkv.go
+++ b/core/kvstore/flushkv/flushkv.go
@@ -48,7 +48,11 @@ func (s *flushKVStore) IterateKeys(prefix kvstore.KeyPrefix, consumerFunc kvstor
 }
 
 func (s *flushKVStore) Clear() error {
-	return s.store.Clear()
+	if err := s.store.Clear(); err != nil {
+		return err
+	}
+
+	return s.store.Flush()
 }
 
 func (s *flushKVStore) Get(key kvstore.Key) (kvstore.Value, error) {

--- a/core/kvstore/flushkv/flushkv.go
+++ b/core/kvstore/flushkv/flushkv.go
@@ -1,6 +1,7 @@
 package flushkv
 
 import (
+	"github.com/iotaledger/hive.go/core/byteutils"
 	"github.com/iotaledger/hive.go/core/kvstore"
 )
 
@@ -28,7 +29,7 @@ func (s *flushKVStore) WithRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
 }
 
 func (s *flushKVStore) WithExtendedRealm(realm kvstore.Realm) (kvstore.KVStore, error) {
-	return s.store.WithExtendedRealm(realm)
+	return s.WithRealm(byteutils.ConcatBytes(s.Realm(), realm))
 }
 
 func (s *flushKVStore) Realm() kvstore.Realm {

--- a/core/kvstore/flushkv/flushkv_test.go
+++ b/core/kvstore/flushkv/flushkv_test.go
@@ -1,0 +1,161 @@
+package flushkv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/core/kvstore"
+	"github.com/iotaledger/hive.go/core/kvstore/mapdb"
+)
+
+var testEntries = []*struct {
+	kvstore.Key
+	kvstore.Value
+}{
+	{Key: []byte("a"), Value: []byte("valueA")},
+	{Key: []byte("b"), Value: []byte("valueB")},
+	{Key: []byte("c"), Value: []byte("valueC")},
+	{Key: []byte("d"), Value: []byte("valueD")},
+}
+
+func TestFlushKVStore_Get(t *testing.T) {
+	store := New(mapdb.NewMapDB())
+	for _, entry := range testEntries {
+		err := store.Set(entry.Key, entry.Value)
+		require.NoError(t, err)
+	}
+
+	for _, entry := range testEntries {
+		value, err := store.Get(entry.Key)
+		assert.Equal(t, entry.Value, value)
+		assert.NoError(t, err)
+	}
+
+	value, err := store.Get([]byte("invalid"))
+	assert.Nil(t, value)
+	assert.Equal(t, kvstore.ErrKeyNotFound, err)
+}
+
+func TestFlushKVStore_Iterate(t *testing.T) {
+	store := New(mapdb.NewMapDB())
+	for _, entry := range testEntries {
+		err := store.Set(entry.Key, entry.Value)
+		require.NoError(t, err)
+	}
+
+	i := 0
+	err := store.Iterate(kvstore.EmptyPrefix, func(key kvstore.Key, value kvstore.Value) bool {
+		entry := &struct {
+			kvstore.Key
+			kvstore.Value
+		}{key, value}
+		assert.Contains(t, testEntries, entry)
+		i++
+
+		return true
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, len(testEntries), i)
+}
+
+func TestFlushKVStore_IterateDirection(t *testing.T) {
+	store := New(mapdb.NewMapDB())
+	for _, entry := range testEntries {
+		err := store.Set(entry.Key, entry.Value)
+		require.NoError(t, err)
+	}
+
+	// forward iteration
+	i := 0
+	err := store.Iterate(kvstore.EmptyPrefix, func(key kvstore.Key, value kvstore.Value) bool {
+		entry := &struct {
+			kvstore.Key
+			kvstore.Value
+		}{key, value}
+		assert.Equal(t, testEntries[i], entry, "entries are not equal")
+		i++
+
+		return true
+	}, kvstore.IterDirectionForward)
+	assert.NoError(t, err)
+	assert.Equal(t, len(testEntries), i)
+
+	// backward iteration
+	i = 0
+	err = store.Iterate(kvstore.EmptyPrefix, func(key kvstore.Key, value kvstore.Value) bool {
+		entry := &struct {
+			kvstore.Key
+			kvstore.Value
+		}{key, value}
+		assert.Equal(t, testEntries[len(testEntries)-1-i], entry, "entries are not equal")
+		i++
+
+		return true
+	}, kvstore.IterDirectionBackward)
+	assert.NoError(t, err)
+	assert.Equal(t, len(testEntries), i)
+}
+
+func TestFlushKVStore_Realm(t *testing.T) {
+	store := New(mapdb.NewMapDB())
+	realm := kvstore.Realm("realm")
+	realmStore, err := store.WithRealm(realm)
+	require.NoError(t, err)
+
+	key := []byte("key")
+	err = realmStore.Set(key, []byte("value"))
+	require.NoError(t, err)
+
+	tmpStore, err := store.WithRealm(kvstore.Realm("tmp"))
+	require.NoError(t, err)
+
+	key2 := []byte("key2")
+	err = tmpStore.Set(key2, []byte("value"))
+	require.NoError(t, err)
+
+	realmStore2, err := store.WithRealm(realm)
+	require.NoError(t, err)
+
+	has, err := realmStore2.Has(key)
+	assert.NoError(t, err)
+	assert.True(t, has)
+	has, err = realmStore2.Has(key2)
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	// when clearing "realm" the key in "tmp" should still be there
+	assert.NoError(t, realmStore.Clear())
+	has, err = tmpStore.Has(key2)
+	assert.NoError(t, err)
+	assert.True(t, has)
+}
+
+func TestFlushKVStore_Clear(t *testing.T) {
+	store := New(mapdb.NewMapDB())
+	require.EqualValues(t, 0, countKeys(t, store))
+
+	for _, entry := range testEntries {
+		err := store.Set(entry.Key, entry.Value)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, len(testEntries), countKeys(t, store))
+
+	// check that Clear removes all the keys
+	err := store.Clear()
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, countKeys(t, store))
+}
+
+func countKeys(t *testing.T, store kvstore.KVStore) int {
+	count := 0
+	err := store.IterateKeys(kvstore.EmptyPrefix, func(k kvstore.Key) bool {
+		count++
+
+		return true
+	})
+	require.NoError(t, err)
+
+	return count
+}

--- a/core/kvstore/kvstore.go
+++ b/core/kvstore/kvstore.go
@@ -59,7 +59,7 @@ type KVStore interface {
 	// WithRealm is a factory method for using the same underlying storage with a different realm.
 	WithRealm(realm Realm) (KVStore, error)
 
-	// WithExtended is a factory method for using the same underlying storage with an realm appended to existing one.
+	// WithExtendedRealm is a factory method for using the same underlying storage with an realm appended to existing one.
 	WithExtendedRealm(realm Realm) (KVStore, error)
 
 	// Realm returns the configured realm.


### PR DESCRIPTION
This PR adds a kvstore that wraps any other kvstore to flush changes immediately.