### PR TITLE
Feat: Added methods to module package that allows us to wait for multiple modules

### DIFF
--- a/runtime/module/utils.go
+++ b/runtime/module/utils.go
@@ -1,0 +1,46 @@
+package module
+
+import (
+	"sync/atomic"
+
+	"github.com/iotaledger/hive.go/lo"
+)
+
+// OnAllConstructed registers a callback that gets executed when all given modules have been constructed.
+func OnAllConstructed(callback func(), modules ...Interface) (unsubscribe func()) {
+	return onModulesTriggered(Interface.HookConstructed, callback, modules...)
+}
+
+// OnAllInitialized registers a callback that gets executed when all given modules have been initialized.
+func OnAllInitialized(callback func(), modulesToWaitFor ...Interface) (unsubscribe func()) {
+	return onModulesTriggered(Interface.HookInitialized, callback, modulesToWaitFor...)
+}
+
+// OnAllShutdown registers a callback that gets executed when all given modules have been shutdown.
+func OnAllShutdown(callback func(), modulesToWaitFor ...Interface) (unsubscribe func()) {
+	return onModulesTriggered(Interface.HookShutdown, callback, modulesToWaitFor...)
+}
+
+// OnAllStopped registers a callback that gets executed when all given modules have been stopped.
+func OnAllStopped(callback func(), modulesToWaitFor ...Interface) (unsubscribe func()) {
+	return onModulesTriggered(Interface.HookStopped, callback, modulesToWaitFor...)
+}
+
+// onModulesTriggered registers a callback that gets executed when all given modules have triggered the given hook.
+func onModulesTriggered(targetHook func(Interface, func()) func(), callback func(), modulesToWaitFor ...Interface) (unsubscribe func()) {
+	var (
+		expectedTriggerCount = int64(len(modulesToWaitFor))
+		actualTriggerCount   atomic.Int64
+	)
+
+	unsubscribeFunctions := make([]func(), len(modulesToWaitFor))
+	for i, module := range modulesToWaitFor {
+		unsubscribeFunctions[i] = targetHook(module, func() {
+			if actualTriggerCount.Add(1) == expectedTriggerCount {
+				callback()
+			}
+		})
+	}
+
+	return lo.Batch(unsubscribeFunctions...)
+}


### PR DESCRIPTION
When we construct components, we often wait for the parent component to be fully constructed before accessing the necessary dependencies.

This happens by doing sth. like:

```
engine.HookConstructed(func() {
    engine.Dependency1.Events.Hook....
    engine.Dependency2.Events.Hook....
})
```

Since the constructed event is only called after we have filled in all of our subcomponents, all of the dependencies are accessible.

It can however happen that we need to access a subcomponent of a dependency and this subcomponent is only available after the dependency itself has been fully constructed.

```
engine.HookConstructed(func() {
    engine.Dependency1.Events.Hook....
    engine.Dependency2.Events.Hook....
    
    // nil pointer exception as SubComponent is only available later
    engine.Dependency1.SubComponent.DoSth()
})
```

We could hook to the constructed event of that Dependency to fill in its subcomponents but what if we need to wait for multiple dependencies before executing some code?

To enable this use case we add 4 new utility functions that allow us to wait for the 4 different lifecycle events of an arbitrary number of other modules:

```
engine.HookConstructed(func() {
    module.OnAllConstructed(func() {
        engine.Dependency1.Events.Hook....
        engine.Dependency2.Events.Hook....
    
        // no nil pointer exception as we wait for Dependency1 to also be constructed
        engine.Dependency1.SubComponent.DoSth()
    }, engine.Dependency1, engine.Dependency2)
})
```