### PR TITLE
Fix potential memory leaks through time.After

### DIFF
--- a/core/autopeering/discover/manager.go
+++ b/core/autopeering/discover/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/hive.go/core/autopeering/server"
 	"github.com/iotaledger/hive.go/core/identity"
 	"github.com/iotaledger/hive.go/core/logger"
+	"github.com/iotaledger/hive.go/core/timeutil"
 )
 
 const (
@@ -80,8 +81,8 @@ func (m *manager) loop() {
 		query     = time.NewTimer(server.ResponseTimeout) // trigger the first query after the reverify
 		queryNext chan time.Duration
 	)
-	defer reverify.Stop()
-	defer query.Stop()
+	defer timeutil.CleanupTimer(reverify)
+	defer timeutil.CleanupTimer(query)
 
 Loop:
 	for {

--- a/core/autopeering/selection/manager.go
+++ b/core/autopeering/selection/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/identity"
 	"github.com/iotaledger/hive.go/core/logger"
+	"github.com/iotaledger/hive.go/core/timeutil"
 )
 
 const (
@@ -194,7 +195,7 @@ func (m *manager) loop() {
 
 	var updateOutResultChan chan peer.PeerDistance
 	updateTimer := time.NewTimer(0) // setting this to 0 will cause a trigger right away
-	defer updateTimer.Stop()
+	defer timeutil.CleanupTimer(updateTimer)
 
 Loop:
 	for {

--- a/core/autopeering/server/server.go
+++ b/core/autopeering/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/core/identity"
 	"github.com/iotaledger/hive.go/core/logger"
 	"github.com/iotaledger/hive.go/core/netutil"
+	"github.com/iotaledger/hive.go/core/timeutil"
 )
 
 const (
@@ -176,7 +177,7 @@ func (s *Server) replyLoop() {
 		matcherList = list.New()
 		timeout     = time.NewTimer(0)
 	)
-	defer timeout.Stop()
+	defer timeutil.CleanupTimer(timeout)
 
 	<-timeout.C // ignore first timeout
 

--- a/core/syncutils/starvingmutex.go
+++ b/core/syncutils/starvingmutex.go
@@ -159,10 +159,13 @@ func (f *StarvingMutex) canWrite() bool {
 }
 
 func (f *StarvingMutex) detectDeadlock(lockType string, trace string, done chan types.Empty) {
+	timer := time.NewTimer(debug.DeadlockDetectionTimeout)
+	defer timer.Stop()
+
 	select {
 	case <-done:
 		return
-	case <-time.After(debug.DeadlockDetectionTimeout):
+	case <-timer.C:
 		fmt.Println("possible deadlock while trying to acquire " + lockType + " (" + debug.DeadlockDetectionTimeout.String() + ") ...")
 		fmt.Println("\n" + trace)
 	}

--- a/core/syncutils/starvingmutex.go
+++ b/core/syncutils/starvingmutex.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/hive.go/core/debug"
 	"github.com/iotaledger/hive.go/core/stringify"
+	"github.com/iotaledger/hive.go/core/timeutil"
 	"github.com/iotaledger/hive.go/core/types"
 )
 
@@ -160,7 +161,7 @@ func (f *StarvingMutex) canWrite() bool {
 
 func (f *StarvingMutex) detectDeadlock(lockType string, trace string, done chan types.Empty) {
 	timer := time.NewTimer(debug.DeadlockDetectionTimeout)
-	defer timer.Stop()
+	defer timeutil.CleanupTimer(timer)
 
 	select {
 	case <-done:

--- a/core/timed/queue.go
+++ b/core/timed/queue.go
@@ -184,17 +184,21 @@ func (t *Queue) Poll(waitIfEmpty bool) any {
 		// release locks
 		t.heapMutex.Unlock()
 
+		timer := time.NewTimer(time.Until(time.Time(polledElement.Key)))
+
 		// wait for the return value to become due
 		select {
 		// react if the queue was shutdown while waiting
 		case <-t.ctx.Done():
 			// abort if the pending elements are supposed to be canceled
 			if t.shutdownFlags.HasBits(CancelPendingElements) {
+				timer.Stop()
 				return nil
 			}
 
 			// immediately return the value if the pending timeouts are supposed to be ignored
 			if t.shutdownFlags.HasBits(IgnorePendingTimeouts) {
+				timer.Stop()
 				return polledElement.Value.Value
 			}
 
@@ -202,19 +206,21 @@ func (t *Queue) Poll(waitIfEmpty bool) any {
 			select {
 			// abort waiting for this element and return the next one instead if it was canceled
 			case <-polledElement.Value.cancel:
+				timer.Stop()
 				continue
 
 			// return the result after the time is reached
-			case <-time.After(time.Until(time.Time(polledElement.Key))):
+			case <-timer.C:
 				return polledElement.Value.Value
 			}
 
 		// abort waiting for this element and return the next one instead if it was canceled
 		case <-polledElement.Value.cancel:
+			timer.Stop()
 			continue
 
 		// return the result after the time is reached
-		case <-time.After(time.Until(time.Time(polledElement.Key))):
+		case <-timer.C:
 			return polledElement.Value.Value
 		}
 	}

--- a/core/timeutil/sleep.go
+++ b/core/timeutil/sleep.go
@@ -9,7 +9,7 @@ import (
 // It returns whether Sleep paused for the entire duration or was cancelled before that.
 func Sleep(ctx context.Context, d time.Duration) bool {
 	t := time.NewTimer(d)
-	defer t.Stop()
+	defer CleanupTimer(t)
 
 	select {
 	case <-ctx.Done():

--- a/core/timeutil/timeutil.go
+++ b/core/timeutil/timeutil.go
@@ -1,0 +1,12 @@
+package timeutil
+
+import "time"
+
+// CleanupTimer stops the timer and drains the Timer's channel.
+// This cannot be done concurrent to other receives from the Timer's
+// channel or other calls to the Timer's Stop method.
+func CleanupTimer(t *time.Timer) {
+	if !t.Stop() {
+		<-t.C
+	}
+}

--- a/core/workerpool/task.go
+++ b/core/workerpool/task.go
@@ -69,10 +69,13 @@ func (t *WorkerPoolTask) markDone() {
 
 // detectedHangingTasks is a debug method that is used to print information about possibly hanging task executions.
 func (t *WorkerPoolTask) detectedHangingTasks() {
+	timer := time.NewTimer(debug.DeadlockDetectionTimeout)
+	defer timer.Stop()
+
 	select {
 	case <-t.doneChan:
 		return
-	case <-time.After(debug.DeadlockDetectionTimeout):
+	case <-timer.C:
 		fmt.Println("task in workerpool seems to hang (" + debug.DeadlockDetectionTimeout.String() + ") ...")
 		fmt.Println("\n" + strings.Replace(strings.Replace(t.stackTrace, "closure:", "task:", 1), "called by", "queued by", 1))
 	}

--- a/core/workerpool/task.go
+++ b/core/workerpool/task.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/hive.go/core/debug"
+	"github.com/iotaledger/hive.go/core/timeutil"
 	"github.com/iotaledger/hive.go/core/types"
 )
 
@@ -70,7 +71,7 @@ func (t *WorkerPoolTask) markDone() {
 // detectedHangingTasks is a debug method that is used to print information about possibly hanging task executions.
 func (t *WorkerPoolTask) detectedHangingTasks() {
 	timer := time.NewTimer(debug.DeadlockDetectionTimeout)
-	defer timer.Stop()
+	defer timeutil.CleanupTimer(timer)
 
 	select {
 	case <-t.doneChan:


### PR DESCRIPTION
# Description of change

This PR fixes some potential memory leaks through the usage of `time.After` without cancelling when abort without the timer firing (see [here.](https://segmentfault.com/a/1190000040105436/en))

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

