### PR TITLE
Fix: Potential memleak in timeutil.Sleep

### DIFF
--- a/core/timeutil/sleep.go
+++ b/core/timeutil/sleep.go
@@ -5,12 +5,17 @@ import (
 	"time"
 )
 
-func Sleep(ctx context.Context, interval time.Duration) bool {
+// Sleep pauses the current goroutine for the duration d or until the context ctx is cancelled.
+// It returns whether Sleep paused for the entire duration or was cancelled before that.
+func Sleep(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+
 	select {
 	case <-ctx.Done():
 		return false
 
-	case <-time.After(interval):
+	case <-t.C:
 		return true
 	}
 }


### PR DESCRIPTION
# Description of change

Using `time.After` creates a new timer which cannot be recovered by the garbage collector until it fires. This PR fixes this by assuring that `Timer.Stop` is always called.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
