### PR TITLE
Fix eviction state for 0 value

### DIFF
--- a/ds/reactive/eviction_state_test.go
+++ b/ds/reactive/eviction_state_test.go
@@ -38,14 +38,27 @@ func TestEvictionEvent(t *testing.T) {
 func TestEvict(t *testing.T) {
 	state := newEvictionState[int]()
 
-	// Setup a slot to be evicted
-	slotToEvict := 1
-	state.evictionEvents.Set(slotToEvict, NewEvent())
+	{
+		// Setup a slot to be evicted
+		slotToEvict := 0
+		state.evictionEvents.Set(slotToEvict, NewEvent())
 
-	// Evict the slot and verify
-	state.Evict(slotToEvict)
-	_, exists := state.evictionEvents.Get(slotToEvict)
-	require.False(t, exists, "Evicted slot should no longer exist in evictionEvents")
+		// Evict the slot and verify
+		state.Evict(slotToEvict)
+		_, exists := state.evictionEvents.Get(slotToEvict)
+		require.False(t, exists, "Evicted slot should no longer exist in evictionEvents")
+	}
+
+	{
+		// Setup a slot to be evicted
+		slotToEvict := 1
+		state.evictionEvents.Set(slotToEvict, NewEvent())
+
+		// Evict the slot and verify
+		state.Evict(slotToEvict)
+		_, exists := state.evictionEvents.Get(slotToEvict)
+		require.False(t, exists, "Evicted slot should no longer exist in evictionEvents")
+	}
 }
 
 // TestEvictPrivate tests the private evict method


### PR DESCRIPTION
This PR fixes a bug for the reactive eviction state where the event is not triggered for the zero value of a type (in our case a slot). 