### PR TITLE
Add iota-core to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## About
 
-Hive.go is a shared library that is used in the GoShimmer and Hornet node software. This library contains shared:
+Hive.go is a shared library that is used in the [GoShimmer](https://github.com/iotaledger/goshimmer), [Hornet](https://github.com/iotaledger/hornet) and [IOTA Core](https://github.com/iotaledger/iota-core) node software. This library contains shared:
 * Data structures
 * Utility methods
 * Abstractions


### PR DESCRIPTION
# Description of change

Added iota-core to the README and added relevant links. Should we still mention GoShimmer or remove it?
Also if you merge this, could you also change the repo description?

Something like:
```diff
- A Go library containing data structures, various utils and abstractions which are used by both GoShimmer and Hornet.
+ A Go library containing data structures, various utils and abstractions which are used by GoShimmer, Hornet an IOTA Core.
```

## Type of change

- Documentation Fix

## Change checklist

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
