### PR TITLE
Add `ierrors` pkg as a wrapper around the stdlib

### DIFF
--- a/ierrors/go.mod
+++ b/ierrors/go.mod
@@ -1,0 +1,11 @@
+module github.com/iotaledger/hive.go/ierrors
+
+go 1.20
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/ierrors/go.sum
+++ b/ierrors/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ierrors/ierrors.go
+++ b/ierrors/ierrors.go
@@ -1,0 +1,75 @@
+// ierrors package provides a wrapper around the "errors" package from the standard library of Go.
+// It enhances error handling by adding additional error creation and manipulation functions.
+// This package also supports stacktraces when the "stacktrace" build tag is added.
+package ierrors
+
+import (
+	"errors"
+)
+
+// New returns an error that formats as the given text.
+// Each call to New returns a distinct error value even if the text is identical.
+func New(text string) error {
+	return errors.New(text)
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+//
+// Unwrap returns nil if the Unwrap method returns []error.
+func Unwrap(err error) error {
+	return errors.Unwrap(err)
+}
+
+// Is reports whether any error in err's tree matches target.
+//
+// The tree consists of err itself, followed by the errors obtained by repeatedly
+// calling Unwrap. When err wraps multiple errors, Is examines err followed by a
+// depth-first traversal of its children.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+//
+// An error type might provide an Is method so it can be treated as equivalent
+// to an existing error. For example, if MyError defines
+//
+//	func (m MyError) Is(target error) bool { return target == fs.ErrExist }
+//
+// then Is(MyError{}, fs.ErrExist) returns true. See syscall.Errno.Is for
+// an example in the standard library. An Is method should only shallowly
+// compare err and the target and not call Unwrap on either.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As finds the first error in err's tree that matches target, and if one is found, sets
+// target to that error value and returns true. Otherwise, it returns false.
+//
+// The tree consists of err itself, followed by the errors obtained by repeatedly
+// calling Unwrap. When err wraps multiple errors, As examines err followed by a
+// depth-first traversal of its children.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// An error type might provide an As method so it can be treated as if it were a
+// different error type.
+//
+// As panics if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type.
+func As(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+// Join returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// Join returns nil if errs contains no non-nil values.
+// The error formats as the concatenation of the strings obtained
+// by calling the Error method of each element of errs, with a newline
+// between each string.
+func Join(errs ...error) error {
+	return errors.Join(errs...)
+}

--- a/ierrors/ierrors_no_stacktrace.go
+++ b/ierrors/ierrors_no_stacktrace.go
@@ -1,0 +1,43 @@
+//go:build !stacktrace
+
+package ierrors
+
+import (
+	"fmt"
+)
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// If the format specifier includes a %w verb with an error operand,
+// the returned error will implement an Unwrap method returning the operand.
+// If there is more than one %w verb, the returned error will implement an
+// Unwrap method returning a []error containing all the %w operands in the
+// order they appear in the arguments.
+// It is invalid to supply the %w verb with an operand that does not implement
+// the error interface. The %w verb is otherwise a synonym for %v.
+// Errorf adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Errorf(format string, args ...any) error {
+	return fmt.Errorf(format, args...)
+}
+
+// Wrap annotates an error with a message.
+// Wrap adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Wrap(err error, message string) error {
+	return fmt.Errorf("%w: %s", err, message)
+}
+
+// Wrapf annotates an error with a message format specifier and arguments.
+// Wrapf adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Wrapf(err error, format string, args ...interface{}) error {
+	return fmt.Errorf("%w: %s", err, fmt.Sprintf(format, args...))
+}
+
+// WithStack adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func WithStack(err error) error {
+	return err
+}

