### PR TITLE
Logger name should be logged in Logf too

### DIFF
--- a/log/logger_impl.go
+++ b/log/logger_impl.go
@@ -259,7 +259,7 @@ func (l *logger) Log(msg string, level Level, args ...any) {
 // Logf emits a formatted log message with the given level.
 func (l *logger) Logf(fmtString string, level Level, args ...any) {
 	if l != nil && l.level.Level() <= level {
-		l.rootLogger.LogAttrs(context.Background(), level, fmt.Sprintf(fmtString, args...))
+		l.rootLogger.LogAttrs(context.Background(), level, fmt.Sprintf(fmtString, args...), slog.Attr{Key: namespaceKey, Value: slog.StringValue(l.path)})
 	}
 }
 


### PR DESCRIPTION
# Description of change

Currently logger name appears in log if the message is logged via `LogDebug`, `LogError`, etc functions, however it doesn't, if message is logged via `LogDebugf`, `LogErrorf`, etc functions. This PR fixes this situation.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

I've used it in my local branch of Wasp.