### PR TITLE
Add safe math module

### DIFF
--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -47,6 +47,21 @@ func SafeSub[T Integer](x T, y T) (T, error) {
 	return result, nil
 }
 
+// Returns x * y or an error if that computation would under- or overflow.
+func SafeMul[T Integer](x T, y T) (T, error) {
+	if x == 0 || y == 0 {
+		return 0, nil
+	}
+
+	result := x * y
+
+	if result/x != y {
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+	}
+
+	return result, nil
+}
+
 // Returns x * y or an error if that computation would overflow.
 //
 // According to benchmarks, this function is about 73% faster than SafeMul.
@@ -155,21 +170,6 @@ func SafeMulInt64(x, y int64) (int64, error) {
 	}
 
 	return loSigned, nil
-}
-
-// Returns x * y or an error if that computation would under- or overflow.
-func SafeMul[T Integer](x T, y T) (T, error) {
-	if x == 0 || y == 0 {
-		return 0, nil
-	}
-
-	result := x * y
-
-	if result/x != y {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
-	}
-
-	return result, nil
 }
 
 // Returns x / y or an error if that computation would cause a division by zero.

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -23,10 +23,10 @@ func SafeAdd[T Integer](x T, y T) (T, error) {
 
 	if y > 0 {
 		if result < x {
-			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d + %d", x, y)
 		}
 	} else if result > x {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d + %d", x, y)
 	}
 
 	return result, nil
@@ -38,10 +38,10 @@ func SafeSub[T Integer](x T, y T) (T, error) {
 
 	if y > 0 {
 		if result > x {
-			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d - %d", x, y)
 		}
 	} else if result < x {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d - %d", x, y)
 	}
 
 	return result, nil
@@ -56,7 +56,7 @@ func SafeMul[T Integer](x T, y T) (T, error) {
 	result := x * y
 
 	if result/x != y {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d * %d", x, y)
 	}
 
 	return result, nil
@@ -73,7 +73,7 @@ func SafeMulUint64(x, y uint64) (uint64, error) {
 	hi, lo := bits.Mul64(x, y)
 
 	if hi != 0 {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d * %d", x, y)
 	}
 
 	return lo, nil
@@ -150,7 +150,7 @@ func SafeMulInt64(x, y int64) (int64, error) {
 
 	// If the computation overflowed a uint64, it would also overflow an int64.
 	if hi != 0 {
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d * %d", x, y)
 	}
 
 	// Interpret the lo result as an int64, then correct for the expected sign.
@@ -162,11 +162,11 @@ func SafeMulInt64(x, y int64) (int64, error) {
 	if resultIsPositive {
 		// If the result is expected to be positive but the sign bit is set, it's an overflow.
 		if signBitSet {
-			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d * %d", x, y)
 		}
 	} else if !signBitSet {
 		// If the result is expected to be negative but the sign bit is not set, it's an underflow.
-		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d * %d", x, y)
 	}
 
 	return loSigned, nil
@@ -175,7 +175,7 @@ func SafeMulInt64(x, y int64) (int64, error) {
 // Returns x / y or an error if that computation would cause a division by zero.
 func SafeDiv[T Integer](x T, y T) (T, error) {
 	if y == 0 {
-		return 0, ierrors.Wrapf(ErrIntegerDivisionByZero, "%d and %d", x, y)
+		return 0, ierrors.Wrapf(ErrIntegerDivisionByZero, "%d / %d", x, y)
 	}
 
 	return x / y, nil

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -1,7 +1,6 @@
 package safemath
 
 import (
-	"errors"
 	"math/bits"
 
 	"github.com/iotaledger/hive.go/ierrors"
@@ -9,9 +8,9 @@ import (
 
 var (
 	// ErrIntegerOverflow gets returned if an operation on two integers would under- or overflow.
-	ErrIntegerOverflow = errors.New("integer under- or overflow")
+	ErrIntegerOverflow = ierrors.New("integer under- or overflow")
 	// ErrIntegerDivisionByZero gets returned if an integer division would cause a division by zero error.
-	ErrIntegerDivisionByZero = errors.New("integer division by zero")
+	ErrIntegerDivisionByZero = ierrors.New("integer division by zero")
 )
 
 type Integer interface {

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -1,0 +1,69 @@
+package safemath
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrIntegerOverflow gets returned if an operation on two integers would under- or overflow.
+	ErrIntegerOverflow = errors.New("integer under- or overflow")
+	// ErrIntegerDivisionByZero gets returned if an integer division would cause a division by zero error.
+	ErrIntegerDivisionByZero = errors.New("integer division by zero")
+)
+
+type Integer interface {
+	~uint64 | ~uint32 | ~uint16 | ~uint8 | ~int64 | ~int32 | ~int16 | ~int8
+}
+
+// Returns an error if x + y would under- or overflow, x + y otherwise.
+func SafeAdd[T Integer](x T, y T) (T, error) {
+	result := x + y
+
+	if y > 0 {
+		if result < x {
+			return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+		}
+	} else if result > x {
+		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+	}
+
+	return result, nil
+}
+
+// Returns an error if x - y would under- or overflow, x - y otherwise.
+func SafeSub[T Integer](x T, y T) (T, error) {
+	result := x - y
+
+	if y > 0 {
+		if result > x {
+			return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+		}
+	} else if result < x {
+		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+	}
+
+	return result, nil
+}
+
+// Returns an error if x * y would under- or overflow, x * y otherwise.
+func SafeMul[T Integer](x T, y T) (T, error) {
+	// Implementation inspired by:
+	// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/8cab922347e79732f6a532a75da5081ba7447a71/contracts/utils/math/Math.sol#L51
+	result := x * y
+
+	if x != 0 && result/x != y {
+		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+	}
+
+	return result, nil
+}
+
+// Returns an error if y is zero and would cause a division by zero, x / y otherwise.
+func SafeDiv[T Integer](x T, y T) (T, error) {
+	if y == 0 {
+		return 0, fmt.Errorf("%w: divisor is zero", ErrIntegerDivisionByZero)
+	}
+
+	return x / y, nil
+}

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -51,6 +51,10 @@ func SafeSub[T Integer](x T, y T) (T, error) {
 //
 // According to benchmarks, this function is about 73% faster than SafeMul.
 func SafeMulUint64(x, y uint64) (uint64, error) {
+	if x == 0 || y == 0 {
+		return 0, nil
+	}
+
 	hi, lo := bits.Mul64(x, y)
 
 	if hi != 0 {
@@ -96,6 +100,10 @@ func SafeMulInt64(x, y int64) (int64, error) {
 	// Interpreted as an int8 and multiplied with -1, to account for the expected sign of the result, we simply get
 	// 0000 0000, since the least significant byte of the result is 0.
 	// However, since the most significant byte of the result is non-zero, we detect the overflow.
+
+	if x == 0 || y == 0 {
+		return 0, nil
+	}
 
 	xNegative := x < 0
 	yNegative := y < 0
@@ -151,9 +159,13 @@ func SafeMulInt64(x, y int64) (int64, error) {
 
 // Returns x * y or an error if that computation would under- or overflow.
 func SafeMul[T Integer](x T, y T) (T, error) {
+	if x == 0 || y == 0 {
+		return 0, nil
+	}
+
 	result := x * y
 
-	if x != 0 && result/x != y {
+	if result/x != y {
 		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -3,6 +3,7 @@ package safemath
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 )
 
 var (
@@ -16,7 +17,7 @@ type Integer interface {
 	~uint64 | ~uint32 | ~uint16 | ~uint8 | ~int64 | ~int32 | ~int16 | ~int8
 }
 
-// Returns an error if x + y would under- or overflow, x + y otherwise.
+// Returns x + y or an error if that computation would under- or overflow.
 func SafeAdd[T Integer](x T, y T) (T, error) {
 	result := x + y
 
@@ -31,7 +32,7 @@ func SafeAdd[T Integer](x T, y T) (T, error) {
 	return result, nil
 }
 
-// Returns an error if x - y would under- or overflow, x - y otherwise.
+// Returns x - y or an error if that computation would under- or overflow.
 func SafeSub[T Integer](x T, y T) (T, error) {
 	result := x - y
 
@@ -46,10 +47,109 @@ func SafeSub[T Integer](x T, y T) (T, error) {
 	return result, nil
 }
 
-// Returns an error if x * y would under- or overflow, x * y otherwise.
+// Returns x * y or an error if that computation would overflow.
+//
+// According to benchmarks, this function is about 73% faster than SafeMul.
+func SafeMulUint64(x, y uint64) (uint64, error) {
+	hi, lo := bits.Mul64(x, y)
+
+	if hi != 0 {
+		return 0, ErrIntegerOverflow
+	}
+
+	return lo, nil
+}
+
+// Returns x * y or an error if that computation would under- or overflow.
+//
+// According to benchmarks, this function is about 27% faster than SafeMul.
+func SafeMulInt64(x, y int64) (int64, error) {
+	// This function stores the sign of the resulting int64 multiplication
+	// and then executes the multiplication with two uint64s, in 128-bit space.
+	// If any of the upper 64-bits are non-zero, an overflow has occurred.
+	// If the result should be positive, but the sign bit is set, an overflow has occurred.
+	// If the result should be negative, but the sign bit is unset, an overflow has occurred.
+	//
+	// The following examples use uint16/int8 as a more easily understandable example.
+	//
+	// *Positive Overflow*
+	//
+	// As a positive overflow example, take int8(66) * 2.
+	// The result as a uint16 will be 132, or in binary: 0000 0000 1000 0100.
+	// Interpreted as an int8 the high part is cut off and so the sign bit (most significant bit) is set,
+	// but we expected the result to be positive, so we detect this as an overflow.
+	//
+	// *Negative Overflow*
+	//
+	// As a negative overflow example, take int8(-66) * 2.
+	// The result as a uint16 will 132, or in binary 0000 0000 1000 0100, since we calculate 66*2 without the sign.
+	// Interpreted as an int8 the high part is cut off and the result multiplied with -1, to account for the
+	// expected sign of the result, so we get 0111 1100.
+	// The sign bit (most significant bit) is unset, but we expected the result to be negative,
+	// so we detect this as an overflow.
+	//
+	// *Overflowing 8-bit space*
+	//
+	// As a larger negative overflow example using 8-bit integers, take int8(-128) * 32.
+	// The multiplication would take place using 16-bits, so the result as a uint16 will be
+	// binary 0001 0000 0000 0000, since we calculate 128*32 without the sign.
+	// Interpreted as an int8 and multiplied with -1, to account for the expected sign of the result, we simply get
+	// 0000 0000, since the least significnat byte of the result is 0.
+	// However, since the most significant byte of the result is non-zero, we detect the overflow.
+
+	xNegative := x < 0
+	yNegative := y < 0
+	xPositive := x > 0
+	yPositive := y > 0
+	resultIsPositive := true
+	var resultSign int64 = 1
+
+	// Store the sign of the resulting computation and negate any negative integers,
+	// so we can correctly convert to uint64.
+	if xNegative {
+		if yPositive {
+			resultIsPositive = false
+			resultSign = -1
+		}
+		x = -x
+	}
+
+	if yNegative {
+		if xPositive {
+			resultIsPositive = false
+			resultSign = -1
+		}
+		y = -y
+	}
+
+	// Execute the multiplication in 128-bit space using unsigned integers.
+	hi, lo := bits.Mul64(uint64(x), uint64(y))
+	// Interpret the lo result as an int64, then correct for the expected sign.
+	loSigned := int64(lo) * resultSign
+
+	// If the computation overflowed a uint64, it would also overflow an int64.
+	if hi != 0 {
+		return 0, ErrIntegerOverflow
+	}
+
+	// Extract the most significant bit, signaling if the number is negative (1) or not (0).
+	signBitSet := ((loSigned >> 63) & 1) == 1
+
+	// If the result is expected to be positive but the sign bit is set, it's an overflow.
+	if resultIsPositive && signBitSet {
+		return 0, ErrIntegerOverflow
+	}
+
+	// If the result is expected to be negative but the sign bit is not set, it's an underflow.
+	if !resultIsPositive && !signBitSet {
+		return 0, ErrIntegerOverflow
+	}
+
+	return loSigned, nil
+}
+
+// Returns x * y or an error if that computation would under- or overflow.
 func SafeMul[T Integer](x T, y T) (T, error) {
-	// Implementation inspired by:
-	// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/8cab922347e79732f6a532a75da5081ba7447a71/contracts/utils/math/Math.sol#L51
 	result := x * y
 
 	if x != 0 && result/x != y {
@@ -59,7 +159,7 @@ func SafeMul[T Integer](x T, y T) (T, error) {
 	return result, nil
 }
 
-// Returns an error if y is zero and would cause a division by zero, x / y otherwise.
+// Returns x / y or an error if that computation would cause a division by zero.
 func SafeDiv[T Integer](x T, y T) (T, error) {
 	if y == 0 {
 		return 0, fmt.Errorf("%w: divisor is zero", ErrIntegerDivisionByZero)

--- a/core/safemath/safe_math.go
+++ b/core/safemath/safe_math.go
@@ -2,8 +2,9 @@ package safemath
 
 import (
 	"errors"
-	"fmt"
 	"math/bits"
+
+	"github.com/iotaledger/hive.go/ierrors"
 )
 
 var (
@@ -23,10 +24,10 @@ func SafeAdd[T Integer](x T, y T) (T, error) {
 
 	if y > 0 {
 		if result < x {
-			return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 		}
 	} else if result > x {
-		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	return result, nil
@@ -38,10 +39,10 @@ func SafeSub[T Integer](x T, y T) (T, error) {
 
 	if y > 0 {
 		if result > x {
-			return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+			return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 		}
 	} else if result < x {
-		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	return result, nil
@@ -54,7 +55,7 @@ func SafeMulUint64(x, y uint64) (uint64, error) {
 	hi, lo := bits.Mul64(x, y)
 
 	if hi != 0 {
-		return 0, ErrIntegerOverflow
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	return lo, nil
@@ -94,7 +95,7 @@ func SafeMulInt64(x, y int64) (int64, error) {
 	// The multiplication would take place using 16-bits, so the result as a uint16 will be
 	// binary 0001 0000 0000 0000, since we calculate 128*32 without the sign.
 	// Interpreted as an int8 and multiplied with -1, to account for the expected sign of the result, we simply get
-	// 0000 0000, since the least significnat byte of the result is 0.
+	// 0000 0000, since the least significant byte of the result is 0.
 	// However, since the most significant byte of the result is non-zero, we detect the overflow.
 
 	xNegative := x < 0
@@ -129,7 +130,7 @@ func SafeMulInt64(x, y int64) (int64, error) {
 
 	// If the computation overflowed a uint64, it would also overflow an int64.
 	if hi != 0 {
-		return 0, ErrIntegerOverflow
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	// Extract the most significant bit, signaling if the number is negative (1) or not (0).
@@ -137,12 +138,12 @@ func SafeMulInt64(x, y int64) (int64, error) {
 
 	// If the result is expected to be positive but the sign bit is set, it's an overflow.
 	if resultIsPositive && signBitSet {
-		return 0, ErrIntegerOverflow
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	// If the result is expected to be negative but the sign bit is not set, it's an underflow.
 	if !resultIsPositive && !signBitSet {
-		return 0, ErrIntegerOverflow
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	return loSigned, nil
@@ -153,7 +154,7 @@ func SafeMul[T Integer](x T, y T) (T, error) {
 	result := x * y
 
 	if x != 0 && result/x != y {
-		return 0, fmt.Errorf("%w: %d and %d", ErrIntegerOverflow, x, y)
+		return 0, ierrors.Wrapf(ErrIntegerOverflow, "%d and %d", x, y)
 	}
 
 	return result, nil
@@ -162,7 +163,7 @@ func SafeMul[T Integer](x T, y T) (T, error) {
 // Returns x / y or an error if that computation would cause a division by zero.
 func SafeDiv[T Integer](x T, y T) (T, error) {
 	if y == 0 {
-		return 0, fmt.Errorf("%w: divisor is zero", ErrIntegerDivisionByZero)
+		return 0, ierrors.Wrapf(ErrIntegerDivisionByZero, "%d and %d", x, y)
 	}
 
 	return x / y, nil

--- a/core/safemath/safe_math_test.go
+++ b/core/safemath/safe_math_test.go
@@ -1,0 +1,198 @@
+package safemath
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeMathAddUint8(t *testing.T) {
+	var err error
+	var ures uint8
+
+	ures, err = SafeAdd(uint8(0), math.MaxUint8)
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(math.MaxUint8))
+
+	ures, err = SafeAdd(math.MaxUint8, uint8(0))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(math.MaxUint8))
+
+	ures, err = SafeAdd(uint8(100), uint8(100))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(200))
+
+	// overflows
+	_, err = SafeAdd(uint8(1), math.MaxUint8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeAdd(math.MaxUint8, uint8(1))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathAddInt8(t *testing.T) {
+	var err error
+	var ires int8
+
+	// positive addends
+	ires, err = SafeAdd(int8(0), math.MaxInt8)
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(math.MaxInt8))
+
+	ires, err = SafeAdd(math.MaxInt8, int8(0))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(math.MaxInt8))
+
+	ires, err = SafeAdd(math.MinInt8, int8(math.MaxInt8))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(-1))
+
+	ires, err = SafeAdd(int8(-100), int8(math.MaxInt8))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(27))
+
+	ires, err = SafeAdd(int8(50), int8(50))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(100))
+
+	// negative addends
+	ires, err = SafeAdd(math.MaxInt8, int8(-math.MaxInt8))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(0))
+
+	ires, err = SafeAdd(math.MaxInt8, int8(-math.MaxInt8))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(0))
+
+	ires, err = SafeAdd(int8(100), int8(-50))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(50))
+
+	// overflows
+	_, err = SafeAdd(int8(1), math.MaxInt8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeAdd(math.MaxInt8, int8(1))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	// underflows
+	_, err = SafeAdd(int8(math.MinInt8), int8(-1))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeAdd(int8(-1), int8(math.MinInt8))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathSubUint8(t *testing.T) {
+	var err error
+	var ures uint8
+
+	ures, err = SafeSub(uint8(5), uint8(5))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(0))
+
+	ures, err = SafeSub(uint8(5), uint8(4))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(1))
+
+	_, err = SafeSub(uint8(4), uint8(5))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeSub(math.MaxUint8-uint8(1), math.MaxUint8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathSubInt8(t *testing.T) {
+	var err error
+	var ires int8
+
+	// positive subtrahends
+	ires, err = SafeSub(int8(5), int8(5))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(0))
+
+	ires, err = SafeSub(int8(5), int8(4))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(1))
+
+	ires, err = SafeSub(int8(4), int8(5))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(-1))
+
+	// negative subtrahends
+	ires, err = SafeSub(int8(-4), int8(-5))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(1))
+
+	// underflows
+	_, err = SafeSub(math.MinInt8, int8(1))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeSub(int8(-2), math.MaxInt8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	// overflows
+	_, err = SafeSub(math.MaxInt8, int8(-1))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeSub(int8(1), math.MinInt8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathMulUint8(t *testing.T) {
+	var err error
+	var ures uint8
+
+	ures, err = SafeMul(uint8(5), uint8(5))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(25))
+
+	_, err = SafeMul(uint8(100), uint8(3))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeMul(math.MaxUint8, uint8(2))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeMul(uint8(51), uint8(10))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathMulInt8(t *testing.T) {
+	var err error
+	var ires int8
+
+	ires, err = SafeMul(int8(5), int8(5))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(25))
+
+	ires, err = SafeMul(int8(5), int8(-5))
+	require.NoError(t, err)
+	require.Equal(t, ires, int8(-25))
+
+	_, err = SafeMul(int8(100), int8(2))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeMul(math.MinInt8, int8(2))
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+
+	_, err = SafeMul(int8(math.MinInt8), math.MaxInt8)
+	require.ErrorIs(t, err, ErrIntegerOverflow)
+}
+
+func TestSafeMathDiv(t *testing.T) {
+	var err error
+	var ures uint8
+
+	ures, err = SafeDiv(uint8(10), uint8(2))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(5))
+
+	ures, err = SafeDiv(uint8(10), uint8(8))
+	require.NoError(t, err)
+	require.Equal(t, ures, uint8(1))
+
+	_, err = SafeDiv(int8(100), int8(0))
+	require.ErrorIs(t, err, ErrIntegerDivisionByZero)
+}
+


### PR DESCRIPTION
# Description of change

Adds a safe math module to the `core` package.

The generic functions `Safe{Mul,Add,Sub,Div}` are implemented in ways that don't depend on the concrete boundaries of the types, e.g. `MaxUint64`, `MaxUint32`, ... otherwise the generic implementation would not be possible in the first place.

As the generic `SafeMul` is implemented with an integer division to check for under-/overflows, two other faster implementations for `Uint64` and `Int64` are also added. The approach for `Int64` is not entirely straightforward, and we might decide to not include it in the package and simply rely on `SafeMul[Int64]` instead, as it is not much slower. The difference should only be problematic if `SafeMul[Int64]` is called in a tight loop.

A possible alternative implementation of `SafeMulInt64` would be to rely on the [overflow flag](https://en.wikipedia.org/wiki/Overflow_flag). It does not seem like go exposes operations that can access this flag, so embedded assembly or some external package might be needed to access the flag. For that reason, I would suggest to look into that when we actually need a super-efficient overflow-checking int64 multiplication function.

Implements iotaledger/iota-core#154.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added tests for the module.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
