### PR TITLE
Feat: reactive.EvictionState

### DIFF
--- a/ds/reactive/eviction_state.go
+++ b/ds/reactive/eviction_state.go
@@ -1,0 +1,23 @@
+package reactive
+
+// EvictionState is a reactive component that implements a slot based eviction mechanism.
+type EvictionState[Type EvictionStateSlotType] interface {
+	// LastEvictedSlot returns a reactive variable that contains the index of the last evicted slot.
+	LastEvictedSlot() Variable[Type]
+
+	// EvictionEvent returns the event that is triggered when the given slot was evicted.
+	EvictionEvent(slot Type) Event
+
+	// Evict evicts the given slot and triggers the corresponding eviction events.
+	Evict(slot Type)
+}
+
+// NewEvictionState creates a new EvictionState instance.
+func NewEvictionState[Type EvictionStateSlotType]() EvictionState[Type] {
+	return newEvictionState[Type]()
+}
+
+// EvictionStateSlotType represents a constraint for the slot type of EvictionState.
+type EvictionStateSlotType interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+}

--- a/ds/reactive/eviction_state.go
+++ b/ds/reactive/eviction_state.go
@@ -19,5 +19,5 @@ func NewEvictionState[Type EvictionStateSlotType]() EvictionState[Type] {
 
 // EvictionStateSlotType represents a constraint for the slot type of EvictionState.
 type EvictionStateSlotType interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64 | ~string
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | ~float32 | ~float64
 }

--- a/ds/reactive/eviction_state_impl.go
+++ b/ds/reactive/eviction_state_impl.go
@@ -53,7 +53,7 @@ func (e *evictionState[Type]) evict(slot Type) (eventsToTrigger []Event) {
 			return lastEvictedSlotIndex
 		}
 
-		for i := lastEvictedSlotIndex + Type(1); i <= slot; i = i + Type(1) {
+		for i := lastEvictedSlotIndex + Type(1); i <= slot; i++ {
 			if slotEvictedEvent, exists := e.evictionEvents.Get(i); exists {
 				eventsToTrigger = append(eventsToTrigger, slotEvictedEvent)
 			}

--- a/ds/reactive/eviction_state_impl.go
+++ b/ds/reactive/eviction_state_impl.go
@@ -1,0 +1,74 @@
+package reactive
+
+import (
+	"github.com/iotaledger/hive.go/ds/shrinkingmap"
+)
+
+// evictionState is the default implementation of the EvictionState interface.
+type evictionState[Type EvictionStateSlotType] struct {
+	// lastEvictedSlot is the index of the last evicted slot.
+	lastEvictedSlot Variable[Type]
+
+	// evictionEvents is the map of all eviction events that were not evicted yet.
+	evictionEvents *shrinkingmap.ShrinkingMap[Type, Event]
+}
+
+// newEvictionState creates a new evictionState instance.
+func newEvictionState[Type EvictionStateSlotType]() *evictionState[Type] {
+	return &evictionState[Type]{
+		lastEvictedSlot: NewVariable[Type](),
+		evictionEvents:  shrinkingmap.New[Type, Event](),
+	}
+}
+
+// LastEvictedSlot returns a reactive variable that contains the index of the last evicted slot.
+func (e *evictionState[Type]) LastEvictedSlot() Variable[Type] {
+	return e.lastEvictedSlot
+}
+
+// EvictionEvent returns the event that is triggered when the given slot was evicted.
+func (e *evictionState[Type]) EvictionEvent(slot Type) Event {
+	evictionEvent := evictedSlotEvent
+
+	e.lastEvictedSlot.Read(func(lastEvictedSlotIndex Type) {
+		if slot > lastEvictedSlotIndex {
+			evictionEvent, _ = e.evictionEvents.GetOrCreate(slot, NewEvent)
+		}
+	})
+
+	return evictionEvent
+}
+
+// Evict evicts the given slot and triggers the corresponding eviction events.
+func (e *evictionState[Type]) Evict(slot Type) {
+	for _, slotEvictedEvent := range e.evict(slot) {
+		slotEvictedEvent.Trigger()
+	}
+}
+
+// evict advances the lastEvictedSlot to the given slot and returns the events that shall be triggered.
+func (e *evictionState[Type]) evict(slot Type) (eventsToTrigger []Event) {
+	e.lastEvictedSlot.Compute(func(lastEvictedSlotIndex Type) Type {
+		if slot <= lastEvictedSlotIndex {
+			return lastEvictedSlotIndex
+		}
+
+		for i := lastEvictedSlotIndex + Type(1); i <= slot; i = i + Type(1) {
+			if slotEvictedEvent, exists := e.evictionEvents.Get(i); exists {
+				eventsToTrigger = append(eventsToTrigger, slotEvictedEvent)
+			}
+		}
+
+		return slot
+	})
+
+	return eventsToTrigger
+}
+
+// evictedSlotEvent holds an event that rep
+var evictedSlotEvent = func() Event {
+	e := NewEvent()
+	e.Trigger()
+
+	return e
+}()


### PR DESCRIPTION
This PR introduces a reactive EvictionState.

Instead of making each consumer manage its own slot based storage, this component exposes a slot based eviction event which allows us to associate the eviction with a specific slot without the need for a fragmented cache in the consuming components.