### PR TITLE
Feat: Add DebounceFunc to WorkerPool

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters-settings:
                 # exclude the ierrors.go file itself
                 files:
                     - "!**/ierrors.go"
+                    - "!**/ierrors_no_stacktrace.go"
                 deny:
                     - pkg: "errors"
                       desc: Should be replaced with "github.com/iotaledger/hive.go/ierrors" package

--- a/runtime/workerpool/workerpool.go
+++ b/runtime/workerpool/workerpool.go
@@ -104,11 +104,13 @@ func (w *WorkerPool) DebounceFunc() (debounce func(workerFunc func(), optStackTr
 		currentInvocation := lastInvocation.Add(1)
 
 		w.Submit(func() {
-			execMutex.Lock()
-			defer execMutex.Unlock()
-
 			if currentInvocation == lastInvocation.Load() {
-				workerFunc()
+				execMutex.Lock()
+				defer execMutex.Unlock()
+
+				if currentInvocation == lastInvocation.Load() {
+					workerFunc()
+				}
 			}
 		})
 	}

--- a/runtime/workerpool/workerpool.go
+++ b/runtime/workerpool/workerpool.go
@@ -112,7 +112,7 @@ func (w *WorkerPool) DebounceFunc() (debounce func(workerFunc func(), optStackTr
 					workerFunc()
 				}
 			}
-		})
+		}, optStackTrace...)
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to create a debounce function for the workerpool, that can be used to submit tasks that are canceled if the function is called with a new task before the previous one was executed.

```go
// DebounceFunc returns a function that can be used to submit a task that is canceled if the function is called with a
// new task before the previous task was executed.
DebounceFunc() (debounce func(workerFunc func(), optStackTrace ...string))
```