### PR TITLE
Add InvalidateBytesCache to Storable

### DIFF
--- a/core/generics/model/storable.go
+++ b/core/generics/model/storable.go
@@ -155,6 +155,11 @@ func (s *Storable[IDType, OuterModelType, OuterModelPtrType, InnerModelType]) By
 	return encodedBytes, err
 }
 
+// InvalidateBytesCache invalidates the bytes cache.
+func (s *Storable[IDType, OuterModelType, OuterModelPtrType, InnerModelType]) InvalidateBytesCache() {
+	s.bytes = nil
+}
+
 // FromObjectStorage deserializes a model from the object storage.
 func (s *Storable[IDType, OuterModelType, OuterModelPtrType, InnerModelType]) FromObjectStorage(key, data []byte) (err error) {
 	if _, err = s.FromBytes(data); err != nil {


### PR DESCRIPTION
Add InvalidateBytesCache method to Storable to be able to invalidate the bytes cache after a Storable was modified but the bytes already calculated. For example, this happens on block creation: we need to compute the bytes to be able to create the signature. However, then we need to set the signature and subsequent serialization needs to take the modified Storable object, including signature into account.