### PR TITLE
Add `ierrors` pkg as a wrapper around the stdlib

### DIFF
--- a/ierrors/errors.go
+++ b/ierrors/errors.go
@@ -1,0 +1,90 @@
+// ierrors package provides a wrapper around the "errors" package from the standard library of Go.
+// It enhances error handling by adding additional error creation and manipulation functions.
+// This package also supports stacktraces when the "stacktrace" build tag is added.
+package ierrors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// New returns an error that formats as the given text.
+// Each call to New returns a distinct error value even if the text is identical.
+func New(text string) error {
+	return errors.New(text)
+}
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// If the format specifier includes a %w verb with an error operand,
+// the returned error will implement an Unwrap method returning the operand.
+// If there is more than one %w verb, the returned error will implement an
+// Unwrap method returning a []error containing all the %w operands in the
+// order they appear in the arguments.
+// It is invalid to supply the %w verb with an operand that does not implement
+// the error interface. The %w verb is otherwise a synonym for %v.
+func Errorf(format string, a ...any) error {
+	return fmt.Errorf(format, a...)
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+//
+// Unwrap returns nil if the Unwrap method returns []error.
+func Unwrap(err error) error {
+	return errors.Unwrap(err)
+}
+
+// Is reports whether any error in err's tree matches target.
+//
+// The tree consists of err itself, followed by the errors obtained by repeatedly
+// calling Unwrap. When err wraps multiple errors, Is examines err followed by a
+// depth-first traversal of its children.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+//
+// An error type might provide an Is method so it can be treated as equivalent
+// to an existing error. For example, if MyError defines
+//
+//	func (m MyError) Is(target error) bool { return target == fs.ErrExist }
+//
+// then Is(MyError{}, fs.ErrExist) returns true. See syscall.Errno.Is for
+// an example in the standard library. An Is method should only shallowly
+// compare err and the target and not call Unwrap on either.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As finds the first error in err's tree that matches target, and if one is found, sets
+// target to that error value and returns true. Otherwise, it returns false.
+//
+// The tree consists of err itself, followed by the errors obtained by repeatedly
+// calling Unwrap. When err wraps multiple errors, As examines err followed by a
+// depth-first traversal of its children.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// An error type might provide an As method so it can be treated as if it were a
+// different error type.
+//
+// As panics if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type.
+func As(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if errs contains no non-nil values.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+func Join(errs ...error) error {
+	return errors.Join(errs...)
+}

--- a/ierrors/go.mod
+++ b/ierrors/go.mod
@@ -1,0 +1,3 @@
+module github.com/iotaledger/hive.go/ierrors
+
+go 1.20

--- a/ierrors/wrap.go
+++ b/ierrors/wrap.go
@@ -1,0 +1,17 @@
+//go:build !stacktrace
+
+package ierrors
+
+import (
+	"fmt"
+)
+
+// Wrapf annotates an error with a message.
+func Wrap(err error, message string) error {
+	return fmt.Errorf("%w: %s", err, message)
+}
+
+// Wrapf annotates an error with a message format specifier and arguments.
+func Wrapf(err error, format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", err, fmt.Sprintf(format, args...))
+}

--- a/ierrors/wrap_stacktrace.go
+++ b/ierrors/wrap_stacktrace.go
@@ -1,0 +1,42 @@
+//go:build stacktrace
+// +build stacktrace
+
+package ierrors
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func stacktrace() string {
+	var result string
+
+	var programCounter [32]uintptr
+	entries := runtime.Callers(3, programCounter[:])
+	frames := runtime.CallersFrames(programCounter[:entries])
+	for {
+		frame, more := frames.Next()
+		if (frame == runtime.Frame{}) {
+			break
+		}
+
+		result = fmt.Sprintf("%s%s\n\t%s:%d\n", result, frame.Function, frame.File, frame.Line)
+		if !more {
+			// remove last newline
+			result = result[:len(result)-1]
+			break
+		}
+	}
+
+	return result
+}
+
+// Wrap annotates an error with a message and a stacktrace.
+func Wrap(err error, message string) error {
+	return fmt.Errorf("%w: %s\n%s", err, message, stacktrace())
+}
+
+// Wrapf annotates an error with a message format specifier, arguments and a stacktrace.
+func Wrapf(err error, format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s\n%s", err, fmt.Sprintf(format, args...), stacktrace())
+}


### PR DESCRIPTION
We use 4 different error packages in the codebase.
This wrapper uses the stdlib `errors` package, but adds some useful functions.

If compiled with the tag `stacktrace`, stacktraces will be added to the `Wrap` and `Wrapf` method.