### PR TITLE
Serialize `time.Time` as `uint64`

### DIFF
--- a/serializer/consts.go
+++ b/serializer/consts.go
@@ -1,5 +1,7 @@
 package serializer
 
+import "math"
+
 const (
 	// OneByte is the byte size of a single byte.
 	OneByte = 1
@@ -29,6 +31,8 @@ const (
 	PayloadLengthByteSize = UInt32ByteSize
 	// MinPayloadByteSize is the minimum size of a payload (together with its length denotation).
 	MinPayloadByteSize = UInt32ByteSize + OneByte
+	// MaxNanoTimestampInt64Seconds is the maximum number of seconds that fit into a nanosecond-precision int64 timestamp.
+	MaxNanoTimestampInt64Seconds = math.MaxInt64 / 1_000_000_000
 )
 
 // TypeDenotationType defines a type denotation.


### PR DESCRIPTION
# Description of change

Serialize `time.Time` as `uint64` since all timestamps should be little-endian encoded `uint64`s according to the TIPs.

The approach for converting between a Unix timestamp in `int64` and `uint64` and vice versa, is to truncate to the common value range both types can represent, which allows for any date in the range `1970-01-01 01:00:00 +0100 CET` and `2262-04-12 01:47:16.854775807 +0200 CEST`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Added tests.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
