### PR TITLE
Feat: Add support for Slice() calls on nil AdvancedSets

### DIFF
--- a/ds/advancedset/advancedset.go
+++ b/ds/advancedset/advancedset.go
@@ -131,11 +131,14 @@ func (t *AdvancedSet[T]) Clone() (cloned *AdvancedSet[T]) {
 // Slice returns a slice of all elements in the set.
 func (t *AdvancedSet[T]) Slice() (slice []T) {
 	slice = make([]T, 0)
-	_ = t.ForEach(func(element T) error {
-		slice = append(slice, element)
 
-		return nil
-	})
+	if t != nil {
+		_ = t.ForEach(func(element T) error {
+			slice = append(slice, element)
+
+			return nil
+		})
+	}
 
 	return slice
 }


### PR DESCRIPTION
# Description of change

This PR introduces the ability to call Slice() on an AdvancedSet that is nil.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
