### PR TITLE
Add de/serialization of pointers to array types incl. object type

### DIFF
--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -43,12 +43,12 @@ func (api *API) decode(ctx context.Context, b []byte, value reflect.Value, ts Ty
 				return 0, ierrors.WithStack(err)
 			}
 
-			deserializer := serializer.NewDeserializer(b)
-			deserializer.CheckTypePrefix(objectCode, typeDen, func(err error) error {
+			deseri := serializer.NewDeserializer(b)
+			deseri.CheckTypePrefix(objectCode, typeDen, func(err error) error {
 				return ierrors.Wrap(err, "failed to check object type")
 			})
-			b = deserializer.RemainingBytes()
-			prefixBytesRead, err := deserializer.Done()
+			b = deseri.RemainingBytes()
+			prefixBytesRead, err := deseri.Done()
 			if err != nil {
 				return 0, ierrors.WithStack(err)
 			}
@@ -177,8 +177,8 @@ func (api *API) decodeInterface(
 	if iObjects == nil {
 		return 0, ierrors.Errorf("interface %s hasn't been registered", valueType)
 	}
-	d := serializer.NewDeserializer(b)
-	objectCode, err := d.GetObjectType(iObjects.typeDenotation)
+	deseri := serializer.NewDeserializer(b)
+	objectCode, err := deseri.GetObjectType(iObjects.typeDenotation)
 	if err != nil {
 		return 0, ierrors.WithStack(err)
 	}

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -86,8 +86,12 @@ func (api *API) encodeBasedOnType(
 		if !elemValue.IsValid() {
 			return nil, ierrors.Errorf("unexpected nil pointer for type %T", valueI)
 		}
-		if elemValue.Kind() == reflect.Struct {
+
+		switch elemValue.Kind() {
+		case reflect.Struct:
 			return api.encodeStruct(ctx, elemValue, elemValue.Interface(), elemValue.Type(), ts, opts)
+		case reflect.Array:
+			return api.encodeArray(ctx, elemValue, ts, opts)
 		}
 
 	case reflect.Struct:
@@ -97,17 +101,7 @@ func (api *API) encodeBasedOnType(
 	case reflect.Map:
 		return api.encodeMap(ctx, value, valueType, ts, opts)
 	case reflect.Array:
-		sliceValue := sliceFromArray(value)
-		sliceValueType := sliceValue.Type()
-		if sliceValueType.AssignableTo(bytesType) {
-			seri := serializer.NewSerializer()
-
-			return seri.WriteBytes(sliceValue.Bytes(), func(err error) error {
-				return ierrors.Wrap(err, "failed to write array of bytes to serializer")
-			}).Serialize()
-		}
-
-		return api.encodeSlice(ctx, sliceValue, sliceValueType, ts, opts)
+		return api.encodeArray(ctx, value, ts, opts)
 	case reflect.Interface:
 		return api.encodeInterface(ctx, value, valueType, ts, opts)
 	case reflect.String:
@@ -301,6 +295,28 @@ func (api *API) encodeStructFields(
 	}
 
 	return nil
+}
+
+func (api *API) encodeArray(ctx context.Context, value reflect.Value, ts TypeSettings, opts *options) ([]byte, error) {
+	sliceValue := sliceFromArray(value)
+	sliceValueType := sliceValue.Type()
+
+	// check if it is an array of bytes
+	if sliceValueType.AssignableTo(bytesType) {
+		seri := serializer.NewSerializer()
+		if objectType := ts.ObjectType(); objectType != nil {
+			seri.WriteNum(objectType, func(err error) error {
+				return ierrors.Wrap(err, "failed to write object type code into serializer")
+			})
+		}
+
+		return seri.WriteBytes(sliceValue.Bytes(), func(err error) error {
+			return ierrors.Wrap(err, "failed to write array of bytes to serializer")
+		}).Serialize()
+	}
+
+	// if it is an array of objects, handle the array like a slice
+	return api.encodeSlice(ctx, sliceValue, sliceValueType, ts, opts)
 }
 
 func (api *API) encodeSlice(ctx context.Context, value reflect.Value, valueType reflect.Type,

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -31,11 +31,11 @@ func (api *API) encode(ctx context.Context, value reflect.Value, ts TypeSettings
 
 		var bPrefix, bEncoded []byte
 		if objectType := ts.ObjectType(); objectType != nil {
-			s := serializer.NewSerializer()
-			s.WriteNum(objectType, func(err error) error {
+			seri := serializer.NewSerializer()
+			seri.WriteNum(objectType, func(err error) error {
 				return ierrors.Wrap(err, "failed to write object type code into serializer")
 			})
-			bPrefix, err = s.Serialize()
+			bPrefix, err = seri.Serialize()
 			if err != nil {
 				return nil, ierrors.WithStack(err)
 			}
@@ -219,17 +219,17 @@ func (api *API) encodeStruct(
 			return ierrors.Wrap(err, "failed to write time to serializer")
 		}).Serialize()
 	}
-	s := serializer.NewSerializer()
+	seri := serializer.NewSerializer()
 	if objectType := ts.ObjectType(); objectType != nil {
-		s.WriteNum(objectType, func(err error) error {
+		seri.WriteNum(objectType, func(err error) error {
 			return ierrors.Wrap(err, "failed to write object type code into serializer")
 		})
 	}
-	if err := api.encodeStructFields(ctx, s, value, valueType, opts); err != nil {
+	if err := api.encodeStructFields(ctx, seri, value, valueType, opts); err != nil {
 		return nil, ierrors.WithStack(err)
 	}
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 func (api *API) encodeStructFields(

--- a/serializer/serix/serix_test.go
+++ b/serializer/serix/serix_test.go
@@ -72,10 +72,10 @@ func (bs Bools) Deserialize(data []byte, deSeriMode serializer.DeSerializationMo
 }
 
 func (bs Bools) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	s := serializer.NewSerializer()
-	s.WriteSliceOfObjects(bs, deSeriMode, deSeriCtx, serializer.SeriLengthPrefixType(boolsLenType), defaultArrayRules, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WriteSliceOfObjects(bs, deSeriMode, deSeriCtx, serializer.SeriLengthPrefixType(boolsLenType), defaultArrayRules, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 func (bs Bools) ToSerializables() serializer.Serializables {
@@ -136,19 +136,19 @@ func (ss SimpleStruct) Deserialize(data []byte, deSeriMode serializer.DeSerializ
 }
 
 func (ss SimpleStruct) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	s := serializer.NewSerializer()
-	s.WriteNum(simpleStructObjectCode, defaultErrProducer)
-	s.WriteBool(ss.Bool, defaultErrProducer)
-	s.WriteNum(ss.Uint, defaultErrProducer)
-	s.WriteString(ss.String, serializer.SeriLengthPrefixTypeAsUint16, defaultErrProducer, 0, 0)
-	s.WriteVariableByteSlice(ss.Bytes, serializer.SeriLengthPrefixTypeAsUint32, defaultErrProducer, 0, 0)
-	s.WriteBytes(ss.BytesArray[:], defaultErrProducer)
-	s.WriteUint256(ss.BigInt, defaultErrProducer)
-	s.WriteTime(ss.Time, defaultErrProducer)
-	s.WriteNum(ss.Int, defaultErrProducer)
-	s.WriteNum(ss.Float, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WriteNum(simpleStructObjectCode, defaultErrProducer)
+	seri.WriteBool(ss.Bool, defaultErrProducer)
+	seri.WriteNum(ss.Uint, defaultErrProducer)
+	seri.WriteString(ss.String, serializer.SeriLengthPrefixTypeAsUint16, defaultErrProducer, 0, 0)
+	seri.WriteVariableByteSlice(ss.Bytes, serializer.SeriLengthPrefixTypeAsUint32, defaultErrProducer, 0, 0)
+	seri.WriteBytes(ss.BytesArray[:], defaultErrProducer)
+	seri.WriteUint256(ss.BigInt, defaultErrProducer)
+	seri.WriteTime(ss.Time, defaultErrProducer)
+	seri.WriteNum(ss.Int, defaultErrProducer)
+	seri.WriteNum(ss.Float, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 type Interface interface {
@@ -195,12 +195,12 @@ func (ii *InterfaceImpl) Deserialize(data []byte, deSeriMode serializer.DeSerial
 }
 
 func (ii *InterfaceImpl) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	ser := serializer.NewSerializer()
-	ser.WriteNum(interfaceImplObjectCode, defaultErrProducer)
-	ser.WriteNum(ii.A, defaultErrProducer)
-	ser.WriteNum(ii.B, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WriteNum(interfaceImplObjectCode, defaultErrProducer)
+	seri.WriteNum(ii.A, defaultErrProducer)
+	seri.WriteNum(ii.B, defaultErrProducer)
 
-	return ser.Serialize()
+	return seri.Serialize()
 }
 
 type StructWithInterface struct {
@@ -223,10 +223,10 @@ func (si StructWithInterface) Deserialize(data []byte, deSeriMode serializer.DeS
 }
 
 func (si StructWithInterface) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	s := serializer.NewSerializer()
-	s.WriteObject(si.Interface.(serializer.Serializable), defaultSeriMode, deSeriCtx, defaultWriteGuard, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WriteObject(si.Interface.(serializer.Serializable), defaultSeriMode, deSeriCtx, defaultWriteGuard, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 type StructWithOptionalField struct {
@@ -249,10 +249,10 @@ func (so StructWithOptionalField) Deserialize(data []byte, deSeriMode serializer
 }
 
 func (so StructWithOptionalField) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	s := serializer.NewSerializer()
-	s.WritePayloadLength(0, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WritePayloadLength(0, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 type StructWithEmbeddedStructs struct {
@@ -276,12 +276,12 @@ func (se StructWithEmbeddedStructs) Deserialize(data []byte, deSeriMode serializ
 }
 
 func (se StructWithEmbeddedStructs) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) ([]byte, error) {
-	s := serializer.NewSerializer()
-	s.WriteNum(se.unexportedStruct.Foo, defaultErrProducer)
-	s.WriteNum(exportedStructObjectCode, defaultErrProducer)
-	s.WriteNum(se.ExportedStruct.Bar, defaultErrProducer)
+	seri := serializer.NewSerializer()
+	seri.WriteNum(se.unexportedStruct.Foo, defaultErrProducer)
+	seri.WriteNum(exportedStructObjectCode, defaultErrProducer)
+	seri.WriteNum(se.ExportedStruct.Bar, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 type unexportedStruct struct {
@@ -317,22 +317,22 @@ func (m Map) Serialize(deSeriMode serializer.DeSerializationMode, deSeriCtx inte
 	bytes := make([][]byte, len(m))
 	var i int
 	for k, v := range m {
-		s := serializer.NewSerializer()
-		s.WriteNum(k, defaultErrProducer)
-		s.WriteNum(v, defaultErrProducer)
-		b, err := s.Serialize()
+		seri := serializer.NewSerializer()
+		seri.WriteNum(k, defaultErrProducer)
+		seri.WriteNum(v, defaultErrProducer)
+		b, err := seri.Serialize()
 		if err != nil {
 			return nil, err
 		}
 		bytes[i] = b
 		i++
 	}
-	s := serializer.NewSerializer()
+	seri := serializer.NewSerializer()
 	mode := defaultSeriMode | serializer.DeSeriModePerformLexicalOrdering
 	arrayRules := &serializer.ArrayRules{ValidationMode: serializer.ArrayValidationModeLexicalOrdering}
-	s.WriteSliceOfByteSlices(bytes, mode, serializer.SeriLengthPrefixType(mapLenType), arrayRules, defaultErrProducer)
+	seri.WriteSliceOfByteSlices(bytes, mode, serializer.SeriLengthPrefixType(mapLenType), arrayRules, defaultErrProducer)
 
-	return s.Serialize()
+	return seri.Serialize()
 }
 
 type CustomSerializable int


### PR DESCRIPTION
This PR adds the possibility to also use pointers to array values in the serix de/serialization.
Also the object type is added / checked.

We can use that to remove the custom serialization of our "Address" implementations in iota.go, because there we currently have to use the following interfaces with manual serialization.
```golang
type Address interface {
	serix.Serializable
	serix.Deserializable
```