### PR TITLE
Fix eviction state for 0 value - covering all edge cases

### DIFF
--- a/ds/reactive/eviction_state.go
+++ b/ds/reactive/eviction_state.go
@@ -3,9 +3,10 @@ package reactive
 // EvictionState is a reactive component that implements a slot based eviction mechanism.
 type EvictionState[Type EvictionStateSlotType] interface {
 	// LastEvictedSlot returns a reactive variable that contains the index of the last evicted slot.
-	LastEvictedSlot() Variable[Type]
+	LastEvictedSlot() Type
 
-	// EvictionEvent returns the event that is triggered when the given slot was evicted.
+	// EvictionEvent returns the event that is triggered when the given slot was evicted. It returns a triggered event
+	// as default if the slot was already evicted.
 	EvictionEvent(slot Type) Event
 
 	// Evict evicts the given slot and triggers the corresponding eviction events.

--- a/ds/reactive/eviction_state_impl.go
+++ b/ds/reactive/eviction_state_impl.go
@@ -1,13 +1,18 @@
 package reactive
 
 import (
+	"sync"
+
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
+	"github.com/iotaledger/hive.go/lo"
 )
 
 // evictionState is the default implementation of the EvictionState interface.
 type evictionState[Type EvictionStateSlotType] struct {
+	mutex sync.RWMutex
+
 	// lastEvictedSlot is the index of the last evicted slot.
-	lastEvictedSlot Variable[Type]
+	lastEvictedSlot *Type
 
 	// evictionEvents is the map of all eviction events that were not evicted yet.
 	evictionEvents *shrinkingmap.ShrinkingMap[Type, Event]
@@ -16,29 +21,38 @@ type evictionState[Type EvictionStateSlotType] struct {
 // newEvictionState creates a new evictionState instance.
 func newEvictionState[Type EvictionStateSlotType]() *evictionState[Type] {
 	return &evictionState[Type]{
-		lastEvictedSlot: NewVariable[Type](),
-		evictionEvents:  shrinkingmap.New[Type, Event](),
+		evictionEvents: shrinkingmap.New[Type, Event](),
 	}
 }
 
-// LastEvictedSlot returns a reactive variable that contains the index of the last evicted slot.
-func (e *evictionState[Type]) LastEvictedSlot() Variable[Type] {
-	return e.lastEvictedSlot
+func (e *evictionState[Type]) setLastEvictedSlot(slot Type) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	e.lastEvictedSlot = &slot
+}
+
+func (e *evictionState[Type]) LastEvictedSlot() Type {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	if e.lastEvictedSlot == nil {
+		return 0
+	}
+
+	return *e.lastEvictedSlot
 }
 
 // EvictionEvent returns the event that is triggered when the given slot was evicted.
 func (e *evictionState[Type]) EvictionEvent(slot Type) Event {
-	evictionEvent := evictedSlotEvent
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
 
-	e.lastEvictedSlot.Read(func(lastEvictedSlotIndex Type) {
-		var zeroValue Type
+	if e.lastEvictedSlot == nil || slot > *e.lastEvictedSlot {
+		return lo.Return1(e.evictionEvents.GetOrCreate(slot, NewEvent))
+	}
 
-		if slot > lastEvictedSlotIndex || (slot == zeroValue && lastEvictedSlotIndex == zeroValue) {
-			evictionEvent, _ = e.evictionEvents.GetOrCreate(slot, NewEvent)
-		}
-	})
-
-	return evictionEvent
+	return evictedSlotEvent
 }
 
 // Evict evicts the given slot and triggers the corresponding eviction events.
@@ -49,31 +63,30 @@ func (e *evictionState[Type]) Evict(slot Type) {
 }
 
 // evict advances the lastEvictedSlot to the given slot and returns the events that shall be triggered.
-func (e *evictionState[Type]) evict(slot Type) (eventsToTrigger []Event) {
-	var zeroValue Type
+func (e *evictionState[Type]) evict(slot Type) []Event {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
 
-	e.lastEvictedSlot.Compute(func(lastEvictedSlotIndex Type) Type {
-		var startingSlot Type
-		if slot <= lastEvictedSlotIndex {
-			// We only continue if the slot is the zero value, and we have not evicted any slot yet.
-			if slot != zeroValue || lastEvictedSlotIndex != zeroValue {
-				return lastEvictedSlotIndex
-			}
+	if e.lastEvictedSlot != nil && slot <= *e.lastEvictedSlot {
+		return nil
+	}
 
-			startingSlot = slot
-		} else {
-			startingSlot = lastEvictedSlotIndex + Type(1)
+	var startingSlot Type
+	if e.lastEvictedSlot == nil {
+		startingSlot = 0
+	} else {
+		startingSlot = *e.lastEvictedSlot + Type(1)
+	}
+
+	var eventsToTrigger []Event
+	for i := startingSlot; i <= slot; i++ {
+		if slotEvictedEvent, exists := e.evictionEvents.Get(i); exists {
+			eventsToTrigger = append(eventsToTrigger, slotEvictedEvent)
+			e.evictionEvents.Delete(i)
 		}
+	}
 
-		for i := startingSlot; i <= slot; i++ {
-			if slotEvictedEvent, exists := e.evictionEvents.Get(i); exists {
-				eventsToTrigger = append(eventsToTrigger, slotEvictedEvent)
-				e.evictionEvents.Delete(i)
-			}
-		}
-
-		return slot
-	})
+	e.lastEvictedSlot = &slot
 
 	return eventsToTrigger
 }

--- a/ds/reactive/eviction_state_impl.go
+++ b/ds/reactive/eviction_state_impl.go
@@ -25,13 +25,6 @@ func newEvictionState[Type EvictionStateSlotType]() *evictionState[Type] {
 	}
 }
 
-func (e *evictionState[Type]) setLastEvictedSlot(slot Type) {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-
-	e.lastEvictedSlot = &slot
-}
-
 func (e *evictionState[Type]) LastEvictedSlot() Type {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()

--- a/ds/reactive/eviction_state_test.go
+++ b/ds/reactive/eviction_state_test.go
@@ -25,11 +25,15 @@ func TestEvictionEvent(t *testing.T) {
 	state := newEvictionState[int]()
 
 	// Test with a slot that should create a new event
-	event := state.EvictionEvent(1)
+	event := state.EvictionEvent(0)
+	require.NotNil(t, event, "EvictionEvent should not return nil for a new slot")
+
+	// Test with a slot that should create a new event
+	event = state.EvictionEvent(1)
 	require.NotNil(t, event, "EvictionEvent should not return nil for a new slot")
 
 	// Test with a slot that should not create a new event
-	state.lastEvictedSlot.Set(1)
+	state.Evict(1)
 	event = state.EvictionEvent(0)
 	require.Equal(t, evictedSlotEvent, event, "EvictionEvent should return the evictedSlotEvent for a slot lower than lastEvictedSlot")
 }
@@ -66,7 +70,7 @@ func TestEvictTriggered(t *testing.T) {
 	state := newEvictionState[int]()
 
 	// Test with a slot less than the current lastEvictedSlotIndex
-	state.lastEvictedSlot.Set(2)                  // Set the last evicted slot to 2
+	state.setLastEvictedSlot(2)                   // Set the last evicted slot to 2
 	state.evictionEvents.Set(1, evictedSlotEvent) // Set an event for slot 1
 	eventsToTrigger := state.evict(1)             // Try to evict slot 1, which is less than the last evicted slot
 	require.Len(t, eventsToTrigger, 0, "evict should not return any events when slot is less than or equal to lastEvictedSlotIndex")


### PR DESCRIPTION
Adjust reactive eviction state to handle all cases with `0` correctly, even if a later slot is evicted and not `0` directly. This is achieved by using a pointer to the `Type` so that there is a clear distinction between `0` being evicted or not.