### PR TITLE
Encode time.Time to uint64 string in map encode

### DIFF
--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -472,13 +472,15 @@ func (s *Serializer) WriteTime(timeToWrite time.Time, errProducer ErrProducer) *
 // nanosecond-precision int64 timestamp will be truncated to the max value.
 // Times before the Unix Epoch will be truncated to the Unix Epoch.
 func TimeToUint64(value time.Time) uint64 {
+	unixSeconds := value.Unix()
 	unixNano := value.UnixNano()
 
 	// we need to check against Unix seconds here, because the UnixNano result is undefined if the Unix time
 	// in nanoseconds cannot be represented by an int64 (a date before the year 1678 or after 2262)
-	if value.Unix() > MaxNanoTimestampInt64Seconds {
+	switch {
+	case unixSeconds > MaxNanoTimestampInt64Seconds:
 		unixNano = math.MaxInt64
-	} else if unixNano < 0 {
+	case unixSeconds < 0 || unixNano < 0:
 		unixNano = 0
 	}
 

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -467,19 +467,19 @@ func (s *Serializer) WriteTime(timeToWrite time.Time, errProducer ErrProducer) *
 	return s
 }
 
-func TimeToUint64(timeToConvert time.Time) uint64 {
-	// Convert the int64 timestamp to uint64 by truncating.
-	var unixNano int64
-	// Times whose unix timestamp in seconds would be larger than what fits into a
-	// nanosecond-precision int64 timestamp will be truncated to the max value.
-	if timeToConvert.Unix() > MaxNanoTimestampInt64Seconds {
+// TimeToUint64 converts times to uint64 unix timestamps with nanosecond-precision.
+// Times whose unix timestamp in seconds would be larger than what fits into a
+// nanosecond-precision int64 timestamp will be truncated to the max value.
+// Times before the Unix Epoch will be truncated to the Unix Epoch.
+func TimeToUint64(value time.Time) uint64 {
+	unixNano := value.UnixNano()
+
+	// we need to check against Unix seconds here, because the UnixNano result is undefined if the Unix time
+	// in nanoseconds cannot be represented by an int64 (a date before the year 1678 or after 2262)
+	if value.Unix() > MaxNanoTimestampInt64Seconds {
 		unixNano = math.MaxInt64
-	} else {
-		unixNano = timeToConvert.UnixNano()
-		// Times before the Unix Epoch will be truncated to the Unix Epoch.
-		if unixNano < 0 {
-			unixNano = 0
-		}
+	} else if unixNano < 0 {
+		unixNano = 0
 	}
 
 	return uint64(unixNano)

--- a/serializer/serializer_test.go
+++ b/serializer/serializer_test.go
@@ -408,6 +408,18 @@ func TestReadWriteTime(t *testing.T) {
 			expectedErr:       nil,
 		},
 		{
+			name:              "ok - time nano before unix epoch is truncated",
+			timeToWrite:       time.Unix(0, -1_000_000),
+			expectedTimestamp: time.Unix(0, 0),
+			expectedErr:       nil,
+		},
+		{
+			name:              "ok - time before min representable is truncated",
+			timeToWrite:       time.Unix(-(serializer.MaxNanoTimestampInt64Seconds + 1), 0),
+			expectedTimestamp: time.Unix(0, 0),
+			expectedErr:       nil,
+		},
+		{
 			name:              "ok - time after max representable is truncated to max",
 			timeToWrite:       time.Unix(serializer.MaxNanoTimestampInt64Seconds+1, 0),
 			expectedTimestamp: time.Unix(0, math.MaxInt64),

--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -269,11 +269,12 @@ func (api *API) mapDecodeStruct(ctx context.Context, mapVal any, value reflect.V
 	valueType reflect.Type, ts TypeSettings, opts *options) error {
 	if valueType == timeType {
 		strVal := mapVal.(string)
-		parsedTime, err := time.Parse(time.RFC3339Nano, strVal)
+		nanoTime, err := strconv.ParseUint(strVal, 10, 64)
 		if err != nil {
 			return ierrors.Wrapf(err, "unable to parse time %s map value", strVal)
 		}
-		value.Set(reflect.ValueOf(parsedTime))
+
+		value.Set(reflect.ValueOf(time.Unix(0, int64(nanoTime)).UTC()))
 
 		return nil
 	}

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -2,7 +2,6 @@ package serix
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -147,20 +146,9 @@ func (api *API) mapEncodeStruct(
 	ctx context.Context, value reflect.Value, valueI interface{}, valueType reflect.Type, ts TypeSettings, opts *options,
 ) (any, error) {
 	if valueTime, ok := valueI.(time.Time); ok {
-		// Convert the int64 timestamp to uint64 by truncating.
-		var unixNano int64
-		// Times whose unix timestamp in seconds would be larger than what fits into a
-		// nanosecond-precision int64 timestamp will be truncated to the max value.
-		if valueTime.Unix() > serializer.MaxNanoTimestampInt64Seconds {
-			unixNano = math.MaxInt64
-		} else {
-			unixNano = valueTime.UnixNano()
-			// Times before the Unix Epoch will be truncated to the Unix Epoch.
-			if unixNano < 0 {
-				unixNano = 0
-			}
-		}
-		return strconv.FormatUint(uint64(unixNano), 10), nil
+		timeUint64 := serializer.TimeToUint64(valueTime)
+
+		return strconv.FormatUint(timeUint64, 10), nil
 	}
 
 	obj := orderedmap.New()

--- a/serializer/serix/map_encode_test.go
+++ b/serializer/serix/map_encode_test.go
@@ -374,8 +374,9 @@ func TestMapEncodeDecode(t *testing.T) {
 				api := serix.NewAPI()
 				must(api.RegisterTypeSettings(example{}, serix.TypeSettings{}.WithObjectType(uint8(23))))
 
-				exampleTime, err := time.Parse(time.RFC3339Nano, "2022-08-12T12:51:18.120072+02:00")
+				uint64Time, err := strconv.ParseUint("1660301478120072000", 10, 64)
 				require.NoError(t, err)
+				exampleTime := time.Unix(0, int64(uint64Time)).UTC()
 
 				return paras{
 					api: api,
@@ -386,7 +387,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			}(),
 			expected: `{
 				"type": 23,
- 				"creationDate": "2022-08-12T12:51:18.120072+02:00"
+ 				"creationDate": "1660301478120072000"
 			}`,
 		},
 


### PR DESCRIPTION
Apply changes in #533 to serix mapEncode and mapDecode.


