### PR TITLE
Parents callback for CausalOrderer

### DIFF
--- a/core/causalorder/testframework_test.go
+++ b/core/causalorder/testframework_test.go
@@ -72,6 +72,9 @@ func NewTestFramework(test *testing.T, workers *workerpool.Group, opts ...option
 				t.evictedEntities[entity.id.alias] = entity
 				t.evictedEntitiesMutex.Unlock()
 			},
+			func(entity *MockedOrderedEntity) (parents []MockedEntityID) {
+				return entity.Parents()
+			},
 			WithReferenceValidator[MockedEntityID](func(entity, parent *MockedOrderedEntity) (err error) {
 				if entity.IsInvalid() {
 					return errors.Errorf("entity %s is invalid", entity.id.alias)


### PR DESCRIPTION
# Description of change

This PR introduces a callback to retrieve entity's parents, instead of always using `.Parents()`  method, as this is not flexible enough.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
