### PR TITLE
Remove bytes validator and call syntactic validator during map decode

### DIFF
--- a/serializer/serializable_test.go
+++ b/serializer/serializable_test.go
@@ -302,20 +302,6 @@ func TestArrayRules_ElementUniqueValidator(t *testing.T) {
 			ar:    &serializer.ArrayRules{},
 			valid: false,
 		},
-		{
-			name: "not ok - dups with reduction",
-			args: [][]byte{
-				{1, 1, 1},
-				{1, 1, 2},
-				{1, 1, 3},
-			},
-			ar: &serializer.ArrayRules{
-				UniquenessSliceFunc: func(next []byte) []byte {
-					return next[:2]
-				},
-			},
-			valid: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -509,20 +495,6 @@ func TestArrayRules_LexicalOrderWithoutDupsValidator(t *testing.T) {
 				{3, 1, 3},
 			},
 			ar:    &serializer.ArrayRules{},
-			valid: false,
-		},
-		{
-			name: "not ok - dups with reduction",
-			args: [][]byte{
-				{1, 1, 1},
-				{1, 1, 2},
-				{1, 1, 3},
-			},
-			ar: &serializer.ArrayRules{
-				UniquenessSliceFunc: func(next []byte) []byte {
-					return next[:2]
-				},
-			},
 			valid: false,
 		},
 	}

