### PR TITLE
Feat: Add noop capabilities to Compute method

### DIFF
--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -9,6 +9,9 @@ import (
 var (
 	// ErrKeyNotFound is returned when an op. doesn't find the given key.
 	ErrKeyNotFound = ierrors.New("key not found")
+	// ErrTypedValueNotChanged is a sentinel error that can be returned by the TypedValue.Compute callback to indicate
+	// that the current value should not be changed.
+	ErrTypedValueNotChanged = ierrors.New("typed value not changed")
 	// ErrStoreClosed is returned when an op accesses the kvstore but it was already closed.
 	ErrStoreClosed = ierrors.New("trying to access closed kvstore")
 

--- a/kvstore/typedvalue.go
+++ b/kvstore/typedvalue.go
@@ -102,6 +102,10 @@ func (t *TypedValue[V]) Compute(computeFunc func(currentValue V, exists bool) (n
 	}
 
 	if newValue, err = computeFunc(currentValue, exists); err != nil {
+		if ierrors.Is(err, ErrTypedValueNotChanged) {
+			return currentValue, nil
+		}
+
 		return newValue, ierrors.Wrap(err, "failed to compute new value")
 	}
 


### PR DESCRIPTION
This PR adds the ability to signal to the Compute method that the value did not changes (by using a sentinel error).

This allows us to not always write the same value over and over again to disk while we determine when to update the value by calling Compute.