### PR TITLE
Feat: Allow use of nil AdvancedSet for iterations and membership checks

### DIFF
--- a/ds/advancedset/advancedset.go
+++ b/ds/advancedset/advancedset.go
@@ -29,6 +29,10 @@ func New[T comparable](elements ...T) *AdvancedSet[T] {
 
 // IsEmpty returns true if the set is empty.
 func (t *AdvancedSet[T]) IsEmpty() (empty bool) {
+	if t == nil {
+		return true
+	}
+
 	return t.OrderedMap.Size() == 0
 }
 
@@ -69,6 +73,10 @@ func (t *AdvancedSet[T]) Delete(element T) (deleted bool) {
 
 // HasAll returns true if all given elements are present in the set.
 func (t *AdvancedSet[T]) HasAll(other *AdvancedSet[T]) (hasAll bool) {
+	if t == nil {
+		return false
+	}
+
 	return other.ForEach(func(element T) error {
 		if !t.Has(element) {
 			return errors.New("element not found")
@@ -80,6 +88,10 @@ func (t *AdvancedSet[T]) HasAll(other *AdvancedSet[T]) (hasAll bool) {
 
 // ForEach iterates through the set and calls the callback for every element.
 func (t *AdvancedSet[T]) ForEach(callback func(element T) (err error)) (err error) {
+	if t == nil {
+		return nil
+	}
+
 	t.OrderedMap.ForEach(func(element T, _ types.Empty) bool {
 		if err = callback(element); err != nil {
 			return false


### PR DESCRIPTION
# Description of change

This PR allows to use the ForEach method of AdvancedSets that are "nil", without panicing.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