--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -13,11 +13,6 @@ import (
 
 func (api *API) decode(ctx context.Context, b []byte, value reflect.Value, ts TypeSettings, opts *options) (int, error) {
 	valueType := value.Type()
-	if opts.validation {
-		if err := api.callBytesValidator(ctx, valueType, b); err != nil {
-			return 0, ierrors.Wrap(err, "pre-deserialization validation failed")
-		}
-	}
 	var deserializable Deserializable
 	var bytesRead int
 

--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -85,7 +85,7 @@ func (api *API) decode(ctx context.Context, b []byte, value reflect.Value, ts Ty
 
 	if opts.validation {
 		if err := api.callSyntacticValidator(ctx, value, valueType); err != nil {
-			return 0, ierrors.Wrap(err, "post-deserialization validation failed")
+			return 0, ierrors.Errorf("post-deserialization validation failed: %w", err)
 		}
 	}
 

--- a/serializer/serix/decode.go
+++ b/serializer/serix/decode.go
@@ -87,10 +87,6 @@ func (api *API) decode(ctx context.Context, b []byte, value reflect.Value, ts Ty
 		if err := api.callSyntacticValidator(ctx, value, valueType); err != nil {
 			return 0, ierrors.Wrap(err, "post-deserialization validation failed")
 		}
-
-		if err := ts.checkMaxByteSize(bytesRead); err != nil {
-			return bytesRead, err
-		}
 	}
 
 	return bytesRead, nil

--- a/serializer/serix/decode_test.go
+++ b/serializer/serix/decode_test.go
@@ -130,14 +130,6 @@ func TestDecode_SyntacticValidation(t *testing.T) {
 	assert.ErrorIs(t, err, errSyntacticValidation)
 }
 
-func TestDecode_BytesValidation(t *testing.T) {
-	t.Parallel()
-	testObj := &ObjectForBytesValidation{}
-	bytesRead, err := testAPI.Decode(ctx, nil, testObj, serix.WithValidation())
-	require.Zero(t, bytesRead)
-	assert.ErrorIs(t, err, errBytesValidation)
-}
-
 func TestDecode_ArrayRules(t *testing.T) {
 	t.Parallel()
 	testObj := &Bools{true, false, true, true}

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -55,10 +55,6 @@ func (api *API) encode(ctx context.Context, value reflect.Value, ts TypeSettings
 	}
 
 	if opts.validation {
-		if err = api.callBytesValidator(ctx, valueType, b); err != nil {
-			return nil, ierrors.Wrap(err, "post-serialization validation failed")
-		}
-
 		if err := ts.checkMaxByteSize(len(b)); err != nil {
 			return nil, err
 		}

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -54,12 +54,6 @@ func (api *API) encode(ctx context.Context, value reflect.Value, ts TypeSettings
 		}
 	}
 
-	if opts.validation {
-		if err := ts.checkMaxByteSize(len(b)); err != nil {
-			return nil, err
-		}
-	}
-
 	return b, nil
 }
 

--- a/serializer/serix/encode.go
+++ b/serializer/serix/encode.go
@@ -18,7 +18,7 @@ func (api *API) encode(ctx context.Context, value reflect.Value, ts TypeSettings
 	valueType := value.Type()
 	if opts.validation {
 		if err = api.callSyntacticValidator(ctx, value, valueType); err != nil {
-			return nil, ierrors.Wrap(err, "pre-serialization validation failed")
+			return nil, ierrors.Errorf("pre-serialization validation failed: %w", err)
 		}
 	}
 

--- a/serializer/serix/encode_test.go
+++ b/serializer/serix/encode_test.go
@@ -81,14 +81,6 @@ func TestEncode_SyntacticValidation(t *testing.T) {
 	assert.ErrorIs(t, err, errSyntacticValidation)
 }
 
-func TestEncode_BytesValidation(t *testing.T) {
-	t.Parallel()
-	testObj := ObjectForBytesValidation{}
-	got, err := testAPI.Encode(ctx, testObj, serix.WithValidation())
-	require.Nil(t, got)
-	assert.ErrorIs(t, err, errBytesValidation)
-}
-
 func TestEncode_ArrayRules(t *testing.T) {
 	t.Parallel()
 	rules := &serix.ArrayRules{Min: 5}

--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -41,6 +41,10 @@ func (api *API) mapDecode(ctx context.Context, mapVal any, value reflect.Value, 
 	}
 
 	if opts.validation {
+		if err := api.callSyntacticValidator(ctx, value, value.Type()); err != nil {
+			return ierrors.Wrap(err, "pre-serialization validation failed")
+		}
+
 		if err := api.checkSerializedSize(ctx, value, ts, opts); err != nil {
 			return err
 		}

--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -44,10 +44,6 @@ func (api *API) mapDecode(ctx context.Context, mapVal any, value reflect.Value, 
 		if err := api.callSyntacticValidator(ctx, value, value.Type()); err != nil {
 			return ierrors.Wrap(err, "post-serialization validation failed")
 		}
-
-		if err := api.checkSerializedSize(ctx, value, ts, opts); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/serializer/serix/map_decode.go
+++ b/serializer/serix/map_decode.go
@@ -42,7 +42,7 @@ func (api *API) mapDecode(ctx context.Context, mapVal any, value reflect.Value, 
 
 	if opts.validation {
 		if err := api.callSyntacticValidator(ctx, value, value.Type()); err != nil {
-			return ierrors.Wrap(err, "pre-serialization validation failed")
+			return ierrors.Wrap(err, "post-serialization validation failed")
 		}
 
 		if err := api.checkSerializedSize(ctx, value, ts, opts); err != nil {

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -261,11 +261,11 @@ func (api *API) mapEncodeSlice(ctx context.Context, value reflect.Value, valueTy
 
 	sliceLen := value.Len()
 
-	if err := ts.checkMinMaxBoundsLength(sliceLen); err != nil {
-		return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
-	}
-
 	if opts.validation {
+		if err := ts.checkMinMaxBoundsLength(sliceLen); err != nil {
+			return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
+		}
+
 		if err := api.checkArrayMustOccur(value, ts); err != nil {
 			return nil, ierrors.Wrapf(err, "can't serialize '%s' type", value.Kind())
 		}

--- a/serializer/serix/map_encode.go
+++ b/serializer/serix/map_encode.go
@@ -31,12 +31,6 @@ func (api *API) mapEncode(ctx context.Context, value reflect.Value, ts TypeSetti
 		}
 	}
 
-	if opts.validation {
-		if err := api.checkSerializedSize(ctx, value, ts, opts); err != nil {
-			return nil, err
-		}
-	}
-
 	if serializable, ok := valueI.(SerializableJSON); ok {
 		ele, err = serializable.EncodeJSON()
 		if err != nil {

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -246,7 +246,7 @@ func (api *API) callSyntacticValidator(ctx context.Context, value reflect.Value,
 		if err, _ := vldtrs.syntacticValidator.Call(
 			[]reflect.Value{reflect.ValueOf(ctx), value},
 		)[0].Interface().(error); err != nil {
-			return ierrors.Wrapf(err, "syntactic validator returns an error for type %s", valueType)
+			return ierrors.Errorf("syntactic validator returned an error for type %s: %w", valueType, err)
 		}
 	}
 

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -304,7 +304,7 @@ func (api *API) getStructFields(structType reflect.Type) ([]structField, error) 
 //
 // syntacticValidator := func (ctx context.Context, t time.Time) error { ... }
 //
-// api.RegisterValidator(time.Time{}, syntacticValidator)
+// api.RegisterValidator(time.Time{}, syntacticValidator).
 func (api *API) RegisterValidator(obj any, syntacticValidatorFn interface{}) error {
 	return api.validatorsRegistry.RegisterValidator(obj, syntacticValidatorFn)
 }

--- a/serializer/serix/serix.go
+++ b/serializer/serix/serix.go
@@ -64,8 +64,6 @@ import (
 )
 
 var (
-	// ErrValidationMaxBytesExceeded gets returned if the serialized byte size of the object too big.
-	ErrValidationMaxBytesExceeded = ierrors.New("max bytes size exceeded")
 	// ErrMapValidationViolatesUniqueness gets returned if the map elements are not unique.
 	ErrMapValidationViolatesUniqueness = ierrors.New("map elements must be unique")
 	// ErrNonUTF8String gets returned when a non UTF-8 string is being encoded/decoded.
@@ -187,19 +185,6 @@ func (api *API) getInterfaceObjects(iType reflect.Type) *InterfaceObjects {
 	}
 
 	return iObj
-}
-
-func (api *API) checkSerializedSize(ctx context.Context, value reflect.Value, ts TypeSettings, opts *options) error {
-	if ts.maxByteSize == 0 {
-		return nil
-	}
-
-	bytes, err := api.encode(ctx, value, ts, opts)
-	if err != nil {
-		return ierrors.Wrapf(err, "can't get serialized size: failed to encode '%s' type", value.Kind())
-	}
-
-	return ts.checkMaxByteSize(len(bytes))
 }
 
 // Checks the "Must Occur" array rules in the given slice.

--- a/serializer/serix/serix_serializable_test.go
+++ b/serializer/serix/serix_serializable_test.go
@@ -378,14 +378,6 @@ func SyntacticValidation(ctx context.Context, obj ObjectForSyntacticValidation) 
 	return errSyntacticValidation
 }
 
-type ObjectForBytesValidation struct{}
-
-var errBytesValidation = ierrors.New("bytes validation failed")
-
-func BytesValidation(ctx context.Context, b []byte) error {
-	return errBytesValidation
-}
-
 func TestMain(m *testing.M) {
 	exitCode := func() int {
 		if err := testAPI.RegisterTypeSettings(
@@ -409,10 +401,7 @@ func TestMain(m *testing.M) {
 		if err := testAPI.RegisterInterfaceObjects((*Interface)(nil), (*InterfaceImpl)(nil)); err != nil {
 			log.Panic(err)
 		}
-		if err := testAPI.RegisterValidators(ObjectForSyntacticValidation{}, nil, SyntacticValidation); err != nil {
-			log.Panic(err)
-		}
-		if err := testAPI.RegisterValidators(ObjectForBytesValidation{}, BytesValidation, nil); err != nil {
+		if err := testAPI.RegisterValidator(ObjectForSyntacticValidation{}, SyntacticValidation); err != nil {
 			log.Panic(err)
 		}
 

--- a/serializer/serix/serix_tags.go
+++ b/serializer/serix/serix_tags.go
@@ -133,13 +133,6 @@ func ParseSerixSettings(tag string, serixPosition int) (TagSettings, error) {
 			}
 			settings.ts = settings.ts.WithDescription(value)
 
-		case "maxByteSize":
-			value, err := parseStructTagValueUint("maxByteSize", keyValue, currentPart)
-			if err != nil {
-				return TagSettings{}, err
-			}
-			settings.ts = settings.ts.WithMaxByteSize(value)
-
 		case "lenPrefix":
 			value, err := parseStructTagValuePrefixType("lenPrefix", keyValue, currentPart)
 			if err != nil {

--- a/serializer/serix/serix_test.go
+++ b/serializer/serix/serix_test.go
@@ -185,7 +185,7 @@ func TestSerixSerializeMap(t *testing.T) {
 	type MyMapTypeValue string
 	type MyMapType map[MyMapTypeKey]MyMapTypeValue
 	type MapStruct struct {
-		MyMap MyMapType `serix:",lenPrefix=uint8,minLen=2,maxLen=4,maxByteSize=50"`
+		MyMap MyMapType `serix:",lenPrefix=uint8,minLen=2,maxLen=4"`
 	}
 
 	testAPI.RegisterTypeSettings(MyMapTypeKey(""), serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint16).WithMinLen(2).WithMaxLen(5))
@@ -230,20 +230,6 @@ func TestSerixSerializeMap(t *testing.T) {
 			target:  &MapStruct{},
 			size:    0,
 			seriErr: serializer.ErrArrayValidationMaxElementsExceeded,
-		},
-		{
-			name: "fail - too big",
-			source: &MapStruct{
-				MyMap: MyMapType{
-					"k1": "v1000",
-					"k2": "v2000",
-					"k3": "v3000",
-					"k4": "v4000",
-				},
-			},
-			target:  &MapStruct{},
-			size:    0,
-			seriErr: serix.ErrValidationMaxBytesExceeded,
 		},
 		{
 			name: "fail - key too short",
@@ -396,7 +382,7 @@ func TestSerixDeserializeMap(t *testing.T) {
 	type MyMapTypeKey string
 	type MyMapTypeValue string
 	type MapStruct struct {
-		MyMap map[MyMapTypeKey]MyMapTypeValue `serix:",lenPrefix=uint8,minLen=2,maxLen=4,maxByteSize=50"`
+		MyMap map[MyMapTypeKey]MyMapTypeValue `serix:",lenPrefix=uint8,minLen=2,maxLen=4"`
 	}
 
 	testAPI.RegisterTypeSettings(MyMapTypeKey(""), serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint16).WithMinLen(2).WithMaxLen(5))
@@ -441,20 +427,6 @@ func TestSerixDeserializeMap(t *testing.T) {
 			target:    &MapStruct{},
 			size:      0,
 			deSeriErr: serializer.ErrArrayValidationMaxElementsExceeded,
-		},
-		{
-			name: "fail - too big",
-			source: &MapStruct{
-				MyMap: map[MyMapTypeKey]MyMapTypeValue{
-					"k1": "v1000",
-					"k2": "v2000",
-					"k3": "v3000",
-					"k4": "v4000",
-				},
-			},
-			target:    &MapStruct{},
-			size:      0,
-			deSeriErr: serix.ErrValidationMaxBytesExceeded,
 		},
 		{
 			name: "fail - key too short",

--- a/serializer/serix/type_settings.go
+++ b/serializer/serix/type_settings.go
@@ -63,8 +63,6 @@ type TypeSettings struct {
 	description string
 	// objectType defines the object type. It can be either uint8 or uint32 number.
 	objectType interface{}
-	// maxByteSize defines the max serialized byte size. 0 means unbounded.
-	maxByteSize uint
 	// lengthPrefixType defines the type of the value denoting the length of a collection.
 	lengthPrefixType *LengthPrefixType
 	// lexicalOrdering defines whether the collection must be lexically ordered during serialization.
@@ -127,18 +125,6 @@ func (ts TypeSettings) WithObjectType(t interface{}) TypeSettings {
 // ObjectType returns the object type as an uint8 or uint32 number.
 func (ts TypeSettings) ObjectType() interface{} {
 	return ts.objectType
-}
-
-// WithMaxByteSize specifies max serialized byte size for the type. 0 means unbounded.
-func (ts TypeSettings) WithMaxByteSize(l uint) TypeSettings {
-	ts.maxByteSize = l
-
-	return ts
-}
-
-// MaxByteSize returns max serialized byte size for the type. 0 means unbounded.
-func (ts TypeSettings) MaxByteSize() uint {
-	return ts.maxByteSize
 }
 
 // WithLengthPrefixType specifies LengthPrefixType.
@@ -303,15 +289,6 @@ func (ts TypeSettings) checkMinMaxBounds(v reflect.Value) error {
 
 	if err := ts.checkMinMaxBoundsLength(v.Len()); err != nil {
 		return ierrors.Wrapf(err, "can't serialize '%s' type", v.Kind())
-	}
-
-	return nil
-}
-
-// checkMaxByteSize checks whether the given type is within its defined size in case it has a max byte size.
-func (ts TypeSettings) checkMaxByteSize(byteSize int) error {
-	if ts.maxByteSize > 0 && byteSize > int(ts.maxByteSize) {
-		return ierrors.Wrapf(ErrValidationMaxBytesExceeded, "serialized size (%d) exceeds max byte size of %d ", byteSize, ts.maxByteSize)
 	}
 
 	return nil


### PR DESCRIPTION
# Description of change

Remove bytes validator and call syntactic validator during map decode. Only check min/max length when validation is on.

Also reorder some errors, so we get more readable error messages:

Before:

> transaction is invalid: metadata exceeds max allowed size: the StateMetadataFeature of the output at index 0 has size 8193; max allowed: 8192: syntactic validator returns an error for type iotago.SignedTransaction: pre-serialization validation failed


After:

> pre-serialization validation failed: syntactic validator returned an error for type iotago.SignedTransaction: transaction is invalid: metadata exceeds max allowed size: the StateMetadataFeature of the output at index 0 has size 8193; max allowed: 8192

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested via iota.go.