### PR TITLE
Catch shutdown signals during provide stage

### DIFF
--- a/app/components/shutdown/component.go
+++ b/app/components/shutdown/component.go
@@ -10,42 +10,37 @@ import (
 func init() {
 	CoreComponent = &app.CoreComponent{
 		Component: &app.Component{
-			Name:      "Shutdown",
-			Provide:   provide,
-			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
-			Params:    params,
-			Configure: configure,
+			Name:    "Shutdown",
+			Provide: provide,
+			Params:  params,
 		},
 	}
 }
 
 var (
 	CoreComponent *app.CoreComponent
-	deps          dependencies
 )
-
-type dependencies struct {
-	dig.In
-	ShutdownHandler *shutdown.ShutdownHandler
-}
 
 func provide(c *dig.Container) error {
 
-	if err := c.Provide(func() *shutdown.ShutdownHandler {
-		return shutdown.NewShutdownHandler(
+	if err := c.Provide(func() (*shutdown.ShutdownHandler, error) {
+		handler := shutdown.NewShutdownHandler(
 			CoreComponent.Logger(),
 			CoreComponent.Daemon(),
 			shutdown.WithStopGracePeriod(ParamsShutdown.StopGracePeriod),
 			shutdown.WithSelfShutdownLogsEnabled(ParamsShutdown.Log.Enabled),
 			shutdown.WithSelfShutdownLogsFilePath(ParamsShutdown.Log.FilePath),
 		)
+
+		// start the handler to be able to catch shutdown signals during the provide stage
+		if err := handler.Run(); err != nil {
+			return nil, err
+		}
+
+		return handler, nil
 	}); err != nil {
 		CoreComponent.LogPanic(err)
 	}
 
 	return nil
-}
-
-func configure() error {
-	return deps.ShutdownHandler.Run()
 }


### PR DESCRIPTION
The shutdown handler was started in the configure stage.

All shutdown signals were ignored in the provide stage of the app, which lead to long running shutdowns if for example the NodeBridge tries to connect to a node in the provide stage, which is not available.

This PR changes the behaviour and starts the shutdown handler immediately. 

![image](https://user-images.githubusercontent.com/32371094/223152958-31df0844-c3fc-43b0-80b5-f4a2da185669.png)
