### PR TITLE
Use UTC time in `ReadTime`

### DIFF
--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -1321,7 +1321,7 @@ func (d *Deserializer) ReadTime(dest *time.Time, errProducer ErrProducer) *Deser
 		nanoseconds = math.MaxInt64
 	}
 
-	*dest = time.Unix(0, int64(nanoseconds)).Local()
+	*dest = time.Unix(0, int64(nanoseconds)).UTC()
 
 	d.offset += UInt64ByteSize
 

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -1321,7 +1321,7 @@ func (d *Deserializer) ReadTime(dest *time.Time, errProducer ErrProducer) *Deser
 		nanoseconds = math.MaxInt64
 	}
 
-	*dest = time.Unix(0, int64(nanoseconds))
+	*dest = time.Unix(0, int64(nanoseconds)).Local()
 
 	d.offset += UInt64ByteSize
 

--- a/serializer/serix/serix_test.go
+++ b/serializer/serix/serix_test.go
@@ -112,7 +112,7 @@ func NewSimpleStruct() SimpleStruct {
 		Bytes:      []byte{1, 2, 3},
 		BytesArray: [16]byte{3, 2, 1},
 		BigInt:     big.NewInt(8),
-		Time:       time.Unix(1000, 1000),
+		Time:       time.Unix(1000, 1000).UTC(),
 		Int:        23,
 		Float:      4.44,
 	}


### PR DESCRIPTION
# Description of change

Use UTC time in `ReadTime`.

UTC is the default for an empty `time.Time` value, so this makes a good default timezone when deserializing.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
