### PR TITLE
Feat: Added OnUpdateOnce method to reactive Variable

### DIFF
--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -38,6 +38,10 @@ type ReadableVariable[Type comparable] interface {
 
 	// OnUpdate registers the given callback that is triggered when the value changes.
 	OnUpdate(consumer func(oldValue, newValue Type), triggerWithInitialZeroValue ...bool) (unsubscribe func())
+
+	// OnUpdateOnce registers the given callback for the next update and then automatically unsubscribes it. It is
+	// possible to provide an optional condition that has to be satisfied for the callback to be triggered.
+	OnUpdateOnce(callback func(oldValue Type, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool)
 }
 
 // NewReadableVariable creates a new ReadableVariable instance with the given value.

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -157,20 +157,25 @@ func (r *readableVariable[Type]) OnUpdate(callback func(prevValue, newValue Type
 // OnUpdateOnce registers the given callback for the next update and then automatically unsubscribes it. It is possible
 // to provide an optional condition that has to be satisfied for the callback to be triggered.
 func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool) {
+	callbackTriggered := NewEvent()
 	var triggeredPreValue, triggeredNewValue Type
 
-	triggered := NewEvent()
-
 	unsubscribe := r.OnUpdate(func(prevValue, newValue Type) {
-		if len(optCondition) == 0 || optCondition[0](prevValue, newValue) {
-			triggeredPreValue = prevValue
-			triggeredNewValue = newValue
-
-			triggered.Trigger()
+		if callbackTriggered.Get() {
+			return
 		}
+
+		if len(optCondition) != 0 && !optCondition[0](prevValue, newValue) {
+			return
+		}
+
+		triggeredPreValue = prevValue
+		triggeredNewValue = newValue
+
+		callbackTriggered.Trigger()
 	})
 
-	triggered.OnTrigger(func() {
+	callbackTriggered.OnTrigger(func() {
 		go unsubscribe()
 
 		callback(triggeredPreValue, triggeredNewValue)

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -154,6 +154,29 @@ func (r *readableVariable[Type]) OnUpdate(callback func(prevValue, newValue Type
 	}
 }
 
+// OnUpdateOnce registers the given callback for the next update and then automatically unsubscribes it. It is possible
+// to provide an optional condition that has to be satisfied for the callback to be triggered.
+func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool) {
+	var triggeredPreValue, triggeredNewValue Type
+
+	triggered := NewEvent()
+
+	unsubscribe := r.OnUpdate(func(prevValue, newValue Type) {
+		if len(optCondition) == 0 || optCondition[0](prevValue, newValue) {
+			triggeredPreValue = prevValue
+			triggeredNewValue = newValue
+
+			triggered.Trigger()
+		}
+	})
+
+	triggered.OnTrigger(func() {
+		go unsubscribe()
+
+		callback(triggeredPreValue, triggeredNewValue)
+	})
+}
+
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // region derivedVariable //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds a convenience methid called "OnUpdateOnce", which automatically unregisters the callback once it was executed the first time.

It is possible to provide an optional condition that has to be satisfied for the callback to be triggered.