### PR TITLE
Feat: Added new Shutdown event to module

### DIFF
--- a/runtime/module/interface.go
+++ b/runtime/module/interface.go
@@ -23,6 +23,15 @@ type Interface interface {
 	// Shutdown shuts down the module, should finally call TriggerStopped.
 	Shutdown()
 
+	// TriggerShutdown triggers the shutdown event.
+	TriggerShutdown()
+
+	// WasShutdown returns true if the shutdown event was triggered.
+	WasShutdown() bool
+
+	// HookShutdown registers a callback for the shutdown event.
+	HookShutdown(func()) (unsubscribe func())
+
 	// TriggerStopped triggers the stopped event.
 	TriggerStopped()
 


### PR DESCRIPTION
This PR introduces a new shutdown event in the Module interface which can be triggered when the shutdown procedure starts which is triggered before the stopped event which indicates that the shutdown was completed.