### PR TITLE
Use commas as separators for features and additional fields instead of whitespace

### DIFF
--- a/codegen/features/cmd/cmd.go
+++ b/codegen/features/cmd/cmd.go
@@ -58,7 +58,7 @@ func main() {
 func printUsage(errorMsg string) {
 	_, _ = fmt.Fprintf(os.Stderr, "Error:\t%s\n\n", errorMsg)
 	_, _ = fmt.Fprintf(os.Stderr, "Usage of gen/cmd:\n")
-	_, _ = fmt.Fprintf(os.Stderr, "\tcmd [templateFile] [outputFile] [typeName] [typeReceiver] [features separated by space] [additional fields separated by space (FieldName=FieldValue)]\n")
+	_, _ = fmt.Fprintf(os.Stderr, "\tcmd [templateFile] [outputFile] [typeName] [typeReceiver] [features separated by comma (Feature1,Feature2)] [additional fields separated by comma (FieldName1=FieldValue1,FieldName2=FieldValue2)]\n")
 
 	os.Exit(2)
 }

--- a/codegen/features/cmd/configuration.go
+++ b/codegen/features/cmd/configuration.go
@@ -9,12 +9,12 @@ import (
 func newConfiguration(fileName, name, receiver, featuresStr, additionalFieldsStr string) any {
 	// add all enabled features to a map
 	features := make(map[string]bool)
-	for _, feature := range strings.Split(featuresStr, " ") {
+	for _, feature := range strings.Split(featuresStr, ",") {
 		features[feature] = true
 	}
 
 	additionalFields := make(map[string]string)
-	for _, additionalField := range strings.Split(additionalFieldsStr, " ") {
+	for _, additionalField := range strings.Split(additionalFieldsStr, ",") {
 		if len(additionalField) == 0 {
 			continue
 		}


### PR DESCRIPTION
This way we can easily pass comments as additional fields for example.