--- a/ierrors/ierrors_stacktrace.go
+++ b/ierrors/ierrors_stacktrace.go
@@ -1,0 +1,118 @@
+//go:build stacktrace
+// +build stacktrace
+
+package ierrors
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+func stacktrace() string {
+	var stack string
+
+	var programCounter [32]uintptr
+	entries := runtime.Callers(4, programCounter[:])
+	frames := runtime.CallersFrames(programCounter[:entries])
+	for {
+		frame, more := frames.Next()
+		if (frame == runtime.Frame{}) {
+			break
+		}
+
+		stack = fmt.Sprintf("%s%s\n\t%s:%d\n", stack, frame.Function, frame.File, frame.Line)
+		if !more {
+			// remove last newline
+			stack = stack[:len(stack)-1]
+			break
+		}
+	}
+
+	return stack
+}
+
+// errorWithStacktrace is an implementation of an error with a stacktrace.
+type errorWithStacktrace struct {
+	err        error
+	stacktrace string
+}
+
+func (e *errorWithStacktrace) Error() string {
+	return fmt.Sprintf("%s\n%s", e.err.Error(), e.stacktrace)
+}
+
+func (e *errorWithStacktrace) Unwrap() error {
+	return e.err
+}
+
+func newErrorWithStacktrace(err error, stacktrace string) *errorWithStacktrace {
+	return &errorWithStacktrace{
+		err:        err,
+		stacktrace: stacktrace,
+	}
+}
+
+// ensureStacktraceUniqueness checks if the given error
+// already contains a stacktrace in it's error tree.
+// if yes, it simply returns the err.
+// if not, it returns a new error with a stacktrace appended.
+func ensureStacktraceUniqueness(err error) error {
+	var errWithStacktrace *errorWithStacktrace
+	if errors.As(err, &errWithStacktrace) {
+		return err
+	}
+
+	return newErrorWithStacktrace(err, stacktrace())
+}
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// If the format specifier includes a %w verb with an error operand,
+// the returned error will implement an Unwrap method returning the operand.
+// If there is more than one %w verb, the returned error will implement an
+// Unwrap method returning a []error containing all the %w operands in the
+// order they appear in the arguments.
+// It is invalid to supply the %w verb with an operand that does not implement
+// the error interface. The %w verb is otherwise a synonym for %v.
+// Errorf adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Errorf(format string, args ...any) error {
+	// check if the error tree already contains an error with a stacktrace
+	return ensureStacktraceUniqueness(fmt.Errorf(format, args...))
+}
+
+// Wrap annotates an error with a message.
+// Wrap adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Wrap(err error, message string) error {
+	return ensureStacktraceUniqueness(fmt.Errorf("%w: %s", err, message))
+}
+
+// Wrapf annotates an error with a message format specifier and arguments.
+// Wrapf adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func Wrapf(err error, format string, args ...interface{}) error {
+	// check if the passed args also contain an error
+	containsErr := false
+	for _, arg := range args {
+		if _, ok := arg.(error); ok {
+			containsErr = true
+			break
+		}
+	}
+
+	if containsErr {
+		// wrap the other errors as well
+		return ensureStacktraceUniqueness(fmt.Errorf("%w: %s", err, fmt.Errorf(format, args...)))
+	}
+
+	return ensureStacktraceUniqueness(fmt.Errorf("%w: %s", err, fmt.Sprintf(format, args...)))
+}
+
+// WithStack adds a stacktrace to the error if there was no stacktrace
+// in the error tree yet and if the build flag "stacktrace" is set.
+func WithStack(err error) error {
+	return ensureStacktraceUniqueness(err)
+}

--- a/ierrors/ierrors_stacktrace_test.go
+++ b/ierrors/ierrors_stacktrace_test.go
@@ -1,0 +1,48 @@
+//go:build stacktrace
+// +build stacktrace
+
+package ierrors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrors(t *testing.T) {
+	var errWithStacktrace *errorWithStacktrace
+
+	// check that there is no stacktrace included
+	err1 := New("err1")
+	require.False(t, Is(err1, &errorWithStacktrace{}))
+
+	// check that there is a stacktrace included
+	err2 := Errorf("err%d", 2)
+	require.ErrorAs(t, err2, &errWithStacktrace)
+
+	err3 := Wrap(err1, "err3")
+	require.ErrorAs(t, err3, &errWithStacktrace)
+
+	err4 := Wrapf(err1, "%s", "err4")
+	require.ErrorAs(t, err4, &errWithStacktrace)
+
+	err5 := WithStack(err1)
+	require.ErrorAs(t, err5, &errWithStacktrace)
+
+	// check that there is no duplicated stacktrace included
+	errStacktrace := WithStack(New("errStacktrace"))
+	require.Equal(t, 1, strings.Count(errStacktrace.Error(), "github.com/iotaledger/hive.go/ierrors.TestErrors"))
+
+	err6 := Errorf("err%d: %w", 6, errStacktrace)
+	require.Equal(t, 1, strings.Count(err6.Error(), "github.com/iotaledger/hive.go/ierrors.TestErrors"))
+
+	err7 := Wrap(errStacktrace, "err7")
+	require.Equal(t, 1, strings.Count(err7.Error(), "github.com/iotaledger/hive.go/ierrors.TestErrors"))
+
+	err8 := Wrapf(errStacktrace, "%s", "err8")
+	require.Equal(t, 1, strings.Count(err8.Error(), "github.com/iotaledger/hive.go/ierrors.TestErrors"))
+
+	err9 := WithStack(errStacktrace)
+	require.Equal(t, 1, strings.Count(err9.Error(), "github.com/iotaledger/hive.go/ierrors.TestErrors"))
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,4 +4,4 @@ set -euxo pipefail
 go version
 go clean -testcache
 
-find . -name go.mod -print0 |  xargs -0 -n1 dirname | xargs -t -n1 -I {} bash -c 'set -euxo pipefail && cd "{}" && go test ./...'
+find . -name go.mod -print0 |  xargs -0 -n1 dirname | xargs -t -n1 -I {} bash -c 'set -euxo pipefail && cd "{}" && go test -tags stacktrace ./...'


### PR DESCRIPTION
We use 4 different error packages in the codebase.
This wrapper uses the stdlib `errors` package, but adds some useful functions.

If compiled with the tag `stacktrace`, stacktraces will be added to the `Errorf`, `Wrap`, `Wrapf` and `WithStack` method.