### PR TITLE
Fix Must Occur serix validation

### DIFF
--- a/serializer/serializable.go
+++ b/serializer/serializable.go
@@ -122,7 +122,9 @@ type ArrayRules struct {
 	Min uint
 	// The max array bound.
 	Max uint
-	// A map of types which must occur within the array.
+	// A map of object types which must occur within the array.
+	// This is only checked on slices of types with an object type set.
+	// In particular, this means this is not checked for byte slices.
 	MustOccur TypePrefixes
 	// The guards applied while de/serializing Serializables.
 	Guards SerializableGuard

--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -435,6 +435,12 @@ func (api *API) decodeSlice(ctx context.Context, b []byte, value reflect.Value,
 		value.Set(reflect.MakeSlice(valueType, 0, 0))
 	}
 
+	if opts.validation {
+		if err := api.checkArrayMustOccur(value, ts); err != nil {
+			return bytesRead, ierrors.Wrapf(err, "can't deserialize '%s' type", value.Kind())
+		}
+	}
+
 	return bytesRead, nil
 }
 

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -319,6 +319,13 @@ func (api *API) encodeSlice(ctx context.Context, value reflect.Value, valueType 
 
 		return seri.Serialize()
 	}
+
+	if opts.validation {
+		if err := api.checkArrayMustOccur(value, ts); err != nil {
+			return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
+		}
+	}
+
 	sliceLen := value.Len()
 	data := make([][]byte, sliceLen)
 	for i := 0; i < sliceLen; i++ {

--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -455,6 +455,12 @@ func (api *API) mapDecodeSlice(ctx context.Context, mapVal any, value reflect.Va
 		value.Set(reflect.MakeSlice(valueType, 0, 0))
 	}
 
+	if opts.validation {
+		if err := api.checkArrayMustOccur(value, ts); err != nil {
+			return ierrors.Wrapf(err, "can't deserialize '%s' type", value.Kind())
+		}
+	}
+
 	return nil
 }
 

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -265,6 +265,12 @@ func (api *API) mapEncodeSlice(ctx context.Context, value reflect.Value, valueTy
 		return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
 	}
 
+	if opts.validation {
+		if err := api.checkArrayMustOccur(value, ts); err != nil {
+			return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
+		}
+	}
+
 	data := make([]any, sliceLen)
 	for i := 0; i < sliceLen; i++ {
 		elemValue := value.Index(i)

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -267,16 +267,12 @@ func (api *API) checkArrayMustOccur(slice reflect.Value, ts TypeSettings) error 
 		return nil
 	}
 
-	var mustOccurPrefixes *serializer.TypePrefixes
-	mustOccurPrefixesInner := make(serializer.TypePrefixes, len(ts.arrayRules.MustOccur))
-
+	mustOccurPrefixes := make(serializer.TypePrefixes, len(ts.arrayRules.MustOccur))
 	for key, value := range ts.arrayRules.MustOccur {
-		mustOccurPrefixesInner[key] = value
+		mustOccurPrefixes[key] = value
 	}
-	mustOccurPrefixes = &mustOccurPrefixesInner
 
 	sliceLen := slice.Len()
-
 	for i := 0; i < sliceLen; i++ {
 		elemValue := slice.Index(i)
 
@@ -293,10 +289,10 @@ func (api *API) checkArrayMustOccur(slice reflect.Value, ts TypeSettings) error 
 		if err != nil {
 			return ierrors.WithStack(err)
 		}
-		delete(*mustOccurPrefixes, typePrefix)
+		delete(mustOccurPrefixes, typePrefix)
 	}
 
-	if len(*mustOccurPrefixes) != 0 {
+	if len(mustOccurPrefixes) != 0 {
 		return ierrors.Wrapf(serializer.ErrArrayValidationTypesNotOccurred, "expected type prefixes that did not occur: %v", mustOccurPrefixes)
 	}
 

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -257,7 +257,12 @@ func (api *API) checkSerializedSize(ctx context.Context, value reflect.Value, ts
 	return api.checkMaxByteSize(len(bytes), ts)
 }
 
+// Checks the "Must Occur" array rules in the given slice.
 func (api *API) checkArrayMustOccur(slice reflect.Value, ts TypeSettings) error {
+	if slice.Kind() != reflect.Slice {
+		return ierrors.Errorf("must occur can only be checked for a slice, got value of kind %v", slice.Kind())
+	}
+
 	if ts.arrayRules == nil || len(ts.arrayRules.MustOccur) == 0 {
 		return nil
 	}

--- a/serializer/serix/serix_test.go
+++ b/serializer/serix/serix_test.go
@@ -3,7 +3,6 @@ package serix_test
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -146,7 +145,6 @@ type serializeTest struct {
 func (test *serializeTest) run(t *testing.T) {
 	// binary serialize
 	serixData, err := testAPI.Encode(context.Background(), test.source, serix.WithValidation())
-	fmt.Println("serialize ", serixData)
 	if test.seriErr != nil {
 		require.ErrorIs(t, err, test.seriErr, "binary serialization failed")
 


### PR DESCRIPTION
# Description of change

Fixes/Implements Must Occur serix validation for arrays.

This functionality is implemented in `ReadSliceOfObjects`, which is never called except in tests.

The way it's implemented trades readability and deduplication over performance. It would have been possible to implement the check on the bytes directly, which would have been more efficient than iterating separately over the slice and over the reflection types. However, obtaining the correct type denotation for the already-serialized objects is not trivial, but needed in order to read the correct number of bytes (uint8 vs uint32 for the two possible type denotations). 
It would have likely also resulted in an implementation that would be integrated in the existing code, which makes it less readable and reusable.

The way it is implemented now is self-contained in a function and simply called four times from encoding/decoding and map encoding/decoding.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tests were added.

Existing test frameworks like `serializeTest` and `deSerializeTest` were not suitable for reuse, so new ones were added.