### PR TITLE
Feat: Add Range method to AdvancedSet (#504

### DIFF
--- a/ds/advancedset/advancedset.go
+++ b/ds/advancedset/advancedset.go
@@ -29,6 +29,10 @@ func New[T comparable](elements ...T) *AdvancedSet[T] {
 
 // IsEmpty returns true if the set is empty.
 func (t *AdvancedSet[T]) IsEmpty() (empty bool) {
+	if t == nil {
+		return true
+	}
+
 	return t.OrderedMap.Size() == 0
 }
 
@@ -69,6 +73,10 @@ func (t *AdvancedSet[T]) Delete(element T) (deleted bool) {
 
 // HasAll returns true if all given elements are present in the set.
 func (t *AdvancedSet[T]) HasAll(other *AdvancedSet[T]) (hasAll bool) {
+	if t == nil {
+		return false
+	}
+
 	return other.ForEach(func(element T) error {
 		if !t.Has(element) {
 			return errors.New("element not found")
@@ -80,6 +88,10 @@ func (t *AdvancedSet[T]) HasAll(other *AdvancedSet[T]) (hasAll bool) {
 
 // ForEach iterates through the set and calls the callback for every element.
 func (t *AdvancedSet[T]) ForEach(callback func(element T) (err error)) (err error) {
+	if t == nil {
+		return nil
+	}
+
 	t.OrderedMap.ForEach(func(element T, _ types.Empty) bool {
 		if err = callback(element); err != nil {
 			return false

--- a/ds/advancedset/advancedset.go
+++ b/ds/advancedset/advancedset.go
@@ -87,7 +87,7 @@ func (t *AdvancedSet[T]) HasAll(other *AdvancedSet[T]) (hasAll bool) {
 }
 
 // ForEach iterates through the set and calls the callback for every element.
-func (t *AdvancedSet[T]) ForEach(callback func(element T) (err error)) (err error) {
+func (t *AdvancedSet[T]) ForEach(callback func(element T) error) (err error) {
 	if t == nil {
 		return nil
 	}
@@ -101,6 +101,17 @@ func (t *AdvancedSet[T]) ForEach(callback func(element T) (err error)) (err erro
 	})
 
 	return err
+}
+
+// Range iterates through the set and calls the callback for every element (without individual error handling).
+func (t *AdvancedSet[T]) Range(callback func(element T)) {
+	if t != nil {
+		t.OrderedMap.ForEach(func(element T, _ types.Empty) bool {
+			callback(element)
+
+			return true
+		})
+	}
 }
 
 // Intersect returns a new set that contains all elements that are present in both sets.


### PR DESCRIPTION
# Description of change

This PR adds a Range method to the AdvancedSet which allows to range over all elements without having to deal with possible errors.

```
mySet.Range(func(element T) {
    doSth(element)
})
```

instead of:

```
_ = mySet.ForEach(func(element T) errror {
    doSth(element)

    return nil
})
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
