### PR TITLE
Feat: Extended Unsubscribe of OnUpdate methods

### DIFF
--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -43,7 +43,7 @@ type ReadableVariable[Type comparable] interface {
 
 	// OnUpdateOnce registers the given callback for the next update and then automatically unsubscribes it. It is
 	// possible to provide an optional condition that has to be satisfied for the callback to be triggered.
-	OnUpdateOnce(callback func(oldValue, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool)
+	OnUpdateOnce(callback func(oldValue, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool) (unsubscribe func())
 
 	// OnUpdateWithContext registers the given callback that is triggered when the value changes. In contrast to the
 	// normal OnUpdate method, this method provides the old and new value as well as a withinContext function that can

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -179,7 +179,9 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 	callbackTriggered.OnTrigger(func() {
 		go unsubscribeFromVariable()
 
-		callback(triggeredPreValue, triggeredNewValue)
+		if triggeredPreValue != triggeredNewValue {
+			callback(triggeredPreValue, triggeredNewValue)
+		}
 	})
 
 	return func() { callbackTriggered.Trigger() }

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -161,7 +161,7 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 	callbackTriggered := NewEvent()
 	var triggeredPreValue, triggeredNewValue Type
 
-	unsubscribe = r.OnUpdate(func(prevValue, newValue Type) {
+	unsubscribeFromVariable := r.OnUpdate(func(prevValue, newValue Type) {
 		if callbackTriggered.Get() {
 			return
 		}
@@ -177,7 +177,7 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 	})
 
 	callbackTriggered.OnTrigger(func() {
-		go unsubscribe()
+		go unsubscribeFromVariable()
 
 		callback(triggeredPreValue, triggeredNewValue)
 	})
@@ -191,7 +191,7 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 func (r *readableVariable[Type]) OnUpdateWithContext(callback func(oldValue, newValue Type, withinContext func(subscriptionFactory func() (unsubscribe func()))), triggerWithInitialZeroValue ...bool) (unsubscribe func()) {
 	var previousUnsubscribedEvent Event
 
-	unsubscribe = r.OnUpdate(func(oldValue, newValue Type) {
+	unsubscribeFromVariable := r.OnUpdate(func(oldValue, newValue Type) {
 		if previousUnsubscribedEvent != nil {
 			previousUnsubscribedEvent.Trigger()
 		}
@@ -209,7 +209,7 @@ func (r *readableVariable[Type]) OnUpdateWithContext(callback func(oldValue, new
 	}, triggerWithInitialZeroValue...)
 
 	return func() {
-		unsubscribe()
+		unsubscribeFromVariable()
 
 		if previousUnsubscribedEvent != nil {
 			previousUnsubscribedEvent.Trigger()

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -157,11 +157,11 @@ func (r *readableVariable[Type]) OnUpdate(callback func(prevValue, newValue Type
 
 // OnUpdateOnce registers the given callback for the next update and then automatically unsubscribes it. It is possible
 // to provide an optional condition that has to be satisfied for the callback to be triggered.
-func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool) {
+func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newValue Type), optCondition ...func(oldValue Type, newValue Type) bool) (unsubscribe func()) {
 	callbackTriggered := NewEvent()
 	var triggeredPreValue, triggeredNewValue Type
 
-	unsubscribe := r.OnUpdate(func(prevValue, newValue Type) {
+	unsubscribe = r.OnUpdate(func(prevValue, newValue Type) {
 		if callbackTriggered.Get() {
 			return
 		}
@@ -181,6 +181,8 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 
 		callback(triggeredPreValue, triggeredNewValue)
 	})
+
+	return func() { callbackTriggered.Trigger() }
 }
 
 // OnUpdateWithContext registers the given callback that is triggered when the value changes. In contrast to the
@@ -189,7 +191,7 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 func (r *readableVariable[Type]) OnUpdateWithContext(callback func(oldValue, newValue Type, withinContext func(subscriptionFactory func() (unsubscribe func()))), triggerWithInitialZeroValue ...bool) (unsubscribe func()) {
 	var previousUnsubscribedEvent Event
 
-	return r.OnUpdate(func(oldValue, newValue Type) {
+	unsubscribe = r.OnUpdate(func(oldValue, newValue Type) {
 		if previousUnsubscribedEvent != nil {
 			previousUnsubscribedEvent.Trigger()
 		}
@@ -205,6 +207,14 @@ func (r *readableVariable[Type]) OnUpdateWithContext(callback func(oldValue, new
 
 		previousUnsubscribedEvent = unsubscribedEvent
 	}, triggerWithInitialZeroValue...)
+
+	return func() {
+		unsubscribe()
+
+		if previousUnsubscribedEvent != nil {
+			previousUnsubscribedEvent.Trigger()
+		}
+	}
 }
 
 // LogUpdates configures the Variable to emit logs about updates with the given logger and log level. An optional

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -161,7 +161,7 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 	callbackTriggered := NewEvent()
 	var triggeredPreValue, triggeredNewValue Type
 
-	unsubscribeFromVariable := r.OnUpdate(func(prevValue, newValue Type) {
+	unsubscribe = r.OnUpdate(func(prevValue, newValue Type) {
 		if callbackTriggered.Get() {
 			return
 		}
@@ -177,14 +177,12 @@ func (r *readableVariable[Type]) OnUpdateOnce(callback func(oldValue Type, newVa
 	})
 
 	callbackTriggered.OnTrigger(func() {
-		go unsubscribeFromVariable()
+		go unsubscribe()
 
-		if triggeredPreValue != triggeredNewValue {
-			callback(triggeredPreValue, triggeredNewValue)
-		}
+		callback(triggeredPreValue, triggeredNewValue)
 	})
 
-	return func() { callbackTriggered.Trigger() }
+	return unsubscribe
 }
 
 // OnUpdateWithContext registers the given callback that is triggered when the value changes. In contrast to the

--- a/ds/reactive/variable_test.go
+++ b/ds/reactive/variable_test.go
@@ -80,7 +80,7 @@ func TestOnUpdateWithContext(t *testing.T) {
 
 	outerVar.Set(1)
 
-	innerVars[2].Set(4)
+	innerVars[2].Set(5)
 	require.Equal(t, []string{"2:3", "2:4"}, collectedValues)
 	innerVars[1].Set(1)
 	require.Equal(t, []string{"2:3", "2:4", "1:1"}, collectedValues)

--- a/ds/reactive/variable_test.go
+++ b/ds/reactive/variable_test.go
@@ -53,3 +53,42 @@ func TestVariable(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestOnUpdateWithContext(t *testing.T) {
+	outerVar := NewVariable[int]()
+
+	innerVars := make([]Variable[int], 0)
+	for i := 0; i < 10; i++ {
+		innerVars = append(innerVars, NewVariable[int]())
+	}
+
+	collectedValues := make([]string, 0)
+	unsubscribe := outerVar.OnUpdateWithContext(func(_, monitoredIndex int, withinContext func(subscriptionFactory func() (unsubscribe func()))) {
+		withinContext(func() func() {
+			return innerVars[monitoredIndex].OnUpdate(func(_, newValue int) {
+				collectedValues = append(collectedValues, fmt.Sprintf("%d:%d", monitoredIndex, newValue))
+			})
+		})
+	})
+
+	outerVar.Set(2)
+
+	innerVars[2].Set(3)
+	require.Equal(t, []string{"2:3"}, collectedValues)
+	innerVars[2].Set(4)
+	require.Equal(t, []string{"2:3", "2:4"}, collectedValues)
+
+	outerVar.Set(1)
+
+	innerVars[2].Set(4)
+	require.Equal(t, []string{"2:3", "2:4"}, collectedValues)
+	innerVars[1].Set(1)
+	require.Equal(t, []string{"2:3", "2:4", "1:1"}, collectedValues)
+	innerVars[1].Set(2)
+	require.Equal(t, []string{"2:3", "2:4", "1:1", "1:2"}, collectedValues)
+
+	unsubscribe()
+
+	innerVars[1].Set(3)
+	require.Equal(t, []string{"2:3", "2:4", "1:1", "1:2"}, collectedValues)
+}

--- a/ds/reactive/variable_test.go
+++ b/ds/reactive/variable_test.go
@@ -92,3 +92,46 @@ func TestOnUpdateWithContext(t *testing.T) {
 	innerVars[1].Set(3)
 	require.Equal(t, []string{"2:3", "2:4", "1:1", "1:2"}, collectedValues)
 }
+
+func TestOnUpdateOnce(t *testing.T) {
+	{
+		myInt := NewVariable[int]()
+
+		var callCount, calledOldValue, calledNewValue int
+		myInt.OnUpdateOnce(func(oldValue, newValue int) {
+			callCount++
+			calledOldValue = oldValue
+			calledNewValue = newValue
+		})
+
+		myInt.Set(1)
+		require.Equal(t, 1, callCount)
+		require.Equal(t, 0, calledOldValue)
+		require.Equal(t, 1, calledNewValue)
+
+		myInt.Set(2)
+		require.Equal(t, 1, callCount)
+		require.Equal(t, 0, calledOldValue)
+		require.Equal(t, 1, calledNewValue)
+	}
+
+	{
+		myInt := NewVariable[int]()
+
+		var callCount, calledOldValue, calledNewValue int
+		unsubscribe := myInt.OnUpdateOnce(func(oldValue, newValue int) {
+			calledOldValue = oldValue
+			calledNewValue = newValue
+		})
+
+		unsubscribe()
+		require.Equal(t, 0, callCount)
+		require.Equal(t, 0, calledOldValue)
+		require.Equal(t, 0, calledNewValue)
+
+		myInt.Set(2)
+		require.Equal(t, 0, callCount)
+		require.Equal(t, 0, calledOldValue)
+		require.Equal(t, 0, calledNewValue)
+	}
+}


### PR DESCRIPTION
This PR makes the `OnUpdateOnce` method return an unsubscribe function and changes the unsubscribe behavior of the `OnUpdateWithContext` function to treat an unsubscribe like a context switch (all child subscriptions unsubscribe as well).