### PR TITLE
Fix: Renamed constructor of AdvancedSet

### DIFF
--- a/ds/advancedset/advancedset.go
+++ b/ds/advancedset/advancedset.go
@@ -17,8 +17,8 @@ type AdvancedSet[T comparable] struct {
 	orderedmap.OrderedMap[T, types.Empty] `serix:"0"`
 }
 
-// NewAdvancedSet creates a new AdvancedSet with given elements.
-func NewAdvancedSet[T comparable](elements ...T) *AdvancedSet[T] {
+// New creates a new AdvancedSet with given elements.
+func New[T comparable](elements ...T) *AdvancedSet[T] {
 	a := &AdvancedSet[T]{*orderedmap.New[T, types.Empty]()}
 	for _, element := range elements {
 		a.Set(element, types.Void)
@@ -50,7 +50,7 @@ func (t *AdvancedSet[T]) AddAll(elements *AdvancedSet[T]) (added bool) {
 
 // DeleteAll deletes given elements from the set.
 func (t *AdvancedSet[T]) DeleteAll(other *AdvancedSet[T]) (removedElements *AdvancedSet[T]) {
-	removedElements = NewAdvancedSet[T]()
+	removedElements = New[T]()
 	_ = other.ForEach(func(element T) (err error) {
 		if t.Delete(element) {
 			removedElements.Add(element)
@@ -98,7 +98,7 @@ func (t *AdvancedSet[T]) Intersect(other *AdvancedSet[T]) (intersection *Advance
 
 // Filter returns a new set that contains all elements that satisfy the given predicate.
 func (t *AdvancedSet[T]) Filter(predicate func(element T) bool) (filtered *AdvancedSet[T]) {
-	filtered = NewAdvancedSet[T]()
+	filtered = New[T]()
 	_ = t.ForEach(func(element T) (err error) {
 		if predicate(element) {
 			filtered.Add(element)
@@ -132,7 +132,7 @@ func (t *AdvancedSet[T]) Is(element T) bool {
 
 // Clone returns a new set that contains the same elements as the original set.
 func (t *AdvancedSet[T]) Clone() (cloned *AdvancedSet[T]) {
-	cloned = NewAdvancedSet[T]()
+	cloned = New[T]()
 	cloned.AddAll(t)
 
 	return cloned

--- a/ds/advancedset/advancedset_test.go
+++ b/ds/advancedset/advancedset_test.go
@@ -127,7 +127,7 @@ func TestAdvancedSet_Slice(t *testing.T) {
 	setSlice := set.Slice()
 
 	require.Equal(t, set.Size(), len(setSlice), "length should be equal")
-	require.True(t, NewAdvancedSet(setSlice...).Equal(set), "sets should be equal")
+	require.True(t, New(setSlice...).Equal(set), "sets should be equal")
 }
 
 func TestAdvancedSet_Iterator(t *testing.T) {
@@ -175,7 +175,7 @@ func TestAdvancedSet_Encoding(t *testing.T) {
 }
 
 func initAdvancedSet(count int, start int) *AdvancedSet[string] {
-	set := NewAdvancedSet[string]()
+	set := New[string]()
 	end := start + count
 	for i := start; i < end; i++ {
 		set.Add(fmt.Sprintf("item%d", i))


### PR DESCRIPTION
# Description of change

This PR fixes a naming issue of the AdvancedSet constructor.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
