### PR TITLE
Enable use of FakeRWMutex through a buildtag

### DIFF
--- a/runtime/syncutils/mutex.go
+++ b/runtime/syncutils/mutex.go
@@ -11,5 +11,5 @@ type Mutex = sync.Mutex
 type RWMutex = sync.RWMutex
 
 func init() {
-	fmt.Println(">>>> use fake mutex")
+	fmt.Println(">>>> use real mutex")
 }

--- a/runtime/syncutils/mutex.go
+++ b/runtime/syncutils/mutex.go
@@ -1,11 +1,15 @@
-//go:build !deadlock
-// +build !deadlock
+//go:build !deadlock && !fake
 
 package syncutils
 
 import (
+	"fmt"
 	"sync"
 )
 
 type Mutex = sync.Mutex
 type RWMutex = sync.RWMutex
+
+func init() {
+	fmt.Println(">>>> use fake mutex")
+}

--- a/runtime/syncutils/mutex.go
+++ b/runtime/syncutils/mutex.go
@@ -3,13 +3,8 @@
 package syncutils
 
 import (
-	"fmt"
 	"sync"
 )
 
 type Mutex = sync.Mutex
 type RWMutex = sync.RWMutex
-
-func init() {
-	fmt.Println(">>>> use real mutex")
-}

--- a/runtime/syncutils/mutex.go
+++ b/runtime/syncutils/mutex.go
@@ -1,4 +1,4 @@
-//go:build !deadlock && !fake
+//go:build !deadlock && !fakemutex
 
 package syncutils
 

--- a/runtime/syncutils/mutex_deadlock.go
+++ b/runtime/syncutils/mutex_deadlock.go
@@ -4,14 +4,16 @@
 package syncutils
 
 import (
+	"fmt"
 	"time"
 
-	deadlock "github.com/sasha-s/go-deadlock"
+	"github.com/sasha-s/go-deadlock"
 )
 
 type Mutex = deadlock.Mutex
 type RWMutex = deadlock.RWMutex
 
 func init() {
+	fmt.Println(">>>> use deadlock mutex")
 	deadlock.Opts.DeadlockTimeout = time.Duration(20 * time.Second)
 }

--- a/runtime/syncutils/mutex_deadlock.go
+++ b/runtime/syncutils/mutex_deadlock.go
@@ -4,7 +4,6 @@
 package syncutils
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/sasha-s/go-deadlock"
@@ -14,6 +13,5 @@ type Mutex = deadlock.Mutex
 type RWMutex = deadlock.RWMutex
 
 func init() {
-	fmt.Println(">>>> use deadlock mutex")
 	deadlock.Opts.DeadlockTimeout = time.Duration(20 * time.Second)
 }

--- a/runtime/syncutils/mutex_fake.go
+++ b/runtime/syncutils/mutex_fake.go
@@ -1,5 +1,4 @@
 //go:build fakemutex
-// +build fakemutex
 
 package syncutils
 

--- a/runtime/syncutils/mutex_fake.go
+++ b/runtime/syncutils/mutex_fake.go
@@ -1,0 +1,15 @@
+//go:build fake
+// +build fake
+
+package syncutils
+
+import (
+	"github.com/iotaledger/hive.go/runtime/syncutils"
+)
+
+type Mutex = syncutils.RWMutexFake
+type RWMutex = syncutils.RWMutexFake
+
+func init() {
+	fmt.Println(">>>> use fake mutex")
+}

--- a/runtime/syncutils/mutex_fake.go
+++ b/runtime/syncutils/mutex_fake.go
@@ -3,12 +3,10 @@
 
 package syncutils
 
-import (
-	"github.com/iotaledger/hive.go/runtime/syncutils"
-)
+import "fmt"
 
-type Mutex = syncutils.RWMutexFake
-type RWMutex = syncutils.RWMutexFake
+type Mutex = RWMutexFake
+type RWMutex = RWMutexFake
 
 func init() {
 	fmt.Println(">>>> use fake mutex")

--- a/runtime/syncutils/mutex_fake.go
+++ b/runtime/syncutils/mutex_fake.go
@@ -1,5 +1,5 @@
-//go:build fake
-// +build fake
+//go:build fakemutex
+// +build fakemutex
 
 package syncutils
 

--- a/runtime/syncutils/mutex_fake.go
+++ b/runtime/syncutils/mutex_fake.go
@@ -3,11 +3,5 @@
 
 package syncutils
 
-import "fmt"
-
 type Mutex = RWMutexFake
 type RWMutex = RWMutexFake
-
-func init() {
-	fmt.Println(">>>> use fake mutex")
-}

--- a/runtime/syncutils/rwmutexfake.go
+++ b/runtime/syncutils/rwmutexfake.go
@@ -1,6 +1,8 @@
 package syncutils
 
-import "sync"
+import (
+	"sync"
+)
 
 type RWMutexFake struct {
 	sync.RWMutex


### PR DESCRIPTION
# Description of change

FakeRWMutex can and should be used as a drop-in replacement for a regular mutex through the use of a `fakemutex` buildtag. Alternatively `deadlock` tag can be used to use a deadlock detection mutex. If neither tag is specified, a real `sync.Mutex/RWMutex` is used.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
