### PR TITLE
Feat: Reactive package

### DIFF
--- a/ds/reactive/counter.go
+++ b/ds/reactive/counter.go
@@ -1,0 +1,17 @@
+package reactive
+
+// Counter is a Variable that derives its value from the number of times a set of monitored input values fulfill a
+// certain condition.
+type Counter[InputType comparable] interface {
+	// Variable holds the counter value.
+	Variable[int]
+
+	// Monitor adds the given input value as an input to the counter and returns a function that can be used to
+	// unsubscribe from the input value.
+	Monitor(input ReadableVariable[InputType]) (unsubscribe func())
+}
+
+// NewCounter creates a Counter that counts the number of times monitored input values fulfill a certain condition.
+func NewCounter[InputType comparable](condition ...func(inputValue InputType) bool) Counter[InputType] {
+	return newCounter(condition...)
+}

--- a/ds/reactive/counter_impl.go
+++ b/ds/reactive/counter_impl.go
@@ -1,0 +1,45 @@
+package reactive
+
+import "github.com/iotaledger/hive.go/lo"
+
+// counter is the default implementation of the Counter interface.
+type counter[InputType comparable] struct {
+	// Variable holds the counter value.
+	Variable[int]
+
+	// condition is the condition that is used to determine whether the input value fulfills the counted criteria.
+	condition func(inputValue InputType) bool
+}
+
+// newCounter creates a counter that counts the number of times monitored input values fulfill a certain condition.
+func newCounter[InputType comparable](condition ...func(inputValue InputType) bool) *counter[InputType] {
+	return &counter[InputType]{
+		Variable: NewVariable[int](),
+		condition: lo.First(condition, func(newInputValue InputType) bool {
+			var zeroValue InputType
+			return newInputValue != zeroValue
+		}),
+	}
+}
+
+// Monitor adds the given input value as an input to the counter and returns a function that can be used to unsubscribe
+// from the input value.
+func (c *counter[InputType]) Monitor(input ReadableVariable[InputType]) (unsubscribe func()) {
+	var conditionWasTrue bool
+
+	return input.OnUpdate(func(_, newInputValue InputType) {
+		c.Compute(func(currentValue int) int {
+			if conditionIsTrue := c.condition(newInputValue); conditionIsTrue != conditionWasTrue {
+				if conditionIsTrue {
+					currentValue++
+				} else {
+					currentValue--
+				}
+
+				conditionWasTrue = conditionIsTrue
+			}
+
+			return currentValue
+		})
+	}, true)
+}

--- a/ds/reactive/counter_test.go
+++ b/ds/reactive/counter_test.go
@@ -1,0 +1,49 @@
+package reactive_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/iotaledger/hive.go/ds/reactive"
+)
+
+// TestMonitorConcurrency checks if Monitor function correctly updates the counter when multiple goroutines are changing the value
+func TestMonitorConcurrency(t *testing.T) {
+	//var wg sync.WaitGroup
+	condition := func(i int) bool { return i%2 == 0 } // condition is true for even numbers
+	c := reactive.NewCounter[int](condition)
+
+	v := reactive.NewVariable[int]()
+
+	// We expect half of the numbers to be even, so the counter should be 500000
+	assert.Equal(t, 0, c.Get()) // 0
+
+	unsubscribe := c.Monitor(v)
+
+	assert.Equal(t, 1, c.Get()) // 1
+
+	var wg sync.WaitGroup
+	// 1001 goroutines each updating the variable 1001 times (odd number of times)
+	for i := 0; i < 1001; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1001; j++ {
+				v.Compute(func(currentValue int) int {
+					return currentValue + 1
+				})
+			}
+		}()
+
+	}
+
+	wg.Wait()
+
+	// We expect half of the numbers to be even, so the counter should be 500000
+	assert.Equal(t, 0, c.Get()) // -1
+
+	// Clean up
+	unsubscribe()
+}

--- a/ds/reactive/event.go
+++ b/ds/reactive/event.go
@@ -1,0 +1,22 @@
+package reactive
+
+// Event is a reactive component that can be triggered exactly once and that informs its subscribers about the trigger.
+// It conforms to the Variable interface and exposes a boolean value that is set to true when the event was triggered.
+type Event interface {
+	// Variable holds the boolean value that indicates whether the event was triggered.
+	Variable[bool]
+
+	// Trigger triggers the event.
+	Trigger()
+
+	// WasTriggered returns true if the event was triggered.
+	WasTriggered() bool
+
+	// OnTrigger registers a callback that is executed when the event is triggered.
+	OnTrigger(func()) (unsubscribe func())
+}
+
+// NewEvent creates a new Event instance.
+func NewEvent() Event {
+	return newEvent()
+}

--- a/ds/reactive/event_impl.go
+++ b/ds/reactive/event_impl.go
@@ -1,0 +1,33 @@
+package reactive
+
+// event is the default implementation of the Event interface.
+type event struct {
+	Variable[bool]
+}
+
+// newEvent creates a new event.
+func newEvent() *event {
+	return &event{
+		Variable: NewVariable[bool](func(currentValue bool, newValue bool) bool {
+			// make sure that the value will always be true once it was set to true
+			return currentValue || newValue
+		}),
+	}
+}
+
+// Trigger triggers the event.
+func (e *event) Trigger() {
+	e.Set(true)
+}
+
+// WasTriggered returns true if the event was triggered.
+func (e *event) WasTriggered() bool {
+	return e.Get()
+}
+
+// OnTrigger registers a callback that is executed when the event is triggered.
+func (e *event) OnTrigger(handler func()) (unsubscribe func()) {
+	return e.OnUpdate(func(_, _ bool) {
+		handler()
+	})
+}

