### PR TITLE
Check for UTF8 validity in serix binary and map serialization

### DIFF
--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -163,17 +163,19 @@ func (api *API) mapDecodeBasedOnType(ctx context.Context, mapVal any, value refl
 		if !ok {
 			return ierrors.New("non string value for string field")
 		}
-		if !utf8.ValidString(str) {
-			return ErrNonUTF8String
-		}
-		addrValue := value.Addr().Convert(reflect.TypeOf((*string)(nil)))
-		addrValue.Elem().Set(reflect.ValueOf(mapVal))
 
 		if opts.validation {
 			if err := api.checkMinMaxBoundsLength(len(str), ts); err != nil {
 				return ierrors.Wrapf(err, "can't deserialize '%s' type", value.Kind())
 			}
+			// check the string for UTF-8 validity
+			if !utf8.ValidString(str) {
+				return ErrNonUTF8String
+			}
 		}
+
+		addrValue := value.Addr().Convert(reflect.TypeOf((*string)(nil)))
+		addrValue.Elem().Set(reflect.ValueOf(mapVal))
 
 		return nil
 	case reflect.Bool:

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -22,11 +22,6 @@ const (
 	keyDefaultSliceArray = "data"
 )
 
-var (
-	// ErrNonUTF8String gets returned when a non UTF-8 string is being encoded/decoded.
-	ErrNonUTF8String = ierrors.New("non UTF-8 string value")
-)
-
 func (api *API) mapEncode(ctx context.Context, value reflect.Value, ts TypeSettings, opts *options) (ele any, err error) {
 	valueI := value.Interface()
 	valueType := value.Type()
@@ -99,13 +94,14 @@ func (api *API) mapEncodeBasedOnType(
 		return api.mapEncodeInterface(ctx, value, valueType, opts)
 	case reflect.String:
 		str := value.String()
-		if !utf8.ValidString(str) {
-			return nil, ErrNonUTF8String
-		}
 
 		if opts.validation {
 			if err := api.checkMinMaxBoundsLength(len(str), ts); err != nil {
 				return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
+			}
+			// check the string for UTF-8 validity
+			if !utf8.ValidString(str) {
+				return nil, ErrNonUTF8String
 			}
 		}
 

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -68,6 +68,8 @@ var (
 	ErrValidationMaxBytesExceeded = ierrors.New("max bytes size exceeded")
 	// ErrMapValidationViolatesUniqueness gets returned if the map elements are not unique.
 	ErrMapValidationViolatesUniqueness = ierrors.New("map elements must be unique")
+	// ErrNonUTF8String gets returned when a non UTF-8 string is being encoded/decoded.
+	ErrNonUTF8String = ierrors.New("non UTF-8 string value")
 )
 
 var (


### PR DESCRIPTION
There was a difference in map serialization and binary serialization in serix.
In the map serialization the UTF8 validity of strings was checked for a string field, but in binary serialization it was not.

This PR fixes that.