### PR TITLE
Initialize slices in serix if the slice was empty during deserialization

### DIFF
--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -349,7 +349,18 @@ func (api *API) decodeSlice(ctx context.Context, b []byte, value reflect.Value,
 		return bytesRead, nil
 	}
 
-	return api.decodeSequence(b, deserializeItem, valueType, ts, opts)
+	bytesRead, err := api.decodeSequence(b, deserializeItem, valueType, ts, opts)
+	if err != nil {
+		return bytesRead, err
+	}
+
+	// check if the slice is a nil pointer to the slice type (in case the sliceLength is zero and the slice was not initialized before)
+	if value.IsNil() {
+		// initialize a new empty slice
+		value.Set(reflect.MakeSlice(valueType, 0, 0))
+	}
+
+	return bytesRead, nil
 }
 
 func (api *API) decodeMap(ctx context.Context, b []byte, value reflect.Value,

--- a/serializer/serix/decode_test.go
+++ b/serializer/serix/decode_test.go
@@ -18,6 +18,13 @@ func TestDecode_Slice(t *testing.T) {
 	testDecode(t, testObj, serix.WithTypeSettings(ts))
 }
 
+func TestDecode_EmptySlice(t *testing.T) {
+	t.Parallel()
+	testObj := Bools{}
+	ts := serix.TypeSettings{}.WithLengthPrefixType(boolsLenType)
+	testDecode(t, testObj, serix.WithTypeSettings(ts))
+}
+
 func TestDecode_Struct(t *testing.T) {
 	t.Parallel()
 	testObj := NewSimpleStruct()


### PR DESCRIPTION
This PR fixes deserialization problems, were we get a nil pointer to a slice, instead of a pointer to an empty slice, if we deserialized data with `sliceLength==0`