### PR TITLE
Refactor: changed signature of NewEntityLogger

### DIFF
--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -144,7 +144,7 @@ func (r *readableVariable[Type]) WithValue(setup func(value Type) (teardown func
 		if len(condition) == 0 || condition[0](value) {
 			unsubscribeOnUpdate(func() func() { return setup(value) })
 		}
-	})
+	}, true)
 }
 
 // WithNonEmptyValue is a utility function that allows to set up dynamic behavior based on the latest (non-empty)

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,8 +3,6 @@ package log
 import (
 	"log/slog"
 	"os"
-
-	"github.com/iotaledger/hive.go/ds/reactive"
 )
 
 // Logger is a reactive logger that can be used to log messages with different log levels.
@@ -86,7 +84,7 @@ type Logger interface {
 	// NewEntityLogger creates a new logger for an entity with the given name. The logger is automatically shut down
 	// when the given shutdown event is triggered. The initLogging function is called with the new logger instance and
 	// can be used to configure the logger.
-	NewEntityLogger(entityName string, shutdownEvent reactive.Event, initLogging func(entityLogger Logger)) Logger
+	NewEntityLogger(entityName string) (entityLogger Logger, shutdown func())
 }
 
 // NewLogger creates a new logger with the given name and an optional handler. If no handler is provided, the logger

--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -224,20 +224,14 @@ func (l *logger) NewChildLogger(name string) (childLogger Logger, shutdown func(
 	return nestedLoggerInstance, nestedLoggerInstance.reactiveLevel.InheritFrom(l.reactiveLevel)
 }
 
-// NewEntityLogger creates a new logger for an entity with the given name. The logger is automatically shut down when
-// the given shutdown event is triggered. The initLogging function is called with the new logger instance and can be
-// used to configure the logger.
-func (l *logger) NewEntityLogger(entityName string, shutdownEvent reactive.Event, initLogging func(entityLogger Logger)) Logger {
+// NewEntityLogger is identical to NewChildLogger with the difference that the name of the logger is automatically
+// extended with a unique identifier to avoid name collisions.
+func (l *logger) NewEntityLogger(entityName string) (entityLogger Logger, shutdown func()) {
 	if l == nil {
-		return l
+		return l, func() {}
 	}
 
-	embeddedLogger, shutdown := l.NewChildLogger(l.uniqueEntityName(entityName))
-	shutdownEvent.OnTrigger(shutdown)
-
-	initLogging(embeddedLogger)
-
-	return embeddedLogger
+	return l.NewChildLogger(l.uniqueEntityName(entityName))
 }
 
 // uniqueEntityName returns the name of an embedded instance of the given type.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -80,11 +80,11 @@ func NewTestObject(logger log.Logger) *TestObject {
 		IsEvicted:           reactive.NewEvent(),
 	}
 
-	t.Logger = logger.NewEntityLogger("TestObject", t.IsEvicted, func(entityLogger log.Logger) {
-		t.ImportantValue1.LogUpdates(entityLogger, log.LevelInfo, "ImportantValue1")
-		t.ImportantValue2.LogUpdates(entityLogger, log.LevelInfo, "ImportantValue2")
-		t.LessImportantValue1.LogUpdates(entityLogger, log.LevelDebug, "LessImportantValue1")
-	})
+	t.Logger, _ = logger.NewEntityLogger("TestObject")
+
+	t.ImportantValue1.LogUpdates(t.Logger, log.LevelInfo, "ImportantValue1")
+	t.ImportantValue2.LogUpdates(t.Logger, log.LevelInfo, "ImportantValue2")
+	t.LessImportantValue1.LogUpdates(t.Logger, log.LevelDebug, "LessImportantValue1")
 
 	return t
 }


### PR DESCRIPTION
This PR changes the NewEntityLogger method to manage the subscription outside similar to the NewChildLogger method.