### PR TITLE
Feat: Add utility functions to reactive framework

### DIFF
--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -94,6 +94,9 @@ type WritableVariable[Type comparable] interface {
 	// DeriveValueFrom is a utility function that allows to derive a value from a newly created DerivedVariable.
 	// It returns a teardown function that unsubscribes the DerivedVariable from its inputs.
 	DeriveValueFrom(source DerivedVariable[Type]) (teardown func())
+
+	// ToggleValue sets the value to the given value and returns a function that resets the value to its zero value.
+	ToggleValue(value Type) (reset func())
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ds/reactive/variable.go
+++ b/ds/reactive/variable.go
@@ -83,6 +83,11 @@ type WritableVariable[Type comparable] interface {
 	// callbacks if the value has changed.
 	Compute(computeFunc func(currentValue Type) Type) (previousValue Type)
 
+	// DefaultTo atomically sets the new value to the default value if the current value is the zero value and triggers
+	// the registered callbacks if the value has changed. It returns the new value and a boolean flag that indicates if
+	// the value was updated.
+	DefaultTo(defaultValue Type) (newValue Type, updated bool)
+
 	// InheritFrom inherits the value from the given ReadableVariable.
 	InheritFrom(other ReadableVariable[Type]) (unsubscribe func())
 

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -61,6 +61,23 @@ func (v *variable[Type]) Compute(computeFunc func(currentValue Type) Type) (prev
 	return previousValue
 }
 
+// DefaultTo atomically sets the new value to the given default value if the current value is the zero value and
+// triggers the registered callbacks if the value has changed. It returns the new value and a boolean flag that
+// indicates if the value was updated.
+func (v *variable[Type]) DefaultTo(defaultValue Type) (newValue Type, updated bool) {
+	v.Compute(func(currentValue Type) Type {
+		if updated = currentValue == *new(Type); updated {
+			newValue = defaultValue
+		} else {
+			newValue = currentValue
+		}
+
+		return newValue
+	})
+
+	return newValue, updated
+}
+
 // InheritFrom inherits the value from the given ReadableVariable.
 func (v *variable[Type]) InheritFrom(other ReadableVariable[Type]) (unsubscribe func()) {
 	return other.OnUpdate(func(_, newValue Type) {

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -226,8 +226,8 @@ func (r *readableVariable[Type]) OnUpdateWithContext(callback func(oldValue, new
 		unsubscribedEvent := NewEvent()
 		withinContext := func(subscribe func() func()) {
 			if !unsubscribedEvent.WasTriggered() {
-				if unsubscribe = subscribe(); unsubscribe != nil {
-					unsubscribedEvent.OnTrigger(unsubscribe)
+				if teardownSubscription := subscribe(); teardownSubscription != nil {
+					unsubscribedEvent.OnTrigger(teardownSubscription)
 				}
 			}
 		}

--- a/ds/reactive/variable_impl.go
+++ b/ds/reactive/variable_impl.go
@@ -95,6 +95,15 @@ func (v *variable[Type]) DeriveValueFrom(source DerivedVariable[Type]) (teardown
 	return source.Unsubscribe
 }
 
+// ToggleValue sets the value to the given value and returns a function that resets the value to its zero value.
+func (v *variable[Type]) ToggleValue(value Type) (reset func()) {
+	v.Set(value)
+
+	return func() {
+		v.Set(*new(Type))
+	}
+}
+
 // updateValue atomically prepares the trigger by setting the new value and returning the new value, the previous value,
 // the triggerID and the callbacks to trigger.
 func (v *variable[Type]) updateValue(newValueGenerator func(Type) Type) (newValue, previousValue Type, triggerID uniqueID, callbacksToTrigger []*callback[func(prevValue, newValue Type)]) {


### PR DESCRIPTION
This PR enables the ability to return a nil "unsubscribe" function in the OnUpdateWithContext method that indicates that nothing should happen when the value changes.