### PR TITLE
Event.Attach with worker pool

### DIFF
--- a/core/generics/event/event.go
+++ b/core/generics/event/event.go
@@ -50,6 +50,16 @@ func (e *Event[T]) AttachWithNewWorkerPool(closure *Closure[T], workers int, tri
 	return wp
 }
 
+// AttachWithWorkerPool allows to register a Closure that is executed asynchronously in the specified worker pool when the Event triggers.
+// If 'triggerMaxCount' is >0, the Closure is automatically detached after exceeding the trigger limit.
+func (e *Event[T]) AttachWithWorkerPool(closure *Closure[T], wp *workerpool.UnboundedWorkerPool, triggerMaxCount ...uint64) {
+	if closure == nil {
+		return
+	}
+
+	e.asyncHandlers.Set(closure.ID, newHandler[T](e.callbackFromClosure(closure, triggerMaxCount...), wp))
+}
+
 // HookBefore allows to register a Closure that is executed before the Event triggers.
 // If 'triggerMaxCount' is >0, the Closure is automatically detached after exceeding the trigger limit.
 func (e *Event[T]) HookBefore(closure *Closure[T], triggerMaxCount ...uint64) {

--- a/core/generics/event/event.go
+++ b/core/generics/event/event.go
@@ -37,15 +37,16 @@ func (e *Event[T]) Attach(closure *Closure[T], triggerMaxCount ...uint64) {
 	e.asyncHandlers.Set(closure.ID, newHandler[T](e.callbackFromClosure(closure, triggerMaxCount...), Loop))
 }
 
-// AttachWithWorkerPool allows to register a Closure that is executed asynchronously in a separate, newly created worker pool when the Event triggers.
+// AttachWithNewWorkerPool allows to register a Closure that is executed asynchronously in a separate, newly created worker pool when the Event triggers.
 // If 'triggerMaxCount' is >0, the Closure is automatically detached after exceeding the trigger limit.
-func (e *Event[T]) AttachWithWorkerPool(closure *Closure[T], workers int, triggerMaxCount ...uint64) *workerpool.UnboundedWorkerPool {
+func (e *Event[T]) AttachWithNewWorkerPool(closure *Closure[T], workers int, triggerMaxCount ...uint64) *workerpool.UnboundedWorkerPool {
 	if closure == nil {
 		return nil
 	}
 
 	wp := workerpool.NewUnboundedWorkerPool(workers)
 	e.asyncHandlers.Set(closure.ID, newHandler[T](e.callbackFromClosure(closure, triggerMaxCount...), wp))
+	wp.Start()
 	return wp
 }
 

--- a/core/generics/event/handler.go
+++ b/core/generics/event/handler.go
@@ -1,0 +1,15 @@
+package event
+
+import "github.com/iotaledger/hive.go/core/workerpool"
+
+type handler[T any] struct {
+	callback func(T)
+	wp       *workerpool.UnboundedWorkerPool
+}
+
+func newHandler[T any](callback func(T), wp *workerpool.UnboundedWorkerPool) *handler[T] {
+	return &handler[T]{
+		callback: callback,
+		wp:       wp,
+	}
+}

--- a/core/generics/event/loop.go
+++ b/core/generics/event/loop.go
@@ -4,8 +4,6 @@ import (
 	"github.com/iotaledger/hive.go/core/workerpool"
 )
 
-const loopQueueSize = 100000
-
 var Loop *workerpool.UnboundedWorkerPool
 
 func init() {


### PR DESCRIPTION
Add attach with worker pool functionality so that different components can attach with distinct worker pools. The standard `Attach` method still uses the global worker pool by default. Specific components can make use of this to lower contention on the global worker pool.