### PR TITLE
Check lexical order and uniquness in map de/encoding

### DIFF
--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -466,6 +466,12 @@ func (api *API) mapDecodeSlice(ctx context.Context, mapVal any, value reflect.Va
 		if err := api.checkArrayMustOccur(value, ts); err != nil {
 			return ierrors.Wrapf(err, "can't deserialize '%s' type", value.Kind())
 		}
+
+		// Hack to check uniqueness and lexical order of the slice of objects.
+		_, err := api.encodeSlice(ctx, value, valueType, ts, opts)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -270,6 +270,13 @@ func (api *API) mapEncodeSlice(ctx context.Context, value reflect.Value, valueTy
 		if err := api.checkArrayMustOccur(value, ts); err != nil {
 			return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
 		}
+
+		// Hack to check uniqueness and lexical order of the slice of objects.
+		// This means we do not auto-sort for maps and the passed slice must be sorted.
+		_, err := api.encodeSlice(ctx, value, valueType, ts, opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	data := make([]any, sliceLen)

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -320,6 +321,10 @@ func (api *API) mapEncodeMap(ctx context.Context, value reflect.Value, ts TypeSe
 		}
 		m.Set(k, v)
 	}
+
+	m.Sort(func(a, b *orderedmap.Pair) bool {
+		return strings.Compare(a.Key(), b.Key()) < 0
+	})
 
 	return m, nil
 }

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -379,6 +379,8 @@ func (api *API) Decode(ctx context.Context, b []byte, obj interface{}, opts ...O
 // JSONDecode deserializes json data into the provided object obj.
 func (api *API) JSONDecode(ctx context.Context, data []byte, obj interface{}, opts ...Option) error {
 	m := map[string]any{}
+	// This does not error on duplicate keys.
+	// Can be fixed once https://github.com/golang/go/issues/48298 is implemented.
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description of change

Check lexical order and uniquness in map de/encoding.

Some of it is implemented as a rather inefficient hack, as we intend to refactor this code soon.

`encoding/json` does not error on duplicate keys, which means an input of `{"a": "0", "a":"1"}` decoded to a `map[string]string` results in the field `a` having value `1`. There is a proposal to add an option to fix this which is noted in a comment. Because we rely on `encoding/json` to decode the initial json, we are unable to detect duplicate keys later.

Fixes iotaledger/iota.go#654.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added tests.