--- a/ds/reactive/set.go
+++ b/ds/reactive/set.go
@@ -1,0 +1,58 @@
+package reactive
+
+import (
+	"github.com/iotaledger/hive.go/ds"
+)
+
+// region Set ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Set is a reactive Set implementation that allows consumers to subscribe to its changes.
+type Set[ElementType comparable] interface {
+	// WriteableSet imports the write methods of the Set interface.
+	ds.WriteableSet[ElementType]
+
+	// ReadableSet imports the read methods of the Set interface.
+	ReadableSet[ElementType]
+}
+
+// NewSet creates a new Set with the given elements.
+func NewSet[T comparable](elements ...T) Set[T] {
+	return newSet(elements...)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region ReadableSet //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// ReadableSet is a reactive Set implementation that allows consumers to subscribe to its value.
+type ReadableSet[ElementType comparable] interface {
+	// OnUpdate registers the given callback that is triggered when the value changes.
+	OnUpdate(callback func(appliedMutations ds.SetMutations[ElementType]), triggerWithInitialZeroValue ...bool) (unsubscribe func())
+
+	// ReadableSet imports the read methods of the Set interface.
+	ds.ReadableSet[ElementType]
+}
+
+// NewReadableSet creates a new ReadableSet with the given elements.
+func NewReadableSet[ElementType comparable](elements ...ElementType) ReadableSet[ElementType] {
+	return newReadableSet(elements...)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region DerivedSet ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// DerivedSet is a reactive Set implementation that allows consumers to subscribe to its changes and that inherits its
+// elements from other sets.
+type DerivedSet[ElementType comparable] interface {
+	Set[ElementType]
+
+	InheritFrom(sources ...ReadableSet[ElementType]) (unsubscribe func())
+}
+
+// NewDerivedSet creates a new DerivedSet with the given elements.
+func NewDerivedSet[ElementType comparable]() DerivedSet[ElementType] {
+	return newDerivedSet[ElementType]()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/set_impl.go
+++ b/ds/reactive/set_impl.go
@@ -1,0 +1,271 @@
+package reactive
+
+import (
+	"sync"
+
+	"github.com/iotaledger/hive.go/ds"
+	"github.com/iotaledger/hive.go/ds/shrinkingmap"
+	"github.com/iotaledger/hive.go/lo"
+)
+
+// region set //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// set is the standard implementation of the Set interface.
+type set[ElementType comparable] struct {
+	// readableSet embeds the ReadableSet implementation.
+	*readableSet[ElementType]
+
+	// mutex is a mutex that is used to make write operations atomic.
+	mutex sync.Mutex
+}
+
+// newSet creates a new set with the given elements.
+func newSet[ElementType comparable](elements ...ElementType) *set[ElementType] {
+	return &set[ElementType]{
+		readableSet: newReadableSet[ElementType](elements...),
+	}
+}
+
+// Add adds a new element to the set and returns true if the element was not present in the set before.
+func (s *set[ElementType]) Add(element ElementType) bool {
+	return s.Apply(ds.NewSetMutations[ElementType](element)).AddedElements().Has(element)
+}
+
+// AddAll adds all elements to the set and returns true if any element has been added.
+func (s *set[ElementType]) AddAll(elements ds.ReadableSet[ElementType]) (addedElements ds.Set[ElementType]) {
+	return s.Apply(ds.NewSetMutations[ElementType](elements.ToSlice()...)).AddedElements()
+}
+
+// Delete deletes the given element from the set.
+func (s *set[ElementType]) Delete(element ElementType) bool {
+	return s.Apply(ds.NewSetMutations[ElementType]().WithDeletedElements(ds.NewSet(element))).DeletedElements().Has(element)
+}
+
+// DeleteAll deletes the given elements from the set.
+func (s *set[ElementType]) DeleteAll(elements ds.ReadableSet[ElementType]) (deletedElements ds.Set[ElementType]) {
+	return s.Apply(ds.NewSetMutations[ElementType]().WithDeletedElements(elements.Clone())).DeletedElements()
+}
+
+// Apply applies the given mutations to the set atomically and returns the applied mutations.
+func (s *set[ElementType]) Apply(mutations ds.SetMutations[ElementType]) (appliedMutations ds.SetMutations[ElementType]) {
+	if mutations.IsEmpty() {
+		return ds.NewSetMutations[ElementType]()
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	appliedMutations, updateID, registeredCallbacks := s.apply(mutations)
+
+	for _, registeredCallback := range registeredCallbacks {
+		if registeredCallback.LockExecution(updateID) {
+			registeredCallback.Invoke(appliedMutations)
+			registeredCallback.UnlockExecution()
+		}
+	}
+
+	return appliedMutations
+}
+
+// Replace replaces the current value of the set with the given elements.
+func (s *set[ElementType]) Replace(elements ds.ReadableSet[ElementType]) (removedElements ds.Set[ElementType]) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	appliedMutations, updateID, registeredCallbacks := s.replace(elements)
+
+	for _, registeredCallback := range registeredCallbacks {
+		if registeredCallback.LockExecution(updateID) {
+			registeredCallback.Invoke(appliedMutations)
+			registeredCallback.UnlockExecution()
+		}
+	}
+
+	return appliedMutations.DeletedElements()
+}
+
+// Decode decodes the set from a byte slice.
+func (s *set[ElementType]) Decode(b []byte) (bytesRead int, err error) {
+	s.readableSet.mutex.Lock()
+	defer s.readableSet.mutex.Unlock()
+
+	return s.value.Decode(b)
+}
+
+// ReadOnly returns a read-only version of the set.
+func (s *set[ElementType]) ReadOnly() ds.ReadableSet[ElementType] {
+	return s.readableSet
+}
+
+// apply applies the given mutations to the set.
+func (s *set[ElementType]) apply(mutations ds.SetMutations[ElementType]) (appliedMutations ds.SetMutations[ElementType], triggerID uniqueID, callbacksToTrigger []*callback[func(ds.SetMutations[ElementType])]) {
+	s.readableSet.mutex.Lock()
+	defer s.readableSet.mutex.Unlock()
+
+	return s.value.Apply(mutations), s.uniqueUpdateID.Next(), s.updateCallbacks.Values()
+}
+
+// replace replaces the current value of the set with the given elements.
+func (s *set[ElementType]) replace(elements ds.ReadableSet[ElementType]) (appliedMutations ds.SetMutations[ElementType], triggerID uniqueID, callbacksToTrigger []*callback[func(ds.SetMutations[ElementType])]) {
+	s.readableSet.mutex.Lock()
+	defer s.readableSet.mutex.Unlock()
+
+	return ds.NewSetMutations[ElementType](elements.ToSlice()...).WithDeletedElements(s.value.Replace(elements)), s.uniqueUpdateID.Next(), s.updateCallbacks.Values()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region readableSet //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// readableSet is th standard implementation of the ReadableSet interface.
+type readableSet[ElementType comparable] struct {
+	// updateCallbacks are the registered callbacks that are triggered when the value changes.
+	updateCallbacks *shrinkingmap.ShrinkingMap[uniqueID, *callback[func(ds.SetMutations[ElementType])]]
+
+	// uniqueUpdateID is the unique ID that is used to identify an update.
+	uniqueUpdateID uniqueID
+
+	// uniqueCallbackID is the unique ID that is used to identify a callback.
+	uniqueCallbackID uniqueID
+
+	// value is the current value of the set.
+	value ds.Set[ElementType]
+
+	// mutex is the mutex that is used to synchronize the access to the value.
+	mutex sync.RWMutex
+
+	// Readable embeds the set.Readable interface.
+	ds.ReadableSet[ElementType]
+}
+
+// newReadableSet creates a new readableSet with the given elements.
+func newReadableSet[ElementType comparable](elements ...ElementType) *readableSet[ElementType] {
+	setInstance := ds.NewSet[ElementType](elements...)
+
+	return &readableSet[ElementType]{
+		ReadableSet:     setInstance.ReadOnly(),
+		value:           setInstance,
+		updateCallbacks: shrinkingmap.New[uniqueID, *callback[func(ds.SetMutations[ElementType])]](),
+	}
+}
+
+// OnUpdate registers the given callback to be triggered when the value of the set changes.
+func (r *readableSet[ElementType]) OnUpdate(callback func(appliedMutations ds.SetMutations[ElementType]), triggerWithInitialZeroValue ...bool) (unsubscribe func()) {
+	r.mutex.Lock()
+
+	mutations := ds.NewSetMutations[ElementType]().WithAddedElements(r.Clone())
+
+	createdCallback := newCallback[func(ds.SetMutations[ElementType])](r.uniqueCallbackID.Next(), callback)
+	r.updateCallbacks.Set(createdCallback.ID, createdCallback)
+
+	// grab the lock to make sure that the callback is not executed before we have called it with the initial value.
+	createdCallback.LockExecution(r.uniqueUpdateID)
+	defer createdCallback.UnlockExecution()
+
+	r.mutex.Unlock()
+
+	if !mutations.IsEmpty() || lo.First(triggerWithInitialZeroValue) {
+		createdCallback.Invoke(mutations)
+	}
+
+	return func() {
+		r.updateCallbacks.Delete(createdCallback.ID)
+
+		createdCallback.MarkUnsubscribed()
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region derivedSet ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// derivedSet is the standard implementation of the DerivedSet interface.
+type derivedSet[ElementType comparable] struct {
+	// set is the set that is derived from the source sets.
+	*set[ElementType]
+
+	// sourceCounters are the counters that keep track of the number of times an element is contained in the source
+	// sets (we only want to remove an element from the set if it is not contained in any of the source sets anymore).
+	sourceCounters *shrinkingmap.ShrinkingMap[ElementType, int]
+}
+
+// newDerivedSet creates a new derivedSet with the given elements.
+func newDerivedSet[ElementType comparable]() *derivedSet[ElementType] {
+	return &derivedSet[ElementType]{
+		set:            newSet[ElementType](),
+		sourceCounters: shrinkingmap.New[ElementType, int](),
+	}
+}
+
+// InheritFrom registers the given sets to inherit their mutations to the set.
+func (s *derivedSet[ElementType]) InheritFrom(sources ...ReadableSet[ElementType]) (unsubscribe func()) {
+	unsubscribeCallbacks := make([]func(), 0)
+
+	for _, source := range sources {
+		sourceElements := ds.NewSet[ElementType]()
+
+		unsubscribeFromSource := source.OnUpdate(func(appliedMutations ds.SetMutations[ElementType]) {
+			s.Apply(sourceElements.Apply(appliedMutations))
+		})
+
+		removeSourceElements := func() {
+			s.Apply(ds.NewSetMutations[ElementType]().WithDeletedElements(sourceElements))
+		}
+
+		unsubscribeCallbacks = append(unsubscribeCallbacks, unsubscribeFromSource, removeSourceElements)
+	}
+
+	return lo.Batch(unsubscribeCallbacks...)
+}
+
+// Apply triggers the update of the set with the given mutations.
+func (s *derivedSet[ElementType]) Apply(mutations ds.SetMutations[ElementType]) (appliedMutations ds.SetMutations[ElementType]) {
+	if mutations.IsEmpty() {
+		return
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	appliedMutations, updateID, registeredCallbacks := s.apply(mutations)
+
+	for _, registeredCallback := range registeredCallbacks {
+		if registeredCallback.LockExecution(updateID) {
+			registeredCallback.Invoke(appliedMutations)
+			registeredCallback.UnlockExecution()
+		}
+	}
+
+	return appliedMutations
+}
+
+// apply prepares the trigger by applying the given mutations to the set and returning the applied
+// mutations, the trigger ID and the callbacks to trigger.
+func (s *derivedSet[ElementType]) apply(mutations ds.SetMutations[ElementType]) (inheritedMutations ds.SetMutations[ElementType], triggerID uniqueID, callbacksToTrigger []*callback[func(ds.SetMutations[ElementType])]) {
+	s.readableSet.mutex.Lock()
+	defer s.readableSet.mutex.Unlock()
+
+	inheritedMutations = ds.NewSetMutations[ElementType]()
+
+	elementsToAdd := inheritedMutations.AddedElements()
+	mutations.AddedElements().Range(func(element ElementType) {
+		if s.sourceCounters.Compute(element, func(currentValue int, _ bool) int {
+			return currentValue + 1
+		}) == 1 {
+			elementsToAdd.Add(element)
+		}
+	})
+
+	elementsToDelete := inheritedMutations.DeletedElements()
+	mutations.DeletedElements().Range(func(element ElementType) {
+		if s.sourceCounters.Compute(element, func(currentValue int, _ bool) int {
+			return currentValue - 1
+		}) == 0 && !elementsToAdd.Delete(element) {
+			elementsToDelete.Add(element)
+		}
+	})
+
+	return s.value.Apply(inheritedMutations), s.uniqueUpdateID.Next(), s.updateCallbacks.Values()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/set_test.go
+++ b/ds/reactive/set_test.go
@@ -1,0 +1,35 @@
+package reactive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/ds"
+)
+
+func TestSet(t *testing.T) {
+	source1 := NewSet[int]()
+	source2 := NewSet[int]()
+
+	inheritedSet := NewDerivedSet[int]()
+	inheritedSet.InheritFrom(source1, source2)
+
+	source1.AddAll(ds.NewSet(1, 2, 4))
+	source2.AddAll(ds.NewSet(7, 9))
+
+	require.True(t, inheritedSet.Has(1))
+	require.True(t, inheritedSet.Has(2))
+	require.True(t, inheritedSet.Has(4))
+	require.True(t, inheritedSet.Has(7))
+	require.True(t, inheritedSet.Has(9))
+
+	inheritedSet1 := NewDerivedSet[int]()
+	inheritedSet1.InheritFrom(source1, source2)
+
+	require.True(t, inheritedSet1.Has(1))
+	require.True(t, inheritedSet1.Has(2))
+	require.True(t, inheritedSet1.Has(4))
+	require.True(t, inheritedSet1.Has(7))
+	require.True(t, inheritedSet1.Has(9))
+}

--- a/ds/reactive/utils.go
+++ b/ds/reactive/utils.go
@@ -1,0 +1,78 @@
+package reactive
+
+import (
+	"sync"
+)
+
+// region callback /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// callback is an internal wrapper for a callback function that is extended by an ID and a mutex (for call order
+// synchronization).
+type callback[FuncType any] struct {
+	// ID is the unique identifier of the callback.
+	ID uniqueID
+
+	// Invoke is the callback function that is invoked when the callback is triggered.
+	Invoke FuncType
+
+	// unsubscribed is a flag that indicates whether the callback was unsubscribed.
+	unsubscribed bool
+
+	// lastUpdate is the last update that was applied to the callback.
+	lastUpdate uniqueID
+
+	// executionMutex is the mutex that is used to synchronize the execution of the callback.
+	executionMutex sync.Mutex
+}
+
+// newCallback is the constructor for the callback type.
+func newCallback[FuncType any](id uniqueID, invoke FuncType) *callback[FuncType] {
+	return &callback[FuncType]{
+		ID:     id,
+		Invoke: invoke,
+	}
+}
+
+// LockExecution locks the callback for the given update and returns true if the callback was locked successfully.
+func (c *callback[FuncType]) LockExecution(updateID uniqueID) bool {
+	c.executionMutex.Lock()
+
+	if c.unsubscribed || updateID != 0 && updateID == c.lastUpdate {
+		c.executionMutex.Unlock()
+
+		return false
+	}
+
+	c.lastUpdate = updateID
+
+	return true
+}
+
+// UnlockExecution unlocks the callback.
+func (c *callback[FuncType]) UnlockExecution() {
+	c.executionMutex.Unlock()
+}
+
+// MarkUnsubscribed marks the callback as unsubscribed (it will no longer trigger).
+func (c *callback[FuncType]) MarkUnsubscribed() {
+	c.executionMutex.Lock()
+	defer c.executionMutex.Unlock()
+
+	c.unsubscribed = true
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region uniqueID /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// UniqueID is a unique identifier.
+type uniqueID uint64
+
+// Next returns the next unique identifier.
+func (u *uniqueID) Next() uniqueID {
+	*u++
+
+	return *u
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -57,43 +57,43 @@ type DerivedVariable[Type comparable] interface {
 }
 
 // DeriveVariableFromInput creates a DerivedVariable that transforms an input value into a different one.
-func DeriveVariableFromInput[Type, InputType1 comparable, InputValueType1 ReadableVariable[InputType1]](compute func(InputType1) Type, input1 *InputValueType1) DerivedVariable[Type] {
+func DeriveVariableFromInput[Type, InputType1 comparable, InputValueType1 ReadableVariable[InputType1]](compute func(InputType1) Type, input1 InputValueType1) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
-		return (*input1).OnUpdate(func(_, input1 InputType1) {
+		return input1.OnUpdate(func(_, input1 InputType1) {
 			d.Compute(func(_ Type) Type { return compute(input1) })
 		}, true)
 	})
 }
 
 // DeriveVariableFrom2Inputs creates a DerivedVariable that transforms two input values into a different one.
-func DeriveVariableFrom2Inputs[Type, InputType1, InputType2 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2]](compute func(InputType1, InputType2) Type, input1 *InputValueType1, input2 *InputValueType2) DerivedVariable[Type] {
+func DeriveVariableFrom2Inputs[Type, InputType1, InputType2 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2]](compute func(InputType1, InputType2) Type, input1 InputValueType1, input2 InputValueType2) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
 		return lo.Batch(
-			(*input1).OnUpdate(func(_, input1 InputType1) {
-				d.Compute(func(_ Type) Type { return compute(input1, (*input2).Get()) })
+			input1.OnUpdate(func(_, input1 InputType1) {
+				d.Compute(func(_ Type) Type { return compute(input1, input2.Get()) })
 			}, true),
 
-			(*input2).OnUpdate(func(_, input2 InputType2) {
-				d.Compute(func(_ Type) Type { return compute((*input1).Get(), input2) })
+			input2.OnUpdate(func(_, input2 InputType2) {
+				d.Compute(func(_ Type) Type { return compute(input1.Get(), input2) })
 			}, true),
 		)
 	})
 }
 
 // DeriveVariableFrom3Inputs creates a DerivedVariable that transforms three input values into a different one.
-func DeriveVariableFrom3Inputs[Type, InputType1, InputType2, InputType3 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2], InputValueType3 ReadableVariable[InputType3]](compute func(InputType1, InputType2, InputType3) Type, input1 *InputValueType1, input2 *InputValueType2, input3 *InputValueType3) DerivedVariable[Type] {
+func DeriveVariableFrom3Inputs[Type, InputType1, InputType2, InputType3 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2], InputValueType3 ReadableVariable[InputType3]](compute func(InputType1, InputType2, InputType3) Type, input1 InputValueType1, input2 InputValueType2, input3 InputValueType3) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
 		return lo.Batch(
-			(*input1).OnUpdate(func(_, input1 InputType1) {
-				d.Compute(func(_ Type) Type { return compute(input1, (*input2).Get(), (*input3).Get()) })
+			input1.OnUpdate(func(_, input1 InputType1) {
+				d.Compute(func(_ Type) Type { return compute(input1, input2.Get(), input3.Get()) })
 			}, true),
 
-			(*input2).OnUpdate(func(_, input2 InputType2) {
-				d.Compute(func(_ Type) Type { return compute((*input1).Get(), input2, (*input3).Get()) })
+			input2.OnUpdate(func(_, input2 InputType2) {
+				d.Compute(func(_ Type) Type { return compute(input1.Get(), input2, input3.Get()) })
 			}, true),
 
-			(*input3).OnUpdate(func(_, input3 InputType3) {
-				d.Compute(func(_ Type) Type { return compute((*input1).Get(), (*input2).Get(), input3) })
+			input3.OnUpdate(func(_, input3 InputType3) {
+				d.Compute(func(_ Type) Type { return compute(input1.Get(), input2.Get(), input3) })
 			}, true),
 		)
 	})

--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -8,14 +8,10 @@ import (
 
 // Variable represents a variable that can be read and written and that informs subscribed consumers about updates.
 type Variable[Type comparable] interface {
-	// Set sets the new value and triggers the registered callbacks if the value has changed.
-	Set(newValue Type) (previousValue Type)
+	// WritableVariable imports the write methods of the Variable.
+	WritableVariable[Type]
 
-	// Compute sets the new value by applying the given function to the current value and triggers the registered
-	// callbacks if the value has changed.
-	Compute(computeFunc func(currentValue Type) Type) (previousValue Type)
-
-	// ReadableVariable imports the interface that allows subscribers to read the value and to be notified when it changes.
+	// ReadableVariable imports the read methods of the Variable.
 	ReadableVariable[Type]
 }
 
@@ -44,6 +40,18 @@ func NewReadableVariable[Type comparable](value Type) ReadableVariable[Type] {
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region WritableVariable /////////////////////////////////////////////////////////////////////////////////////////////
+
+// WritableVariable represents a variable that can be written to.
+type WritableVariable[Type comparable] interface {
+	// Set sets the new value and triggers the registered callbacks if the value has changed.
+	Set(newValue Type) (previousValue Type)
+
+	// Compute sets the new value by applying the given function to the current value and triggers the registered
+	// callbacks if the value has changed.
+	Compute(computeFunc func(currentValue Type) Type) (previousValue Type)
+}
 
 // region DerivedVariable //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -56,8 +56,8 @@ type DerivedVariable[Type comparable] interface {
 	Unsubscribe()
 }
 
-// DeriveVariableFromInput creates a DerivedVariable that transforms an input value into a different one.
-func DeriveVariableFromInput[Type, InputType1 comparable, InputValueType1 ReadableVariable[InputType1]](compute func(InputType1) Type, input1 InputValueType1) DerivedVariable[Type] {
+// NewDerivedVariable creates a DerivedVariable that transforms an input value into a different one.
+func NewDerivedVariable[Type, InputType1 comparable, InputValueType1 ReadableVariable[InputType1]](compute func(InputType1) Type, input1 InputValueType1) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
 		return input1.OnUpdate(func(_, input1 InputType1) {
 			d.Compute(func(_ Type) Type { return compute(input1) })
@@ -65,8 +65,8 @@ func DeriveVariableFromInput[Type, InputType1 comparable, InputValueType1 Readab
 	})
 }
 
-// DeriveVariableFrom2Inputs creates a DerivedVariable that transforms two input values into a different one.
-func DeriveVariableFrom2Inputs[Type, InputType1, InputType2 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2]](compute func(InputType1, InputType2) Type, input1 InputValueType1, input2 InputValueType2) DerivedVariable[Type] {
+// NewDerivedVariable2 creates a DerivedVariable that transforms two input values into a different one.
+func NewDerivedVariable2[Type, InputType1, InputType2 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2]](compute func(InputType1, InputType2) Type, input1 InputValueType1, input2 InputValueType2) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
 		return lo.Batch(
 			input1.OnUpdate(func(_, input1 InputType1) {
@@ -80,8 +80,8 @@ func DeriveVariableFrom2Inputs[Type, InputType1, InputType2 comparable, InputVal
 	})
 }
 
-// DeriveVariableFrom3Inputs creates a DerivedVariable that transforms three input values into a different one.
-func DeriveVariableFrom3Inputs[Type, InputType1, InputType2, InputType3 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2], InputValueType3 ReadableVariable[InputType3]](compute func(InputType1, InputType2, InputType3) Type, input1 InputValueType1, input2 InputValueType2, input3 InputValueType3) DerivedVariable[Type] {
+// NewDerivedVariable3 creates a DerivedVariable that transforms three input values into a different one.
+func NewDerivedVariable3[Type, InputType1, InputType2, InputType3 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2], InputValueType3 ReadableVariable[InputType3]](compute func(InputType1, InputType2, InputType3) Type, input1 InputValueType1, input2 InputValueType2, input3 InputValueType3) DerivedVariable[Type] {
 	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
 		return lo.Batch(
 			input1.OnUpdate(func(_, input1 InputType1) {

--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -1,0 +1,102 @@
+package reactive
+
+import (
+	"github.com/iotaledger/hive.go/lo"
+)
+
+// region Variable /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Variable represents a variable that can be read and written and that informs subscribed consumers about updates.
+type Variable[Type comparable] interface {
+	// Set sets the new value and triggers the registered callbacks if the value has changed.
+	Set(newValue Type) (previousValue Type)
+
+	// Compute sets the new value by applying the given function to the current value and triggers the registered
+	// callbacks if the value has changed.
+	Compute(computeFunc func(currentValue Type) Type) (previousValue Type)
+
+	// ReadableVariable imports the interface that allows subscribers to read the value and to be notified when it changes.
+	ReadableVariable[Type]
+}
+
+// NewVariable creates a new Variable instance with an optional transformation function that can be used to rewrite the
+// value before it is stored.
+func NewVariable[Type comparable](transformationFunc ...func(currentValue Type, newValue Type) Type) Variable[Type] {
+	return newVariable(transformationFunc...)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region ReadableVariable /////////////////////////////////////////////////////////////////////////////////////////////
+
+// ReadableVariable represents a variable that can be read and that informs subscribed consumers about updates.
+type ReadableVariable[Type comparable] interface {
+	// Get returns the current value.
+	Get() Type
+
+	// OnUpdate registers the given callback that is triggered when the value changes.
+	OnUpdate(consumer func(oldValue, newValue Type), triggerWithInitialZeroValue ...bool) (unsubscribe func())
+}
+
+// NewReadableVariable creates a new ReadableVariable instance with the given value.
+func NewReadableVariable[Type comparable](value Type) ReadableVariable[Type] {
+	return newReadableVariable(value)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region DerivedVariable //////////////////////////////////////////////////////////////////////////////////////////////
+
+// DerivedVariable is a Variable that automatically derives its value from other input values.
+type DerivedVariable[Type comparable] interface {
+	// Variable is the variable that holds the derived value.
+	Variable[Type]
+
+	// Unsubscribe unsubscribes the DerivedVariable from its input values.
+	Unsubscribe()
+}
+
+// DeriveVariableFromInput creates a DerivedVariable that transforms an input value into a different one.
+func DeriveVariableFromInput[Type, InputType1 comparable, InputValueType1 ReadableVariable[InputType1]](compute func(InputType1) Type, input1 *InputValueType1) DerivedVariable[Type] {
+	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
+		return (*input1).OnUpdate(func(_, input1 InputType1) {
+			d.Compute(func(_ Type) Type { return compute(input1) })
+		}, true)
+	})
+}
+
+// DeriveVariableFrom2Inputs creates a DerivedVariable that transforms two input values into a different one.
+func DeriveVariableFrom2Inputs[Type, InputType1, InputType2 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2]](compute func(InputType1, InputType2) Type, input1 *InputValueType1, input2 *InputValueType2) DerivedVariable[Type] {
+	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
+		return lo.Batch(
+			(*input1).OnUpdate(func(_, input1 InputType1) {
+				d.Compute(func(_ Type) Type { return compute(input1, (*input2).Get()) })
+			}, true),
+
+			(*input2).OnUpdate(func(_, input2 InputType2) {
+				d.Compute(func(_ Type) Type { return compute((*input1).Get(), input2) })
+			}, true),
+		)
+	})
+}
+
+// DeriveVariableFrom3Inputs creates a DerivedVariable that transforms three input values into a different one.
+func DeriveVariableFrom3Inputs[Type, InputType1, InputType2, InputType3 comparable, InputValueType1 ReadableVariable[InputType1], InputValueType2 ReadableVariable[InputType2], InputValueType3 ReadableVariable[InputType3]](compute func(InputType1, InputType2, InputType3) Type, input1 *InputValueType1, input2 *InputValueType2, input3 *InputValueType3) DerivedVariable[Type] {
+	return newDerivedVariable[Type](func(d DerivedVariable[Type]) func() {
+		return lo.Batch(
+			(*input1).OnUpdate(func(_, input1 InputType1) {
+				d.Compute(func(_ Type) Type { return compute(input1, (*input2).Get(), (*input3).Get()) })
+			}, true),
+
+			(*input2).OnUpdate(func(_, input2 InputType2) {
+				d.Compute(func(_ Type) Type { return compute((*input1).Get(), input2, (*input3).Get()) })
+			}, true),
+
+			(*input3).OnUpdate(func(_, input3 InputType3) {
+				d.Compute(func(_ Type) Type { return compute((*input1).Get(), (*input2).Get(), input3) })
+			}, true),
+		)
+	})
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -58,15 +58,13 @@ func (v *variable[Type]) updateValue(newValueGenerator func(Type) Type) (newValu
 	v.valueMutex.Lock()
 	defer v.valueMutex.Unlock()
 
-	previousValue = v.value
-	newValue = v.transformationFunc(previousValue, newValueGenerator(previousValue))
-	if newValue == previousValue {
-		return newValue, previousValue, 0, nil
+	if previousValue, newValue = v.value, v.transformationFunc(v.value, newValueGenerator(v.value)); newValue != previousValue {
+		v.value = newValue
+		triggerID = v.uniqueUpdateID.Next()
+		callbacksToTrigger = v.registeredCallbacks.Values()
 	}
 
-	v.value = newValue
-
-	return newValue, previousValue, v.uniqueUpdateID.Next(), v.registeredCallbacks.Values()
+	return newValue, previousValue, triggerID, callbacksToTrigger
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -1,0 +1,167 @@
+package reactive
+
+import (
+	"sync"
+
+	"github.com/iotaledger/hive.go/ds/shrinkingmap"
+	"github.com/iotaledger/hive.go/lo"
+)
+
+// region variable /////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// variable is the default implementation of the Variable interface.
+type variable[Type comparable] struct {
+	*readableVariable[Type]
+
+	// transformationFunc is the function that is used to transform the value before it is stored.
+	transformationFunc func(currentValue Type, newValue Type) Type
+
+	// updateOrderMutex is used to make sure that write operations are executed sequentially (all subscribers are
+	// notified before the next write operation is executed).
+	updateOrderMutex sync.Mutex
+}
+
+// newVariable creates a new variable with an optional transformation function that can be used to rewrite the value
+// before it is stored.
+func newVariable[Type comparable](transformationFunc ...func(currentValue Type, newValue Type) Type) *variable[Type] {
+	return &variable[Type]{
+		transformationFunc: lo.First(transformationFunc, func(_ Type, newValue Type) Type { return newValue }),
+		readableVariable:   newReadableVariable[Type](),
+	}
+}
+
+// Set sets the new value and triggers the registered callbacks if the value has changed.
+func (v *variable[Type]) Set(newValue Type) (previousValue Type) {
+	return v.Compute(func(Type) Type { return newValue })
+}
+
+// Compute computes the new value based on the current value and triggers the registered callbacks if the value changed.
+func (v *variable[Type]) Compute(computeFunc func(currentValue Type) Type) (previousValue Type) {
+	v.updateOrderMutex.Lock()
+	defer v.updateOrderMutex.Unlock()
+
+	newValue, previousValue, updateID, registeredCallbacks := v.updateValue(computeFunc)
+
+	for _, registeredCallback := range registeredCallbacks {
+		if registeredCallback.LockExecution(updateID) {
+			registeredCallback.Invoke(previousValue, newValue)
+			registeredCallback.UnlockExecution()
+		}
+	}
+
+	return previousValue
+}
+
+// updateValue atomically prepares the trigger by setting the new value and returning the new value, the previous value,
+// the triggerID and the callbacks to trigger.
+func (v *variable[Type]) updateValue(newValueGenerator func(Type) Type) (newValue, previousValue Type, triggerID uniqueID, callbacksToTrigger []*callback[func(prevValue, newValue Type)]) {
+	v.valueMutex.Lock()
+	defer v.valueMutex.Unlock()
+
+	if previousValue, newValue = v.value, newValueGenerator(previousValue); newValue == previousValue {
+		return newValue, previousValue, 0, nil
+	}
+
+	v.value = newValue
+
+	return newValue, previousValue, v.uniqueUpdateID.Next(), v.registeredCallbacks.Values()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region readableVariable /////////////////////////////////////////////////////////////////////////////////////////////
+
+// readableVariable is the default implementation of the ReadableVariable interface.
+type readableVariable[Type comparable] struct {
+	// value holds the current value.
+	value Type
+
+	// registeredCallbacks holds the callbacks that are triggered when the value changes.
+	registeredCallbacks *shrinkingmap.ShrinkingMap[uniqueID, *callback[func(prevValue, newValue Type)]]
+
+	// uniqueUpdateID is used to derive a unique identifier for each update.
+	uniqueUpdateID uniqueID
+
+	// uniqueCallbackID is used to derive a unique identifier for each callback.
+	uniqueCallbackID uniqueID
+
+	// valueMutex is used to ensure that access to the value is synchronized.
+	valueMutex sync.RWMutex
+}
+
+// newReadableVariable creates a new readableVariable instance with an optional initial value.
+func newReadableVariable[Type comparable](initialValue ...Type) *readableVariable[Type] {
+	return &readableVariable[Type]{
+		value:               lo.First(initialValue),
+		registeredCallbacks: shrinkingmap.New[uniqueID, *callback[func(prevValue, newValue Type)]](),
+	}
+}
+
+// Get returns the current value.
+func (r *readableVariable[Type]) Get() Type {
+	r.valueMutex.RLock()
+	defer r.valueMutex.RUnlock()
+
+	return r.value
+}
+
+// OnUpdate registers the given callback that is triggered when the value changes.
+func (r *readableVariable[Type]) OnUpdate(callback func(prevValue, newValue Type), triggerWithInitialZeroValue ...bool) (unsubscribe func()) {
+	r.valueMutex.Lock()
+
+	currentValue := r.value
+	createdCallback := newCallback[func(prevValue, newValue Type)](r.uniqueCallbackID.Next(), callback)
+	r.registeredCallbacks.Set(createdCallback.ID, createdCallback)
+
+	// grab the execution lock before we unlock the mutex, so the callback cannot be triggered by another
+	// thread updating the value before we have called the callback with the initial value
+	createdCallback.LockExecution(r.uniqueUpdateID)
+	defer createdCallback.UnlockExecution()
+
+	r.valueMutex.Unlock()
+
+	var emptyValue Type
+	if currentValue != emptyValue || lo.First(triggerWithInitialZeroValue) {
+		createdCallback.Invoke(emptyValue, currentValue)
+	}
+
+	return func() {
+		r.registeredCallbacks.Delete(createdCallback.ID)
+
+		createdCallback.MarkUnsubscribed()
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region derivedVariable //////////////////////////////////////////////////////////////////////////////////////////////
+
+// derivedVariable implements the DerivedVariable interface.
+type derivedVariable[ValueType comparable] struct {
+	// Variable is the Variable that holds the derived value.
+	Variable[ValueType]
+
+	// unsubscribe is the function that is used to unsubscribe the derivedVariable from the inputs.
+	unsubscribe func()
+
+	// unsubscribeOnce is used to make sure that the unsubscribe function is only called once.
+	unsubscribeOnce sync.Once
+}
+
+// newDerivedVariable creates a new derivedVariable instance.
+func newDerivedVariable[ValueType comparable](subscribe func(DerivedVariable[ValueType]) func()) *derivedVariable[ValueType] {
+	d := &derivedVariable[ValueType]{
+		Variable: NewVariable[ValueType](),
+	}
+
+	d.unsubscribe = subscribe(d)
+
+	return d
+}
+
+// Unsubscribe unsubscribes the DerivedVariable from its input values.
+func (d *derivedVariable[ValueType]) Unsubscribe() {
+	d.unsubscribeOnce.Do(d.unsubscribe)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -58,7 +58,7 @@ func (v *variable[Type]) updateValue(newValueGenerator func(Type) Type) (newValu
 	v.valueMutex.Lock()
 	defer v.valueMutex.Unlock()
 
-	if previousValue, newValue = v.value, newValueGenerator(previousValue); newValue == previousValue {
+	if previousValue, newValue = v.value, v.transformationFunc(previousValue, newValueGenerator(previousValue)); newValue == previousValue {
 		return newValue, previousValue, 0, nil
 	}
 

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -58,7 +58,9 @@ func (v *variable[Type]) updateValue(newValueGenerator func(Type) Type) (newValu
 	v.valueMutex.Lock()
 	defer v.valueMutex.Unlock()
 
-	if previousValue, newValue = v.value, v.transformationFunc(previousValue, newValueGenerator(previousValue)); newValue == previousValue {
+	previousValue = v.value
+	newValue = v.transformationFunc(previousValue, newValueGenerator(previousValue))
+	if newValue == previousValue {
 		return newValue, previousValue, 0, nil
 	}
 

--- a/ds/reactive/variable_test.go
+++ b/ds/reactive/variable_test.go
@@ -1,0 +1,55 @@
+package reactive
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariable(t *testing.T) {
+	myInt := NewVariable[int]()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	myInt.OnUpdate(func(prevValue, newValue int) {
+		if prevValue != 0 {
+			require.Equal(t, prevValue+1, newValue)
+		}
+		//fmt.Println("0> [START] OnUpdate", prevValue, newValue)
+		defer fmt.Println("0> [DONE] OnUpdate ", prevValue, newValue)
+
+		time.Sleep(200 * time.Millisecond)
+
+		if newValue == 3 {
+			wg.Done()
+		}
+	})
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		myInt.OnUpdate(func(prevValue, newValue int) {
+			if prevValue != 0 {
+				require.Equal(t, prevValue+1, newValue)
+			}
+
+			defer fmt.Println("1> [DONE] OnUpdate ", prevValue, newValue)
+
+			time.Sleep(400 * time.Millisecond)
+
+			if newValue == 3 {
+				wg.Done()
+			}
+		})
+	}()
+
+	myInt.Set(1)
+	myInt.Set(2)
+	myInt.Set(3)
+
+	wg.Wait()
+}


### PR DESCRIPTION
This PR introduces the reactive package which provides a set of primitives that can be used to create "reactive circuits" that aim to replace the complex propagation algorithms used in IOTA core by composable and generalized building blocks.