### PR TITLE
Fix `mergedContext` initialization

### DIFF
--- a/runtime/contextutils/merged_context.go
+++ b/runtime/contextutils/merged_context.go
@@ -59,7 +59,7 @@ func MergeContexts(ctxPrimary context.Context, ctxSecondary context.Context) (co
 	go func() {
 		select {
 		case <-mc.cancelCtx.Done():
-			setCtxDoneFunc(ErrMergedContextCanceled)
+			setCtxDoneFunc(ierrors.Join(context.Canceled, ErrMergedContextCanceled))
 		case <-mc.ctxPrimary.Done():
 			setCtxDoneFunc(mc.ctxPrimary.Err())
 		case <-mc.ctxSecondary.Done():
@@ -68,7 +68,7 @@ func MergeContexts(ctxPrimary context.Context, ctxSecondary context.Context) (co
 	}()
 
 	var mergedCancelFunc context.CancelFunc = func() {
-		setCtxDoneFunc(ErrMergedContextCanceled)
+		setCtxDoneFunc(ierrors.Join(context.Canceled, ErrMergedContextCanceled))
 	}
 
 	return mc, mergedCancelFunc

--- a/runtime/contextutils/merged_context.go
+++ b/runtime/contextutils/merged_context.go
@@ -71,6 +71,14 @@ func MergeContexts(ctxPrimary context.Context, ctxSecondary context.Context) (co
 		setCtxDoneFunc(ierrors.Join(context.Canceled, ErrMergedContextCanceled))
 	}
 
+	// check if the given contexts are already canceled during initialization
+	if mc.ctxPrimary.Err() != nil {
+		setCtxDoneFunc(mc.ctxPrimary.Err())
+	}
+	if mc.ctxSecondary.Err() != nil {
+		setCtxDoneFunc(mc.ctxSecondary.Err())
+	}
+
 	return mc, mergedCancelFunc
 }
 

--- a/runtime/contextutils/merged_context_test.go
+++ b/runtime/contextutils/merged_context_test.go
@@ -72,6 +72,55 @@ func TestMergedContextSecondaryCancel(t *testing.T) {
 
 	require.Equal(t, ctx2.Err(), mergedCtx.Err())
 }
+
+func TestMergedContextPrimaryCancelBefore(t *testing.T) {
+
+	ctx1, cancel1 := context.WithCancel(context.WithValue(context.Background(), "one", 1))
+	defer cancel1()
+
+	ctx2, cancel2 := context.WithCancel(context.WithValue(context.Background(), "two", 2))
+	defer cancel2()
+
+	cancel1()
+
+	mergedCtx, _ := MergeContexts(ctx1, ctx2)
+
+	require.True(t, func() bool {
+		select {
+		case <-mergedCtx.Done():
+			return true
+		default:
+			return false
+		}
+	}())
+
+	require.Equal(t, ctx1.Err(), mergedCtx.Err())
+}
+
+func TestMergedContextSecondaryCancelBefore(t *testing.T) {
+
+	ctx1, cancel1 := context.WithCancel(context.WithValue(context.Background(), "one", 1))
+	defer cancel1()
+
+	ctx2, cancel2 := context.WithCancel(context.WithValue(context.Background(), "two", 2))
+	defer cancel2()
+
+	cancel2()
+
+	mergedCtx, _ := MergeContexts(ctx1, ctx2)
+
+	require.True(t, func() bool {
+		select {
+		case <-mergedCtx.Done():
+			return true
+		default:
+			return false
+		}
+	}())
+
+	require.Equal(t, ctx2.Err(), mergedCtx.Err())
+}
+
 func TestMergedContextValues(t *testing.T) {
 
 	ctx1, cancel1 := context.WithCancel(context.WithValue(context.Background(), "one", 1))

--- a/runtime/contextutils/merged_context_test.go
+++ b/runtime/contextutils/merged_context_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergedContextCancel(t *testing.T) {
@@ -14,7 +14,7 @@ func TestMergedContextCancel(t *testing.T) {
 	mergedCtx, mergedCancel := MergeContexts(context.Background(), context.Background())
 	mergedCancel()
 
-	assert.True(t, func() bool {
+	require.True(t, func() bool {
 		select {
 		case <-mergedCtx.Done():
 			return true
@@ -23,7 +23,8 @@ func TestMergedContextCancel(t *testing.T) {
 		}
 	}())
 
-	assert.Equal(t, ErrMergedContextCanceled, mergedCtx.Err())
+	require.ErrorIs(t, mergedCtx.Err(), ErrMergedContextCanceled)
+	require.ErrorIs(t, mergedCtx.Err(), context.Canceled)
 }
 
 func TestMergedContextPrimaryCancel(t *testing.T) {
@@ -37,7 +38,7 @@ func TestMergedContextPrimaryCancel(t *testing.T) {
 	mergedCtx, _ := MergeContexts(ctx1, ctx2)
 	cancel1()
 
-	assert.True(t, func() bool {
+	require.True(t, func() bool {
 		select {
 		case <-mergedCtx.Done():
 			return true
@@ -46,7 +47,7 @@ func TestMergedContextPrimaryCancel(t *testing.T) {
 		}
 	}())
 
-	assert.Equal(t, ctx1.Err(), mergedCtx.Err())
+	require.Equal(t, ctx1.Err(), mergedCtx.Err())
 }
 
 func TestMergedContextSecondaryCancel(t *testing.T) {
@@ -60,7 +61,7 @@ func TestMergedContextSecondaryCancel(t *testing.T) {
 	mergedCtx, _ := MergeContexts(ctx1, ctx2)
 	cancel2()
 
-	assert.True(t, func() bool {
+	require.True(t, func() bool {
 		select {
 		case <-mergedCtx.Done():
 			return true
@@ -69,7 +70,7 @@ func TestMergedContextSecondaryCancel(t *testing.T) {
 		}
 	}())
 
-	assert.Equal(t, ctx2.Err(), mergedCtx.Err())
+	require.Equal(t, ctx2.Err(), mergedCtx.Err())
 }
 func TestMergedContextValues(t *testing.T) {
 
@@ -81,9 +82,9 @@ func TestMergedContextValues(t *testing.T) {
 
 	mergedCtx, _ := MergeContexts(ctx1, ctx2)
 
-	assert.Equal(t, mergedCtx.Value("one"), 1)
-	assert.Equal(t, mergedCtx.Value("two"), 2)
-	assert.Nil(t, mergedCtx.Value("three"))
+	require.Equal(t, mergedCtx.Value("one"), 1)
+	require.Equal(t, mergedCtx.Value("two"), 2)
+	require.Nil(t, mergedCtx.Value("three"))
 }
 
 func TestMergedContextDeadline(t *testing.T) {
@@ -100,8 +101,8 @@ func TestMergedContextDeadline(t *testing.T) {
 	mergedCtx, _ := MergeContexts(ctx1, ctx2)
 
 	deadline, ok := mergedCtx.Deadline()
-	assert.False(t, deadline.IsZero())
-	assert.True(t, ok)
+	require.False(t, deadline.IsZero())
+	require.True(t, ok)
 
-	assert.Equal(t, deadline2, deadline)
+	require.Equal(t, deadline2, deadline)
 }


### PR DESCRIPTION
If the `mergedContext` was canceled, we did not return `context.Canceled` in the error chain which caused some logic on top to fail.

Also, if one of the given contexts was done before the initialization, we did not check that but relied on a go routine to set the error. This caused nondeterministic behaviour and was fixed. 